### PR TITLE
Sample number processor variable

### DIFF
--- a/examples/DRWI_CitSci/DRWI_CitSci.ino
+++ b/examples/DRWI_CitSci/DRWI_CitSci.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card and sending the data to
 both the EnviroDIY data portal and Stroud's custom data portal as should be

--- a/examples/DRWI_CitSci/DRWI_CitSci.ino
+++ b/examples/DRWI_CitSci/DRWI_CitSci.ino
@@ -192,9 +192,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/DRWI_CitSci/platformio.ini
+++ b/examples/DRWI_CitSci/platformio.ini
@@ -18,4 +18,4 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1

--- a/examples/DRWI_NoCellular/DRWI_NoCellular.ino
+++ b/examples/DRWI_NoCellular/DRWI_NoCellular.ino
@@ -136,9 +136,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/DRWI_NoCellular/DRWI_NoCellular.ino
+++ b/examples/DRWI_NoCellular/DRWI_NoCellular.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data from a Decagon CTD-10 and a Campbell
 OBS 3+ to an SD card.

--- a/examples/DRWI_NoCellular/platformio.ini
+++ b/examples/DRWI_NoCellular/platformio.ini
@@ -18,4 +18,4 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -129,7 +129,7 @@ bool wakeFxn(void)
 // Describe the physical pin connection of your modem to your board
 const long ModemBaud = 57600;        // Communication speed of the modem
 const int8_t modemVccPin = -2;       // MCU pin controlling modem power (-1 if not applicable)
-const int8_t modemResetPin = -1;     // MCU Pin connected to ESP8266's RSTB pin (-1 if unconnected)
+const int8_t modemResetPin = -1;     // MCU pin connected to ESP8266's RSTB pin (-1 if unconnected)
 const int8_t espSleepRqPin = 13;     // ESP8266 GPIO pin used for wake from light sleep (-1 if not applicable)
 const int8_t modemSleepRqPin = 19;   // MCU pin used for wake from light sleep (-1 if not applicable)
 const int8_t espStatusPin = -1;      // ESP8266 GPIO pin used to give modem status (-1 if not applicable)
@@ -153,7 +153,7 @@ bool sleepFxn(void)
     // {
     //     uint32_t sleepSeconds = (((uint32_t)loggingInterval) * 60 * 1000) - 75000L;
     //     String sleepCommand = String(sleepSeconds);
-    //     tinyModem->sendAT(GF("+GSLP="), sleepCommand);
+    //     tinyModem->sendAT(F("+GSLP="), sleepCommand);
     //     // Power down for 1 minute less than logging interval
     //     // Better:  Calculate length of loop and power down for logging interval - loop time
     //     return tinyModem->waitResponse() == 1;
@@ -163,10 +163,10 @@ bool sleepFxn(void)
     // pin to view the sleep status.
     else if (modemSleepRqPin >= 0 && modemStatusPin >= 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0,"),
-                          String(espStatusPin), GF(","), modemStatusLevel);
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0,"),
+                          String(espStatusPin), F(","), modemStatusLevel);
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -174,9 +174,9 @@ bool sleepFxn(void)
     // Light sleep without the status pin
     else if (modemSleepRqPin >= 0 && modemStatusPin < 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0"));
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0"));
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -538,17 +538,18 @@ void setup()
 
     // Set up the sleep/wake pin for the modem and put its inital value as "off"
     #if defined(TINY_GSM_MODEM_XBEE)
+        Serial.println(F("Setting up sleep mode on the XBee."));
         pinMode(modemSleepRqPin, OUTPUT);
         digitalWrite(modemSleepRqPin, LOW);  // Turn it on to talk, just in case
         if (tinyModem->commandMode())
         {
-            tinyModem->sendAT(GF("SM"),1);  // Pin sleep
+            tinyModem->sendAT(F("SM"),1);  // Pin sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("DO"),0);  // Disable remote manager
+            tinyModem->sendAT(F("DO"),0);  // Disable remote manager
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),0);  // For Cellular - disconnected sleep
+            tinyModem->sendAT(F("SO"),0);  // For Cellular - disconnected sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
+            tinyModem->sendAT(F("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
             tinyModem->waitResponse();
             tinyModem->writeChanges();
             tinyModem->exitCommand();

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -453,9 +453,9 @@ Variable *calcCorrDepth = new Variable(calculateWaterDepthTempCorrected, rhoDept
 // NOTE:  Since we've created all of the variable pointers above, we can just
 // reference them by name here.
 Variable *variableList[] = {
+    mayflySampNo,
     mayflyBatt,
     mayflyRAM,
-    mayflySampNo,
     ds3231Temp,
     bme280Temp,
     bme280Humid,

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -493,9 +493,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -347,7 +347,7 @@ Variable *ds18Temp = new MaximDS18_Temp(&ds18_u, "12345678-abcd-1234-efgh-123456
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 (default) or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card and sending the data to
 the EnviroDIY data portal.

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -58,6 +58,7 @@ ProcessorStats mayfly(MFVersion);
 // Create the battery voltage and free RAM variable objects for the processor and return variable-type pointers to them
 Variable *mayflyBatt = new ProcessorStats_Batt(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *mayflyRAM = new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
+Variable *mayflySampNo = new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 
 
 // ==========================================================================
@@ -454,6 +455,7 @@ Variable *calcCorrDepth = new Variable(calculateWaterDepthTempCorrected, rhoDept
 Variable *variableList[] = {
     mayflyBatt,
     mayflyRAM,
+    mayflySampNo,
     ds3231Temp,
     bme280Temp,
     bme280Humid,

--- a/examples/baro_rho_correction/platformio.ini
+++ b/examples/baro_rho_correction/platformio.ini
@@ -19,4 +19,4 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -323,7 +323,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 // Create the dissolved oxygen percent, dissolved oxygen concentration, and
 // temperature variable objects for the Y504 and return variable-type
 // pointers to them
@@ -342,7 +342,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 // Create the turbidity and temperature variable objects for the Y511 and return variable-type pointers to them
 Variable *y511Turb = new YosemitechY511_Turbidity(&y511, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y511Temp = new YosemitechY511_Temp(&y511, "12345678-abcd-1234-efgh-1234567890ab");
@@ -358,7 +358,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 // Create the chlorophyll concentration and temperature variable objects for the Y514 and return variable-type pointers to them
 Variable *y514Chloro = new YosemitechY514_Chlorophyll(&y514, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y514Temp = new YosemitechY514_Temp(&y514, "12345678-abcd-1234-efgh-1234567890ab");
@@ -374,7 +374,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 // Create the specific conductance and temperature variable objects for the Y520 and return variable-type pointers to them
 Variable *y520Cond = new YosemitechY520_Cond(&y520, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-1234567890ab");

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -450,9 +450,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card and sending only a
 portion of that data to the EnviroDIY data portal.

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -129,7 +129,7 @@ bool wakeFxn(void)
 // Describe the physical pin connection of your modem to your board
 const long ModemBaud = 57600;        // Communication speed of the modem
 const int8_t modemVccPin = -2;       // MCU pin controlling modem power (-1 if not applicable)
-const int8_t modemResetPin = -1;     // MCU Pin connected to ESP8266's RSTB pin (-1 if unconnected)
+const int8_t modemResetPin = -1;     // MCU pin connected to ESP8266's RSTB pin (-1 if unconnected)
 const int8_t espSleepRqPin = 13;     // ESP8266 GPIO pin used for wake from light sleep (-1 if not applicable)
 const int8_t modemSleepRqPin = 19;   // MCU pin used for wake from light sleep (-1 if not applicable)
 const int8_t espStatusPin = -1;      // ESP8266 GPIO pin used to give modem status (-1 if not applicable)
@@ -153,7 +153,7 @@ bool sleepFxn(void)
     // {
     //     uint32_t sleepSeconds = (((uint32_t)loggingInterval) * 60 * 1000) - 75000L;
     //     String sleepCommand = String(sleepSeconds);
-    //     tinyModem->sendAT(GF("+GSLP="), sleepCommand);
+    //     tinyModem->sendAT(F("+GSLP="), sleepCommand);
     //     // Power down for 1 minute less than logging interval
     //     // Better:  Calculate length of loop and power down for logging interval - loop time
     //     return tinyModem->waitResponse() == 1;
@@ -163,10 +163,10 @@ bool sleepFxn(void)
     // pin to view the sleep status.
     else if (modemSleepRqPin >= 0 && modemStatusPin >= 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0,"),
-                          String(espStatusPin), GF(","), modemStatusLevel);
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0,"),
+                          String(espStatusPin), F(","), modemStatusLevel);
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -174,9 +174,9 @@ bool sleepFxn(void)
     // Light sleep without the status pin
     else if (modemSleepRqPin >= 0 && modemStatusPin < 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0"));
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0"));
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -498,17 +498,18 @@ void setup()
 
     // Set up the sleep/wake pin for the modem and put its inital value as "off"
     #if defined(TINY_GSM_MODEM_XBEE)
+        Serial.println(F("Setting up sleep mode on the XBee."));
         pinMode(modemSleepRqPin, OUTPUT);
         digitalWrite(modemSleepRqPin, LOW);  // Turn it on to talk, just in case
         if (tinyModem->commandMode())
         {
-            tinyModem->sendAT(GF("SM"),1);  // Pin sleep
+            tinyModem->sendAT(F("SM"),1);  // Pin sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("DO"),0);  // Disable remote manager
+            tinyModem->sendAT(F("DO"),0);  // Disable remote manager
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),0);  // For Cellular - disconnected sleep
+            tinyModem->sendAT(F("SO"),0);  // For Cellular - disconnected sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
+            tinyModem->sendAT(F("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
             tinyModem->waitResponse();
             tinyModem->writeChanges();
             tinyModem->exitCommand();

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -323,7 +323,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 // Create the dissolved oxygen percent, dissolved oxygen concentration, and
 // temperature variable objects for the Y504 and return variable-type
 // pointers to them
@@ -342,7 +342,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 // Create the turbidity and temperature variable objects for the Y511 and return variable-type pointers to them
 Variable *y511Turb = new YosemitechY511_Turbidity(&y511, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y511Temp = new YosemitechY511_Temp(&y511, "12345678-abcd-1234-efgh-1234567890ab");
@@ -358,7 +358,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 // Create the chlorophyll concentration and temperature variable objects for the Y514 and return variable-type pointers to them
 Variable *y514Chloro = new YosemitechY514_Chlorophyll(&y514, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y514Temp = new YosemitechY514_Temp(&y514, "12345678-abcd-1234-efgh-1234567890ab");
@@ -374,7 +374,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 // Create the specific conductance and temperature variable objects for the Y520 and return variable-type pointers to them
 Variable *y520Cond = new YosemitechY520_Cond(&y520, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-1234567890ab");

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -58,6 +58,7 @@ ProcessorStats mayfly(MFVersion);
 // Create the battery voltage and free RAM variable objects for the processor and return variable-type pointers to them
 Variable *mayflyBatt = new ProcessorStats_Batt(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 Variable *mayflyRAM = new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
+Variable *mayflySampNo = new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 
 
 // ==========================================================================
@@ -390,6 +391,7 @@ Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-123
 Variable *variableList_complete[] = {
     mayflyBatt,
     mayflyRAM,
+    mayflySampNo,
     ds3231Temp,
     y504DOpct,
     y504DOmgL,

--- a/examples/data_saving/data_saving.ino
+++ b/examples/data_saving/data_saving.ino
@@ -389,9 +389,9 @@ Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-123
 // NOTE:  Since we've created all of the variable pointers above, we can just
 // reference them by name here.
 Variable *variableList_complete[] = {
+    mayflySampNo,
     mayflyBatt,
     mayflyRAM,
-    mayflySampNo,
     ds3231Temp,
     y504DOpct,
     y504DOmgL,

--- a/examples/data_saving/platformio.ini
+++ b/examples/data_saving/platformio.ini
@@ -18,5 +18,5 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     https://github.com/PaulStoffregen/AltSoftSerial.git

--- a/examples/double_logger/double_logger.ino
+++ b/examples/double_logger/double_logger.ino
@@ -174,9 +174,9 @@ Logger  logger5min(LoggerID, 5, sdCardPin, wakePin, &array5min);
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/double_logger/double_logger.ino
+++ b/examples/double_logger/double_logger.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data from different variables at two
 different logging intervals.  This example uses more of the manual functions

--- a/examples/double_logger/platformio.ini
+++ b/examples/double_logger/platformio.ini
@@ -18,4 +18,4 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -486,7 +486,7 @@ MaximDS18 ds18_5(OneWireAddress5, OneWirePower, OneWireBus);
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -706,6 +706,7 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOpct(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOmgL(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
+    new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_Batt(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-efgh-1234567890ab"),

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -516,7 +516,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -529,7 +529,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -542,7 +542,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -555,7 +555,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -568,7 +568,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -581,7 +581,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -594,7 +594,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -607,7 +607,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -620,7 +620,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -516,7 +516,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -529,7 +529,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -542,7 +542,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -555,7 +555,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -568,7 +568,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -581,7 +581,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -594,7 +594,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -607,7 +607,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -620,7 +620,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -437,7 +437,7 @@ MPL115A2 mpl115a2(I2CPower, MPL115A2ReadingsToAvg);
 // Neither hardware serial nor AltSoftSerial require any modifications to
 // deal with interrupt conflicts.
 
-const int SonarData = 11;     // data receive pin
+const int8_t SonarData = 11;     // data receive pin
 
 #include <SoftwareSerial_ExtInts.h>  // for the stream communication
 SoftwareSerial_ExtInts sonarSerial(SonarData, -1);  // No Tx pin is required, only Rx
@@ -737,9 +737,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -125,7 +125,7 @@ bool wakeFxn(void)
 // Describe the physical pin connection of your modem to your board
 const long ModemBaud = 57600;        // Communication speed of the modem
 const int8_t modemVccPin = -2;       // MCU pin controlling modem power (-1 if not applicable)
-const int8_t modemResetPin = -1;     // MCU Pin connected to ESP8266's RSTB pin (-1 if unconnected)
+const int8_t modemResetPin = -1;     // MCU pin connected to ESP8266's RSTB pin (-1 if unconnected)
 const int8_t espSleepRqPin = 13;     // ESP8266 GPIO pin used for wake from light sleep (-1 if not applicable)
 const int8_t modemSleepRqPin = 19;   // MCU pin used for wake from light sleep (-1 if not applicable)
 const int8_t espStatusPin = -1;      // ESP8266 GPIO pin used to give modem status (-1 if not applicable)
@@ -149,7 +149,7 @@ bool sleepFxn(void)
     // {
     //     uint32_t sleepSeconds = (((uint32_t)loggingInterval) * 60 * 1000) - 75000L;
     //     String sleepCommand = String(sleepSeconds);
-    //     tinyModem->sendAT(GF("+GSLP="), sleepCommand);
+    //     tinyModem->sendAT(F("+GSLP="), sleepCommand);
     //     // Power down for 1 minute less than logging interval
     //     // Better:  Calculate length of loop and power down for logging interval - loop time
     //     return tinyModem->waitResponse() == 1;
@@ -159,10 +159,10 @@ bool sleepFxn(void)
     // pin to view the sleep status.
     else if (modemSleepRqPin >= 0 && modemStatusPin >= 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0,"),
-                          String(espStatusPin), GF(","), modemStatusLevel);
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0,"),
+                          String(espStatusPin), F(","), modemStatusLevel);
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -170,9 +170,9 @@ bool sleepFxn(void)
     // Light sleep without the status pin
     else if (modemSleepRqPin >= 0 && modemStatusPin < 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0"));
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0"));
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -795,17 +795,18 @@ void setup()
 
     // Set up the sleep/wake pin for the modem and put its inital value as "off"
     #if defined(TINY_GSM_MODEM_XBEE)
+        Serial.println(F("Setting up sleep mode on the XBee."));
         pinMode(modemSleepRqPin, OUTPUT);
         digitalWrite(modemSleepRqPin, LOW);  // Turn it on to talk, just in case
         if (tinyModem->commandMode())
         {
-            tinyModem->sendAT(GF("SM"),1);  // Pin sleep
+            tinyModem->sendAT(F("SM"),1);  // Pin sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("DO"),0);  // Disable remote manager
+            tinyModem->sendAT(F("DO"),0);  // Disable remote manager
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),0);  // For Cellular - disconnected sleep
+            tinyModem->sendAT(F("SO"),0);  // For Cellular - disconnected sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
+            tinyModem->sendAT(F("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
             tinyModem->waitResponse();
             tinyModem->writeChanges();
             tinyModem->exitCommand();

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -641,6 +641,7 @@ ZebraTechDOpto dopto(*DOptoDI12address, SDI12Power, SDI12Data);
 // Create pointers for all of the variables from the sensors
 // at the same time putting them into an array
 Variable *variableList[] = {
+    new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ApogeeSQ212_PAR(&SQ212, "12345678-abcd-1234-efgh-1234567890ab"),
     new AOSongAM2315_Humidity(&am2315, "12345678-abcd-1234-efgh-1234567890ab"),
     new AOSongAM2315_Temp(&am2315, "12345678-abcd-1234-efgh-1234567890ab"),
@@ -706,7 +707,6 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOpct(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOmgL(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
-    new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_Batt(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-efgh-1234567890ab"),

--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card and sending the data to
 the EnviroDIY data portal.

--- a/examples/logging_to_EnviroDIY/platformio.ini
+++ b/examples/logging_to_EnviroDIY/platformio.ini
@@ -18,6 +18,6 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     https://github.com/PaulStoffregen/AltSoftSerial.git
     https://github.com/EnviroDIY/SoftwaterSerial_ExternalInts.git

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -644,6 +644,7 @@ ZebraTechDOpto dopto(*DOptoDI12address, SDI12Power, SDI12Data);
 // Create pointers for all of the variables from the sensors
 // at the same time putting them into an array
 Variable *variableList[] = {
+    new ProcessorStats_SampleNumber(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new ApogeeSQ212_PAR(&SQ212, "12345678-abcd-1234-efgh-1234567890ab"),
     new AOSongAM2315_Humidity(&am2315, "12345678-abcd-1234-efgh-1234567890ab"),
     new AOSongAM2315_Temp(&am2315, "12345678-abcd-1234-efgh-1234567890ab"),
@@ -709,7 +710,6 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOpct(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOmgL(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
-    new ProcessorStats_SampleNumber(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_FreeRam(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_Batt(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-efgh-1234567890ab"),

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card and sending the data to
 the EnviroDIY data portal via a AtSAMD21 board, such as an Arduino Zero or Feather M0.

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -427,8 +427,8 @@ MPL115A2 mpl115a2(I2CPower, MPL115A2ReadingsToAvg);
 // ==========================================================================
 
 // Set up a 'new' UART for receiving sonar data - in this case, using SERCOM2
-// In this case, the Rx will be on digital pin 5, which is SERCOM2's Rx Pad #3
-// Although the MaxBotix cannot use it, the Tx will be on digital pin 2, which is SERCOM2's Rx Pad #2
+// In this case, the Rx will be on digital pin 5, which is SERCOM2's Pad #3
+// Although the MaxBotix cannot use it, the Tx will be on digital pin 2, which is SERCOM2's Pad #2
 // NOTE:  SERCOM2 is undefinied on a "standard" Arduino Zero and many clones,
 //        but not all!  Please check the variant.cpp file for you individual board!
 //        Sodaq Autonomo's and Sodaq One's do NOT follow the 'standard' SERCOM definitions!
@@ -495,8 +495,8 @@ RainCounterI2C tbi2c(RainCounterI2CAddress, depthPerTipEvent);
 
 
 // Set up a 'new' UART for modbus communication - in this case, using SERCOM1
-// In this case, the Rx will be on digital pin 11, which is SERCOM1's Rx Pad #0
-// The Tx will be on digital pin 10, which is SERCOM1's Rx Pad #2
+// In this case, the Rx will be on digital pin 11, which is SERCOM1's Pad #0
+// The Tx will be on digital pin 10, which is SERCOM1's Pad #2
 // NOTE:  SERCOM1 is undefinied on a "standard" Arduino Zero and many clones,
 //        but not all!  Please check the variant.cpp file for you individual board!
 //        Sodaq Autonomo's and Sodaq One's do NOT follow the 'standard' SERCOM definitions!
@@ -777,20 +777,6 @@ void setup()
     Serial.print(F("Using ModularSensors Library version "));
     Serial.println(MODULAR_SENSORS_VERSION);
 
-    // Assign pins SERCOM functionality for extra UARTS
-    pinPeripheral(2, PIO_SERCOM);
-    pinPeripheral(5, PIO_SERCOM);
-    pinPeripheral(10, PIO_SERCOM);
-    pinPeripheral(11, PIO_SERCOM);
-
-    // Set up pins for the LED's
-    pinMode(greenLED, OUTPUT);
-    digitalWrite(greenLED, LOW);
-    pinMode(redLED, OUTPUT);
-    digitalWrite(redLED, LOW);
-    // Blink the LEDs to show the board is on and starting up
-    greenredflash();
-
     // Start the serial connection with the modem
     ModemSerial.begin(ModemBaud);
 
@@ -799,6 +785,20 @@ void setup()
 
     // Start the SoftwareSerial stream for the sonar
     sonarSerial.begin(9600);
+
+    // Assign pins SERCOM functionality
+    pinPeripheral(2, PIO_SERCOM); // Serial3 Tx = SERCOM2 Pad #2
+    pinPeripheral(5, PIO_SERCOM);  // Serial3 Rx = SERCOM2 Pad #3
+    pinPeripheral(10, PIO_SERCOM);  // Serial2 Tx = SERCOM1 Pad #2
+    pinPeripheral(11, PIO_SERCOM);  // Serial2 Rx = SERCOM1 Pad #0
+
+    // Set up pins for the LED's
+    pinMode(greenLED, OUTPUT);
+    digitalWrite(greenLED, LOW);
+    pinMode(redLED, OUTPUT);
+    digitalWrite(redLED, LOW);
+    // Blink the LEDs to show the board is on and starting up
+    greenredflash();
 
     // Set up the sleep/wake pin for the modem and put its inital value as "off"
     #if defined(TINY_GSM_MODEM_XBEE)

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -519,7 +519,7 @@ const int8_t modbusSensorPower = -1;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -532,7 +532,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -545,7 +545,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -558,7 +558,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -571,7 +571,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -584,7 +584,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -597,7 +597,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -610,7 +610,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -623,7 +623,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -2,7 +2,7 @@
 logging_to_EnviroDIY_Zero.ino
 Written By:  Sara Damiano (sdamiano@stroudcenter.org)
 Development Environment: PlatformIO
-Hardware Platform: EnviroDIY Mayfly Arduino Datalogger
+Hardware Platform: Adafruit Adalogger M0
 Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
@@ -709,6 +709,7 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOpct(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     new ZebraTechDOpto_DOmgL(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
+    new ProcessorStats_SampleNumber(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_FreeRam(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_Batt(&feather, "12345678-abcd-1234-efgh-1234567890ab"),
     new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-efgh-1234567890ab"),

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -519,7 +519,7 @@ const int8_t modbusSensorPower = -1;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -532,7 +532,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -545,7 +545,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -558,7 +558,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -571,7 +571,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -584,7 +584,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -597,7 +597,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -610,7 +610,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -623,7 +623,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -478,7 +478,7 @@ MaximDS18 ds18_5(OneWireAddress5, OneWirePower, OneWireBus);
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -323,7 +323,7 @@ AOSongDHT dht(DHTPower, DHTPin, dhtType);
 // ==========================================================================
 #include <sensors/ApogeeSQ212.h>
 const int8_t SQ212Power = -1;  // Pin to switch power on and off (-1 if unconnected)
-const int8_t SQ212Data = 0;  // The data pin ON THE ADS1115 (NOT the Arduino Pin Number)
+const int8_t SQ212Data = 2;  // The data pin ON THE ADS1115 (NOT the Arduino Pin Number)
 const uint8_t SQ212_ADS1115Address = 0x48;  // The I2C address of the ADS1115 ADC
 // Create and return the Apogee SQ212 sensor object
 ApogeeSQ212 SQ212(SQ212Power, SQ212Data);
@@ -404,7 +404,7 @@ DecagonES2 es2(*ES2SDI12address, SDI12Power, SDI12Data, ES2NumberReadings);
 // ==========================================================================
 #include <sensors/ExternalVoltage.h>
 const int8_t VoltPower = -1;  // Pin to switch power on and off (-1 if unconnected)
-const int8_t VoltData = 0;  // The data pin ON THE ADS1115 (NOT the Arduino Pin Number)
+const int8_t VoltData = 2;  // The data pin ON THE ADS1115 (NOT the Arduino Pin Number)
 const float VoltGain = 10; // Default 1/gain for grove voltage divider is 10x
 const uint8_t Volt_ADS1115Address = 0x48;  // The I2C address of the ADS1115 ADC
 const uint8_t VoltReadsToAvg = 1; // Only read one sample
@@ -759,9 +759,9 @@ void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 // ==========================================================================
 void setup()
 {
-    // Wait for the native/onboard USB port to be ready
-    // NOTE:  This waits for the USB drivers to be active on the chip, not for
-    // any information to be sent or a serial port monitor to connect.
+    // Wait for USB connection to be established by PC
+    // NOTE:  Only use this when debugging - if not connected to a PC, this
+    // will prevent the script from starting
     while (!Serial){}
 
     // Start the primary serial connection
@@ -805,6 +805,7 @@ void setup()
         Serial.println(F("Setting up sleep mode on the XBee."));
         pinMode(modemSleepRqPin, OUTPUT);
         digitalWrite(modemSleepRqPin, LOW);  // Turn it on to talk, just in case
+        tinyModem->init();  // initialize
         if (tinyModem->commandMode())
         {
             tinyModem->sendAT(F("SM"),1);  // Pin sleep

--- a/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
+++ b/examples/logging_to_EnviroDIY_Zero/logging_to_EnviroDIY_Zero.ino
@@ -740,9 +740,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/logging_to_EnviroDIY_Zero/platformio.ini
+++ b/examples/logging_to_EnviroDIY_Zero/platformio.ini
@@ -18,5 +18,5 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = SoftwareSerial_ExtInts, AltSoftSerial
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     RTCZero

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -268,7 +268,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -281,7 +281,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -294,7 +294,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -307,7 +307,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -320,7 +320,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -333,7 +333,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -346,7 +346,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -359,7 +359,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -372,7 +372,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -238,7 +238,7 @@ MaximDS18 ds18_5(OneWireAddress5, OneWirePower, OneWireBus);
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -268,7 +268,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -281,7 +281,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -294,7 +294,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -307,7 +307,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -320,7 +320,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -333,7 +333,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -346,7 +346,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -359,7 +359,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -372,7 +372,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -392,6 +392,7 @@ ZebraTechDOpto dopto(*DOptoDI12address, SDI12Power, SDI12Data);
 // Create pointers for all of the variables from the sensors
 // at the same time putting them into an array
 Variable *variableList[] = {
+    new ProcessorStats_SampleNumber(&mayfly),
     new ApogeeSQ212_PAR(&SQ212),
     new AOSongAM2315_Humidity(&am2315),
     new AOSongAM2315_Temp(&am2315),
@@ -455,7 +456,6 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto),
     new ZebraTechDOpto_DOpct(&dopto),
     new ZebraTechDOpto_DOmgL(&dopto),
-    new ProcessorStats_SampleNumber(&mayfly),
     new ProcessorStats_FreeRam(&mayfly),
     new ProcessorStats_Batt(&mayfly),
     new MaximDS3231_Temp(&ds3231),

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -189,7 +189,7 @@ MPL115A2 mpl115a2(I2CPower, MPL115A2ReadingsToAvg);
 // Neither hardware serial nor AltSoftSerial require any modifications to
 // deal with interrupt conflicts.
 
-const int SonarData = 11;     // data receive pin
+const int8_t SonarData = 11;     // data receive pin
 
 #include <SoftwareSerial_ExtInts.h>  // for the stream communication
 SoftwareSerial_ExtInts sonarSerial(SonarData, -1);  // No Tx pin is required, only Rx
@@ -472,9 +472,9 @@ VariableArray sensors(variableCount, variableList);
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -455,6 +455,7 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto),
     new ZebraTechDOpto_DOpct(&dopto),
     new ZebraTechDOpto_DOmgL(&dopto),
+    new ProcessorStats_SampleNumber(&mayfly),
     new ProcessorStats_FreeRam(&mayfly),
     new ProcessorStats_Batt(&mayfly),
     new MaximDS3231_Temp(&ds3231),

--- a/examples/multisensor_print/multisensor_print.ino
+++ b/examples/multisensor_print/multisensor_print.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of printing data from multiple sensors using
 the modular sensor library.

--- a/examples/multisensor_print/platformio.ini
+++ b/examples/multisensor_print/platformio.ini
@@ -18,6 +18,6 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     https://github.com/PaulStoffregen/AltSoftSerial.git
     https://github.com/EnviroDIY/SoftwaterSerial_ExternalInts.git

--- a/examples/simple_logging/platformio.ini
+++ b/examples/simple_logging/platformio.ini
@@ -18,6 +18,6 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     https://github.com/PaulStoffregen/AltSoftSerial.git
     https://github.com/EnviroDIY/SoftwaterSerial_ExternalInts.git

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -405,6 +405,7 @@ ZebraTechDOpto dopto(*DOptoDI12address, SDI12Power, SDI12Data);
 // Create pointers for all of the variables from the sensors
 // at the same time putting them into an array
 Variable *variableList[] = {
+    new ProcessorStats_SampleNumber(&mayfly),
     new ApogeeSQ212_PAR(&SQ212),
     new AOSongAM2315_Humidity(&am2315),
     new AOSongAM2315_Temp(&am2315),
@@ -468,7 +469,6 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto),
     new ZebraTechDOpto_DOpct(&dopto),
     new ZebraTechDOpto_DOmgL(&dopto),
-    new ProcessorStats_SampleNumber(&mayfly),
     new ProcessorStats_FreeRam(&mayfly),
     new ProcessorStats_Batt(&mayfly),
     new MaximDS3231_Temp(&ds3231),

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -468,6 +468,7 @@ Variable *variableList[] = {
     new ZebraTechDOpto_Temp(&dopto),
     new ZebraTechDOpto_DOpct(&dopto),
     new ZebraTechDOpto_DOmgL(&dopto),
+    new ProcessorStats_SampleNumber(&mayfly),
     new ProcessorStats_FreeRam(&mayfly),
     new ProcessorStats_Batt(&mayfly),
     new MaximDS3231_Temp(&ds3231),

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -202,7 +202,7 @@ MPL115A2 mpl115a2(I2CPower, MPL115A2ReadingsToAvg);
 // Neither hardware serial nor AltSoftSerial require any modifications to
 // deal with interrupt conflicts.
 
-const int SonarData = 11;     // data receive pin
+const int8_t SonarData = 11;     // data receive pin
 
 #include <SoftwareSerial_ExtInts.h>  // for the stream communication
 SoftwareSerial_ExtInts sonarSerial(SonarData, -1);  // No Tx pin is required, only Rx
@@ -487,9 +487,9 @@ Logger logger(LoggerID, loggingInterval, sdCardPin, wakePin, &varArray);
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -281,7 +281,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -294,7 +294,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -307,7 +307,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -320,7 +320,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -333,7 +333,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -346,7 +346,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -359,7 +359,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -372,7 +372,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -385,7 +385,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of logging data to an SD card
 

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -251,7 +251,7 @@ MaximDS18 ds18_5(OneWireAddress5, OneWirePower, OneWireBus);
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/examples/simple_logging/simple_logging.ino
+++ b/examples/simple_logging/simple_logging.ino
@@ -281,7 +281,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 
 
 // ==========================================================================
@@ -294,7 +294,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 
 
 // ==========================================================================
@@ -307,7 +307,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
 
 
 // ==========================================================================
@@ -320,7 +320,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 
 
 // ==========================================================================
@@ -333,7 +333,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 
 
 // ==========================================================================
@@ -346,7 +346,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 
 
 // ==========================================================================
@@ -359,7 +359,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
 
 
 // ==========================================================================
@@ -372,7 +372,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
 
 
 // ==========================================================================
@@ -385,7 +385,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
 
 
 // ==========================================================================

--- a/examples/single_sensor/platformio.ini
+++ b/examples/single_sensor/platformio.ini
@@ -18,5 +18,5 @@ framework = arduino
 lib_ldf_mode = deep
 lib_ignore = RTCZero
 lib_deps =
-    EnviroDIY_ModularSensors@=0.16.0
+    EnviroDIY_ModularSensors@=0.16.1
     https://github.com/EnviroDIY/SoftwaterSerial_ExternalInts.git

--- a/examples/single_sensor/single_sensor.ino
+++ b/examples/single_sensor/single_sensor.ino
@@ -7,7 +7,7 @@ Software License: BSD-3.
   Copyright (c) 2017, Stroud Water Research Center (SWRC)
   and the EnviroDIY Development Team
 
-This example sketch is written for ModularSensors library version 0.16.0
+This example sketch is written for ModularSensors library version 0.16.1
 
 This sketch is an example of getting data from a single sensor, in this case, a
 MaxBotix Ultrasonic Range Finder

--- a/examples/single_sensor/single_sensor.ino
+++ b/examples/single_sensor/single_sensor.ino
@@ -47,8 +47,8 @@ const char *sketchName = "single_sensor.ino";
 // Neither hardware serial nor AltSoftSerial require any modifications to
 // deal with interrupt conflicts.
 
-const int SonarData = 11;     // data  pin
-const int SonarTrigger = -1;   // Trigger pin
+const int8_t SonarData = 11;     // data  pin
+const int8_t SonarTrigger = -1;   // Trigger pin
 const int8_t SonarPower = 22;   // excite (power) pin
 
 
@@ -106,9 +106,9 @@ const int8_t greenLED = 8;  // Pin for the green LED
 const int8_t redLED = 9;  // Pin for the red LED
 
 // Flashes to Mayfly's LED's
-void greenredflash(int numFlash = 4)
+void greenredflash(uint8_t numFlash = 4)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(75);

--- a/library.json
+++ b/library.json
@@ -55,6 +55,11 @@
             "+<sensors/*.cpp>",
             "+<sensors/*.h>"
         ]
+        "flags":
+        [
+            "-D SDI12_EXTERNAL_PCINT",
+            "-D NEOSWSERIAL_EXTERNAL_PCINT"
+        ]
     },
     "dependencies":
     [
@@ -206,9 +211,9 @@
         },
         {
             "name": "Arduino-SDI-12_ExtInts",
-            "version": "https://github.com/EnviroDIY/Arduino-SDI-12.git#b6f2031d2875d386da3e0f080a21047247402341",
+            "version": "https://github.com/EnviroDIY/Arduino-SDI-12.git#e818e6baff9412499e5eb740994ba8848c4d2ac4",
             "version_branch": "https://github.com/EnviroDIY/Arduino-SDI-12.git#ExtInts",
-            "version_number": "=1.3.3",
+            "version_number": "=1.3.4",
             "note": "EnviroDIY SDI-12 Library, dependent on external library for interrupts",
             "authors": [
                 "Kevin M. Smith",

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -607,7 +607,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
 // Create the pressure, temperature, and height variable objects for the ES2 and return variable-type pointers to them
 // Variable *acculevPress = new KellerAcculevel_Pressure(&acculevel, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *acculevTemp = new KellerAcculevel_Temp(&acculevel, "12345678-abcd-1234-efgh-1234567890ab");
@@ -625,7 +625,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
 // Create the dissolved oxygen percent, dissolved oxygen concentration, and
 // temperature variable objects for the Y504 and return variable-type
 // pointers to them
@@ -644,7 +644,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
 // Create the turbidity and temperature variable objects for the Y510 and return variable-type pointers to them
 // Variable *y510Turb = new YosemitechY510_Turbidity(&y510, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y510Temp = new YosemitechY510_Temp(&y510, "12345678-abcd-1234-efgh-1234567890ab");
@@ -660,7 +660,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
 // Create the turbidity and temperature variable objects for the Y511 and return variable-type pointers to them
 // Variable *y511Turb = new YosemitechY511_Turbidity(&y511, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y511Temp = new YosemitechY511_Temp(&y511, "12345678-abcd-1234-efgh-1234567890ab");
@@ -676,7 +676,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
 // Create the chlorophyll concentration and temperature variable objects for the Y514 and return variable-type pointers to them
 // Variable *y514Chloro = new YosemitechY514_Chlorophyll(&y514, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y514Temp = new YosemitechY514_Temp(&y514, "12345678-abcd-1234-efgh-1234567890ab");
@@ -692,7 +692,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
 // Create the specific conductance and temperature variable objects for the Y520 and return variable-type pointers to them
 // Variable *y520Cond = new YosemitechY520_Cond(&y520, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-1234567890ab");
@@ -708,7 +708,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
 // Create the pH, electrical potential, and temperature variable objects for the Y532 and return variable-type pointers to them
 // Variable *y532Voltage = new YosemitechY532_Voltage(&y532, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y532pH = new YosemitechY532_pH(&y532, "12345678-abcd-1234-efgh-1234567890ab");
@@ -725,7 +725,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
 // Create the COD, turbidity, and temperature variable objects for the Y550 and return variable-type pointers to them
 // Variable *y550COD = new YosemitechY550_COD(&y550, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y550Turbid = new YosemitechY550_Turbidity(&y550, "12345678-abcd-1234-efgh-1234567890ab");
@@ -743,7 +743,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 3;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
 // Create all of the variable objects for the Y4000 and return variable-type pointers to them
 // Variable *y4000DO = new YosemitechY4000_DOmgL(&y4000, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y4000Turb = new YosemitechY4000_Turbidity(&y4000, "12345678-abcd-1234-efgh-1234567890ab");

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -552,7 +552,7 @@ MaximDS18 ds18_5(OneWireAddress5, OneWirePower, OneWireBus);
 #include <sensors/MeaSpecMS5803.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
 const uint8_t MS5803i2c_addr = 0x76;  // The MS5803 can be addressed either as 0x76 or 0x77
-const int MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
+const int16_t MS5803maxPressure = 14;  // The maximum pressure measurable by the specific MS5803 model
 const uint8_t MS5803ReadingsToAvg = 1;
 // Create and return the MeaSpec MS5803 pressure and temperature sensor object
 MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803ReadingsToAvg);

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -64,6 +64,7 @@ ProcessorStats mayfly(MFVersion);
 // send data over the modem or if the data should only be logged.
 Variable *mayflyBatt = new ProcessorStats_Batt(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *mayflyRAM = new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
+// Variable *mayflySampNo = new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab");
 
 
 // ==========================================================================
@@ -843,6 +844,7 @@ Variable *variableList[] = {
     // new ZebraTechDOpto_Temp(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     // new ZebraTechDOpto_DOpct(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
     // new ZebraTechDOpto_DOmgL(&dopto, "12345678-abcd-1234-efgh-1234567890ab"),
+    new ProcessorStats_SampleNumber(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     new ProcessorStats_FreeRam(&mayfly, "12345678-abcd-1234-efgh-1234567890ab"),
     mayflyBatt,
     new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-efgh-1234567890ab"),

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -135,7 +135,7 @@ bool wakeFxn(void)
 // Describe the physical pin connection of your modem to your board
 const long ModemBaud = 57600;        // Communication speed of the modem
 const int8_t modemVccPin = -2;       // MCU pin controlling modem power (-1 if not applicable)
-const int8_t modemResetPin = -1;     // MCU Pin connected to ESP8266's RSTB pin (-1 if unconnected)
+const int8_t modemResetPin = -1;     // MCU pin connected to ESP8266's RSTB pin (-1 if unconnected)
 const int8_t espSleepRqPin = 13;     // ESP8266 GPIO pin used for wake from light sleep (-1 if not applicable)
 const int8_t modemSleepRqPin = 19;   // MCU pin used for wake from light sleep (-1 if not applicable)
 const int8_t espStatusPin = -1;      // ESP8266 GPIO pin used to give modem status (-1 if not applicable)
@@ -159,7 +159,7 @@ bool sleepFxn(void)
     // {
     //     uint32_t sleepSeconds = (((uint32_t)loggingInterval) * 60 * 1000) - 75000L;
     //     String sleepCommand = String(sleepSeconds);
-    //     tinyModem->sendAT(GF("+GSLP="), sleepCommand);
+    //     tinyModem->sendAT(F("+GSLP="), sleepCommand);
     //     // Power down for 1 minute less than logging interval
     //     // Better:  Calculate length of loop and power down for logging interval - loop time
     //     return tinyModem->waitResponse() == 1;
@@ -169,10 +169,10 @@ bool sleepFxn(void)
     // pin to view the sleep status.
     else if (modemSleepRqPin >= 0 && modemStatusPin >= 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0,"),
-                          String(espStatusPin), GF(","), modemStatusLevel);
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0,"),
+                          String(espStatusPin), F(","), modemStatusLevel);
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -180,9 +180,9 @@ bool sleepFxn(void)
     // Light sleep without the status pin
     else if (modemSleepRqPin >= 0 && modemStatusPin < 0)
     {
-        tinyModem->sendAT(GF("+WAKEUPGPIO=1,"), String(espSleepRqPin), GF(",0"));
+        tinyModem->sendAT(F("+WAKEUPGPIO=1,"), String(espSleepRqPin), F(",0"));
         bool success = tinyModem->waitResponse() == 1;
-        tinyModem->sendAT(GF("+SLEEP=1"));
+        tinyModem->sendAT(F("+SLEEP=1"));
         success &= tinyModem->waitResponse() == 1;
         digitalWrite(redLED, LOW);
         return success;
@@ -942,17 +942,18 @@ void setup()
 
     // Set up the sleep/wake pin for the modem and put its inital value as "off"
     #if defined(TINY_GSM_MODEM_XBEE)
+        Serial.println(F("Setting up sleep mode on the XBee."));
         pinMode(modemSleepRqPin, OUTPUT);
         digitalWrite(modemSleepRqPin, LOW);  // Turn it on to talk, just in case
         if (tinyModem->commandMode())
         {
-            tinyModem->sendAT(GF("SM"),1);  // Pin sleep
+            tinyModem->sendAT(F("SM"),1);  // Pin sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("DO"),0);  // Disable remote manager
+            tinyModem->sendAT(F("DO"),0);  // Disable remote manager
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),0);  // For Cellular - disconnected sleep
+            tinyModem->sendAT(F("SO"),0);  // For Cellular - disconnected sleep
             tinyModem->waitResponse();
-            tinyModem->sendAT(GF("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
+            tinyModem->sendAT(F("SO"),200);  // For WiFi - Disassociate from AP for Deep Sleep
             tinyModem->waitResponse();
             tinyModem->writeChanges();
             tinyModem->exitCommand();

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -498,7 +498,7 @@ MPL115A2 mpl115a2(I2CPower, MPL115A2ReadingsToAvg);
 // Neither hardware serial nor AltSoftSerial require any modifications to
 // deal with interrupt conflicts.
 
-const int SonarData = 11;     // data receive pin
+const int8_t SonarData = 11;     // data receive pin
 
 #include <SoftwareSerial_ExtInts.h>  // for the stream communication
 SoftwareSerial_ExtInts sonarSerial(SonarData, -1);  // No Tx pin is required, only Rx
@@ -566,12 +566,12 @@ MeaSpecMS5803 ms5803(I2CPower, MS5803i2c_addr, MS5803maxPressure, MS5803Readings
 // ==========================================================================
 #include <sensors/PaleoTerraRedox.h>
 // const int8_t I2CPower = 22;  // Pin to switch power on and off (-1 if unconnected)
-const int sclPin1 = 4;  //Clock pin to be used with 1st redox probe
-const int sdaPin1 = 5;  //Data pin to be used with 1st redox probe
-const int sclPin2 = 6;  //Clock pin to be used with 2nd redox probe
-const int sdaPin2 = 7;  //Data pin to be used with 2nd redox probe
-const int sclPin3 = 10;  //Clock pin to be used with 2nd redox probe
-const int sdaPin3 = 11;  //Data pin to be used with 2nd redox probe
+const int8_t sclPin1 = 4;  //Clock pin to be used with 1st redox probe
+const int8_t sdaPin1 = 5;  //Data pin to be used with 1st redox probe
+const int8_t sclPin2 = 6;  //Clock pin to be used with 2nd redox probe
+const int8_t sdaPin2 = 7;  //Data pin to be used with 2nd redox probe
+const int8_t sclPin3 = 10;  //Clock pin to be used with 2nd redox probe
+const int8_t sdaPin3 = 11;  //Data pin to be used with 2nd redox probe
 const uint8_t PaleoTerraReadingsToAvg = 1;
 Create and return the Paleo Terra Redox sensor objects
 PaleoTerraRedox redox1(I2CPower, sclPin1, sdaPin1, PaleoTerraReadingsToAvg);
@@ -873,9 +873,9 @@ const char *samplingFeature = "12345678-abcd-1234-efgh-1234567890ab";     // Sam
 // ==========================================================================
 
 // Flashes the LED's on the primary board
-void greenredflash(int numFlash = 4, int rate = 75)
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75)
 {
-  for (int i = 0; i < numFlash; i++) {
+  for (uint8_t i = 0; i < numFlash; i++) {
     digitalWrite(greenLED, HIGH);
     digitalWrite(redLED, LOW);
     delay(rate);

--- a/sensor_tests/AnthonyTest2/AnthonyTest2.ino
+++ b/sensor_tests/AnthonyTest2/AnthonyTest2.ino
@@ -607,7 +607,7 @@ const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (
 const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
-KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, acculevelNumberReadings);
+KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 // Create the pressure, temperature, and height variable objects for the ES2 and return variable-type pointers to them
 // Variable *acculevPress = new KellerAcculevel_Pressure(&acculevel, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *acculevTemp = new KellerAcculevel_Temp(&acculevel, "12345678-abcd-1234-efgh-1234567890ab");
@@ -625,7 +625,7 @@ byte y504ModbusAddress = 0x04;  // The modbus address of the Y504
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y504NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y504 dissolved oxygen sensor object
-YosemitechY504 y504(y504ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y504NumberReadings);
+YosemitechY504 y504(y504ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y504NumberReadings);
 // Create the dissolved oxygen percent, dissolved oxygen concentration, and
 // temperature variable objects for the Y504 and return variable-type
 // pointers to them
@@ -644,7 +644,7 @@ byte y510ModbusAddress = 0x0B;  // The modbus address of the Y510
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y510NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y510-B Turbidity sensor object
-YosemitechY510 y510(y510ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y510NumberReadings);
+YosemitechY510 y510(y510ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y510NumberReadings);
 // Create the turbidity and temperature variable objects for the Y510 and return variable-type pointers to them
 // Variable *y510Turb = new YosemitechY510_Turbidity(&y510, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y510Temp = new YosemitechY510_Temp(&y510, "12345678-abcd-1234-efgh-1234567890ab");
@@ -660,7 +660,7 @@ byte y511ModbusAddress = 0x1A;  // The modbus address of the Y511
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y511NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y511-A Turbidity sensor object
-YosemitechY511 y511(y511ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y511NumberReadings);
+YosemitechY511 y511(y511ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y511NumberReadings);
 // Create the turbidity and temperature variable objects for the Y511 and return variable-type pointers to them
 // Variable *y511Turb = new YosemitechY511_Turbidity(&y511, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y511Temp = new YosemitechY511_Temp(&y511, "12345678-abcd-1234-efgh-1234567890ab");
@@ -676,7 +676,7 @@ byte y514ModbusAddress = 0x14;  // The modbus address of the Y514
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y514NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y514 chlorophyll sensor object
-YosemitechY514 y514(y514ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y514NumberReadings);
+YosemitechY514 y514(y514ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y514NumberReadings);
 // Create the chlorophyll concentration and temperature variable objects for the Y514 and return variable-type pointers to them
 // Variable *y514Chloro = new YosemitechY514_Chlorophyll(&y514, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y514Temp = new YosemitechY514_Temp(&y514, "12345678-abcd-1234-efgh-1234567890ab");
@@ -692,7 +692,7 @@ byte y520ModbusAddress = 0x20;  // The modbus address of the Y520
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y520NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y520 conductivity sensor object
-YosemitechY520 y520(y520ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y520NumberReadings);
+YosemitechY520 y520(y520ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y520NumberReadings);
 // Create the specific conductance and temperature variable objects for the Y520 and return variable-type pointers to them
 // Variable *y520Cond = new YosemitechY520_Cond(&y520, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y520Temp = new YosemitechY520_Temp(&y520, "12345678-abcd-1234-efgh-1234567890ab");
@@ -708,7 +708,7 @@ byte y532ModbusAddress = 0x32;  // The modbus address of the Y532
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y532NumberReadings = 1;  // The manufacturer actually doesn't mention averaging for this one
 // Create and return the Yosemitech Y532 pH sensor object
-YosemitechY532 y532(y532ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y532NumberReadings);
+YosemitechY532 y532(y532ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y532NumberReadings);
 // Create the pH, electrical potential, and temperature variable objects for the Y532 and return variable-type pointers to them
 // Variable *y532Voltage = new YosemitechY532_Voltage(&y532, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y532pH = new YosemitechY532_pH(&y532, "12345678-abcd-1234-efgh-1234567890ab");
@@ -725,7 +725,7 @@ byte y550ModbusAddress = 0x50;  // The modbus address of the Y550
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y550NumberReadings = 5;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Y550 conductivity sensor object
-YosemitechY550 y550(y550ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y550NumberReadings);
+YosemitechY550 y550(y550ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y550NumberReadings);
 // Create the COD, turbidity, and temperature variable objects for the Y550 and return variable-type pointers to them
 // Variable *y550COD = new YosemitechY550_COD(&y550, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y550Turbid = new YosemitechY550_Turbidity(&y550, "12345678-abcd-1234-efgh-1234567890ab");
@@ -743,7 +743,7 @@ byte y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
 // const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t y4000NumberReadings = 3;  // The manufacturer recommends averaging 10 readings, but we take 5 to minimize power consumption
 // Create and return the Yosemitech Y4000 multi-parameter sensor object
-YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, modbusSensorPower, rs485AdapterPower, max485EnablePin, y4000NumberReadings);
+YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, y4000NumberReadings);
 // Create all of the variable objects for the Y4000 and return variable-type pointers to them
 // Variable *y4000DO = new YosemitechY4000_DOmgL(&y4000, "12345678-abcd-1234-efgh-1234567890ab");
 // Variable *y4000Turb = new YosemitechY4000_Turbidity(&y4000, "12345678-abcd-1234-efgh-1234567890ab");

--- a/src/LoggerBase.cpp
+++ b/src/LoggerBase.cpp
@@ -209,7 +209,7 @@ bool Logger::syncRTClock(uint32_t nist)
         formatDateTime_ISO8601(nist_logTZ));
 
     // See how long it took to get the time from NIST
-    int sync_time = (millis() - start_millis)/1000;
+    uint32_t sync_time = (millis() - start_millis)/1000;
 
     // Check the current RTC time
     uint32_t cur_logTZ = getNowEpoch();

--- a/src/LoggerDreamHost.cpp
+++ b/src/LoggerDreamHost.cpp
@@ -38,7 +38,7 @@ void LoggerDreamHost::printSensorDataDreamHost(Stream *stream)
     stream->print(String(F("?LoggerID=")) + String(Logger::_loggerID));
     stream->print(String(F("&Loggertime=")) + String(Logger::markedEpochTime - 946684800));  // Correct time from epoch to y2k
 
-    for (int i = 0; i < _internalArray->getVariableCount(); i++)
+    for (uint8_t i = 0; i < _internalArray->getVariableCount(); i++)
     {
         stream->print(String(F("&")) + String(_internalArray->arrayOfVars[i]->getVarCode()) \
             + String(F("=")) + String(_internalArray->arrayOfVars[i]->getValueString()));
@@ -64,7 +64,7 @@ void LoggerDreamHost::printDreamHostRequest(Stream *stream)
 
 
 // Post the data to dream host.
-int LoggerDreamHost::postDataDreamHost(void)
+int16_t LoggerDreamHost::postDataDreamHost(void)
 {
     // do not continue if no modem!
     if (_logModem == NULL)
@@ -107,11 +107,11 @@ int LoggerDreamHost::postDataDreamHost(void)
     else PRINTOUT(F("\n -- Unable to Establish Connection to DreamHost -- "));
 
     // Process the HTTP response
-    int responseCode = 0;
+    int16_t responseCode = 0;
     if (did_respond > 0)
     {
         char responseCode_char[4];
-        for (int i = 0; i < 3; i++)
+        for (uint8_t i = 0; i < 3; i++)
         {
             responseCode_char[i] = response_buffer[i+9];
         }

--- a/src/LoggerDreamHost.cpp
+++ b/src/LoggerDreamHost.cpp
@@ -75,7 +75,7 @@ int16_t LoggerDreamHost::postDataDreamHost(void)
 
     // Create a buffer for the response
     char response_buffer[12] = "";
-    int did_respond = 0;
+    uint16_t did_respond = 0;
 
     // Open a TCP/IP connection to DreamHost
     if(_logModem->_tinyClient->connect("swrcsensors.dreamhosters.com", 80))

--- a/src/LoggerDreamHost.h
+++ b/src/LoggerDreamHost.h
@@ -47,7 +47,7 @@ public:
     // DreamHost URL and then streams out a get request
     // over that connection.
     // The return is the http status code of the response.
-    int postDataDreamHost(void);
+    int16_t postDataDreamHost(void);
 
     // This prevents the logging function from dual-posting to EnviroDIY
     void disableDualPost(void);

--- a/src/LoggerEnviroDIY.cpp
+++ b/src/LoggerEnviroDIY.cpp
@@ -112,7 +112,7 @@ void LoggerEnviroDIY::printSensorDataJSON(Stream *stream)
 {
     stream->print(String(F("{")));
     stream->print(String(F("\"sampling_feature\": \"")));
-    stream->print(String(_samplingFeature)); + F("");
+    stream->print(String(_samplingFeature));
     stream->print(String(F("\", \"timestamp\": \"")));
     stream->print(String(formatDateTime_ISO8601(markedEpochTime)) + F("\", "));
 

--- a/src/LoggerEnviroDIY.cpp
+++ b/src/LoggerEnviroDIY.cpp
@@ -217,7 +217,7 @@ int16_t LoggerEnviroDIY::postDataEnviroDIY(void)
 
     // Create a buffer for the response
     char response_buffer[12] = "";
-    int did_respond = 0;
+    uint16_t did_respond = 0;
 
     // Open a TCP/IP connection to the Enviro DIY Data Portal (WebSDL)
     if(_logModem->_tinyClient->connect("data.envirodiy.org", 80))

--- a/src/LoggerEnviroDIY.cpp
+++ b/src/LoggerEnviroDIY.cpp
@@ -116,7 +116,7 @@ void LoggerEnviroDIY::printSensorDataJSON(Stream *stream)
     stream->print(String(F("\", \"timestamp\": \"")));
     stream->print(String(formatDateTime_ISO8601(markedEpochTime)) + F("\", "));
 
-    for (int i = 0; i < _internalArray->getVariableCount(); i++)
+    for (uint8_t i = 0; i < _internalArray->getVariableCount(); i++)
     {
         stream->print(String(F("\"")) + _internalArray->arrayOfVars[i]->getVarUUID() + String(F("\": ")) + _internalArray->arrayOfVars[i]->getValueString());
         if (i + 1 != _internalArray->getVariableCount())
@@ -135,12 +135,12 @@ void LoggerEnviroDIY::printEnviroDIYRequest(Stream *stream)
 {
     // First we need to calculate how long the json string is going to be
     // This is needed for the "Content-Length" header
-    int jsonLength = 22;  // {"sampling_feature": "
+    uint16_t jsonLength = 22;  // {"sampling_feature": "
     jsonLength += 36;  // sampling feature UUID
     jsonLength += 17;  // ", "timestamp": "
     jsonLength += 25;  // markedISO8601Time
     jsonLength += 3;  //  ",_
-    for (int i = 0; i < _internalArray->getVariableCount(); i++)
+    for (uint8_t i = 0; i < _internalArray->getVariableCount(); i++)
     {
         jsonLength += 1;  //  "
         jsonLength += 36;  // variable UUID
@@ -206,7 +206,7 @@ bool LoggerEnviroDIY::queueDataEnviroDIY(void)
 // EnviroDIY/ODM2DataSharingPortal and then streams out a post request
 // over that connection.
 // The return is the http status code of the response.
-int LoggerEnviroDIY::postDataEnviroDIY(void)
+int16_t LoggerEnviroDIY::postDataEnviroDIY(void)
 {
     // do not continue if no modem!
     if (_logModem == NULL)
@@ -250,11 +250,11 @@ int LoggerEnviroDIY::postDataEnviroDIY(void)
     else PRINTOUT(F("\n -- Unable to Establish Connection to EnviroDIY Data Portal -- "));
 
     // Process the HTTP response
-    int responseCode = 0;
+    int16_t responseCode = 0;
     if (did_respond > 0)
     {
         char responseCode_char[4];
-        for (int i = 0; i < 3; i++)
+        for (uint8_t i = 0; i < 3; i++)
         {
             responseCode_char[i] = response_buffer[i+9];
         }

--- a/src/LoggerEnviroDIY.h
+++ b/src/LoggerEnviroDIY.h
@@ -59,7 +59,7 @@ public:
     // EnviroDIY/ODM2DataSharingPortal and then streams out a post request
     // over that connection.
     // The return is the http status code of the response.
-    int postDataEnviroDIY(void);
+    int16_t postDataEnviroDIY(void);
 
     // ===================================================================== //
     // Convience functions to call several of the above functions

--- a/src/LoggerModem.cpp
+++ b/src/LoggerModem.cpp
@@ -752,6 +752,8 @@ bool loggerModem::modemSleepPowerDown(void)
 
     // Unset the activation time
     _millisSensorActivated = 0;
+    // Unset the measurement request time
+    _millisMeasurementRequested = 0;
     // Unset the status bits for sensor activation (bits 3 & 4) and measurement
     // request (bits 5 & 6)
     _sensorStatus &= 0b10000111;

--- a/src/LoggerModem.cpp
+++ b/src/LoggerModem.cpp
@@ -412,9 +412,9 @@ bool loggerModem::addSingleMeasurementResult(void)
     bool success = true;
 
     // Initialize float variable
-    int signalQual = -9999;
-    int percent = -9999;
-    int rssi = -9999;
+    int16_t signalQual = -9999;
+    int16_t percent = -9999;
+    int16_t rssi = -9999;
 
     // Check a measurement was *successfully* started (status bit 6 set)
     // Only go on to get a result if it was
@@ -669,20 +669,20 @@ void loggerModem::disconnectInternet(void)
 
 
 /***
-int loggerModem::openTCP(const char *host, uint16_t port)
+int16_t loggerModem::openTCP(const char *host, uint16_t port)
 {
     MS_MOD_DBG(F("Connecting to "), host, F("..."));
-    int ret_val = _tinyClient->connect(host, port);
+    int16_t ret_val = _tinyClient->connect(host, port);
     if (ret_val) MS_MOD_DBG(F("   ...Success!"));
     else MS_MOD_DBG(F("   ...Connection failed."));
     return ret_val;
 }
 
 
-int loggerModem::openTCP(IPAddress ip, uint16_t port)
+int16_t loggerModem::openTCP(IPAddress ip, uint16_t port)
 {
     MS_MOD_DBG(F("Connecting to "), ip, F("..."));
-    int ret_val = _tinyClient->connect(ip, port);
+    int16_t ret_val = _tinyClient->connect(ip, port);
     if (ret_val) MS_MOD_DBG(F("   ...Success!"));
     else MS_MOD_DBG(F("   ...Connection failed."));
     return ret_val;
@@ -853,11 +853,11 @@ uint32_t loggerModem::getNISTTime(void)
 }
 
 // Helper to get approximate RSSI from CSQ (assuming no noise)
-int loggerModem::getRSSIFromCSQ(int csq)
+int16_t loggerModem::getRSSIFromCSQ(int16_t csq)
 {
-    int CSQs[33]  = {  0,   1,   2,   3,   4,   5,   6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 99};
-    int RSSIs[33] = {113, 111, 109, 107, 105, 103, 101, 99, 97, 95, 93, 91, 89, 87, 85, 83, 81, 79, 77, 75, 73, 71, 69, 67, 65, 63, 61, 59, 57, 55, 53, 51, 0};
-    for (int i = 0; i < 33; i++)
+    int16_t CSQs[33]  = {  0,   1,   2,   3,   4,   5,   6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 99};
+    int16_t RSSIs[33] = {113, 111, 109, 107, 105, 103, 101, 99, 97, 95, 93, 91, 89, 87, 85, 83, 81, 79, 77, 75, 73, 71, 69, 67, 65, 63, 61, 59, 57, 55, 53, 51, 0};
+    for (uint8_t i = 0; i < 33; i++)
     {
         if (CSQs[i] == csq) return RSSIs[i];
     }
@@ -865,11 +865,11 @@ int loggerModem::getRSSIFromCSQ(int csq)
 }
 
 // Helper to get signal percent from CSQ
-int loggerModem::getPctFromCSQ(int csq)
+int16_t loggerModem::getPctFromCSQ(int16_t csq)
 {
-    int CSQs[33] = {0, 1, 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 99};
-    int PCTs[33] = {0, 3, 6, 10, 13, 16, 19, 23, 26, 29, 32, 36, 39, 42, 45, 48, 52, 55, 58, 61, 65, 68, 71, 74, 78, 81, 84, 87, 90, 94, 97, 100, 0};
-    for (int i = 0; i < 33; i++)
+    int16_t CSQs[33] = {0, 1, 2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 99};
+    int16_t PCTs[33] = {0, 3, 6, 10, 13, 16, 19, 23, 26, 29, 32, 36, 39, 42, 45, 48, 52, 55, 58, 61, 65, 68, 71, 74, 78, 81, 84, 87, 90, 94, 97, 100, 0};
+    for (uint8_t i = 0; i < 33; i++)
     {
         if (CSQs[i] == csq) return PCTs[i];
     }
@@ -877,9 +877,9 @@ int loggerModem::getPctFromCSQ(int csq)
 }
 
 // Helper to get signal percent from RSSI
-int loggerModem::getPctFromRSSI(int rssi)
+int16_t loggerModem::getPctFromRSSI(int16_t rssi)
 {
-    int pct = 1.6163*rssi + 182.61;
+    int16_t pct = 1.6163*rssi + 182.61;
     if (rssi == 0) pct = 0;
     if (rssi == (255-93)) pct = 0;  // This is a no-data-yet value from XBee
     return pct;

--- a/src/LoggerModem.h
+++ b/src/LoggerModem.h
@@ -131,16 +131,16 @@ protected:
 // These are the unique functions for the modem as an internet connected device
 // ==========================================================================//
 public:
-    int getSignalRSSI(void) {return sensorValues[RSSI_VAR_NUM];}
-    int getSignalPercent(void) {return sensorValues[PERCENT_SIGNAL_VAR_NUM];}
+    int16_t getSignalRSSI(void) {return sensorValues[RSSI_VAR_NUM];}
+    int16_t getSignalPercent(void) {return sensorValues[PERCENT_SIGNAL_VAR_NUM];}
 
     bool connectInternet(uint32_t waitTime_ms = 50000L);
     void disconnectInternet(void);
 
     // This has the same functionality as Client->connect with debugging text
-    // int openTCP(const char *host, uint16_t port);
+    // int16_t openTCP(const char *host, uint16_t port);
     // This has the same functionality as Client->connect with debugging text
-    // int openTCP(IPAddress ip, uint16_t port);
+    // int16_t openTCP(IPAddress ip, uint16_t port);
     // This has the same functionality as Client->close with debugging text
     // void closeTCP(void);
     // Special sleep and power function for the modem
@@ -159,11 +159,11 @@ public:
 
 private:
     // Helper to get approximate RSSI from CSQ (assuming no noise)
-    static int getRSSIFromCSQ(int csq);
+    static int16_t getRSSIFromCSQ(int16_t csq);
     // Helper to get signal percent from CSQ
-    static int getPctFromCSQ(int csq);
+    static int16_t getPctFromCSQ(int16_t csq);
     // Helper to get signal percent from CSQ
-    static int getPctFromRSSI(int rssi);
+    static int16_t getPctFromRSSI(int16_t rssi);
 
 private:
     bool _statusLevel;

--- a/src/ModSensorDebugger.h
+++ b/src/ModSensorDebugger.h
@@ -15,7 +15,7 @@
 #include <Arduino.h>
 
 // The current library version number
-#define MODULAR_SENSORS_VERSION "0.16.0"
+#define MODULAR_SENSORS_VERSION "0.16.1"
 
 #ifndef STANDARD_SERIAL_OUTPUT
     #if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)

--- a/src/ModSensorDebugger.h
+++ b/src/ModSensorDebugger.h
@@ -19,8 +19,8 @@
 
 #ifndef STANDARD_SERIAL_OUTPUT
     #if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)
-      #define Serial SERIAL_PORT_USBVIRTUAL
-      #define STANDARD_SERIAL_OUTPUT Serial
+      // #define Serial SERIAL_PORT_USBVIRTUAL
+      #define STANDARD_SERIAL_OUTPUT SERIAL_PORT_USBVIRTUAL
     #elif defined __AVR__
       #define STANDARD_SERIAL_OUTPUT Serial
     #endif
@@ -58,6 +58,19 @@
 #else
     #define MS_DBG(...)
 #endif  // DEBUGGING_SERIAL_OUTPUT
+
+
+/***
+#if defined(__AVR__)
+  typedef const __FlashStringHelper* GsmConstStr;
+  #define GFP(x) (reinterpret_cast<GsmConstStr>(x))
+  #define GF(x)  F(x)
+#else
+  typedef const char* GsmConstStr;
+  #define GFP(x) x
+  #define GF(x)  x
+#endif
+***/
 
 
 #endif  // ModSensorDebugger_h

--- a/src/SensorBase.cpp
+++ b/src/SensorBase.cpp
@@ -428,14 +428,14 @@ bool Sensor::update(void)
 // This is a helper function to check if the power needs to be turned on
 bool Sensor::checkPowerOn(bool debug)
 {
-    if (debug) MS_DBG(F("Checking power status:  Power to "), getSensorNameAndLocation());
+    if (debug) {MS_DBG(F("Checking power status:  Power to "), getSensorNameAndLocation());}
     if (_powerPin >= 0)
     {
         int8_t powerBitNumber = log(digitalPinToBitMask(_powerPin))/log(2);
 
         if (bitRead(*portInputRegister(digitalPinToPort(_powerPin)), powerBitNumber) == LOW)
         {
-            if (debug) MS_DBG(F(" was off."));
+            if (debug) {MS_DBG(F(" was off."));}
             // Reset time of power on, in-case it was set to a value
             if (_millisPowerOn != 0) _millisPowerOn = 0;
             // Unset the status bits for sensor power (bits 1 & 2),
@@ -445,7 +445,7 @@ bool Sensor::checkPowerOn(bool debug)
         }
         else
         {
-            if (debug) MS_DBG((" was on."));
+            if (debug) {MS_DBG((" was on."));}
             // Mark the power-on time, just in case it  had not been marked
             if (_millisPowerOn == 0) _millisPowerOn = millis();
             // Set the status bit for sensor power attempt (bit 1) and success (bit 2)
@@ -455,7 +455,7 @@ bool Sensor::checkPowerOn(bool debug)
     }
     else
     {
-        if (debug) MS_DBG(F(" is not controlled by this library."));
+        if (debug) {MS_DBG(F(" is not controlled by this library."));}
         // Mark the power-on time, just in case it  had not been marked
         if (_millisPowerOn == 0) _millisPowerOn = millis();
         // Set the status bit for sensor power attempt (bit 1) and success (bit 2)
@@ -472,7 +472,7 @@ bool Sensor::isWarmedUp(bool debug)
     // so the warm up time is essentially already passed.
     if (!bitRead(_sensorStatus, 2))
     {
-        if (debug) MS_DBG(getSensorNameAndLocation(), F(" does not have power and cannot warm up!"));
+        if (debug) {MS_DBG(getSensorNameAndLocation(), F(" does not have power and cannot warm up!"));}
         return true;
     }
 
@@ -480,8 +480,8 @@ bool Sensor::isWarmedUp(bool debug)
     // If the sensor has power and enough time has elapsed, it's warmed up
     if (elapsed_since_power_on > _warmUpTime_ms)
     {
-        if (debug) MS_DBG(F("It's been "), (elapsed_since_power_on), F("ms, and "),
-              getSensorNameAndLocation(), F(" should be warmed up!"));
+        if (debug) {MS_DBG(F("It's been "), (elapsed_since_power_on), F("ms, and "),
+              getSensorNameAndLocation(), F(" should be warmed up!"));}
         return true;
     }
     // If the sensor has power but the time hasn't passed, we still need to wait
@@ -501,7 +501,8 @@ bool Sensor::isStable(bool debug)
     // stabilization time is essentially already passed
     if (!bitRead(_sensorStatus, 4))
     {
-        if (debug) MS_DBG(getSensorNameAndLocation(), F(" is not active and cannot stabilize!"));
+        if (debug) {MS_DBG(getSensorNameAndLocation(),
+            F(" is not active and cannot stabilize!"));}
         return true;
     }
 
@@ -509,8 +510,8 @@ bool Sensor::isStable(bool debug)
     // If the sensor has been activated and enough time has elapsed, it's stable
     if (elapsed_since_wake_up > _stabilizationTime_ms)
     {
-        if (debug) MS_DBG(F("It's been "), (elapsed_since_wake_up), F("ms, and "),
-               getSensorNameAndLocation(), F(" should be stable!"));
+        if (debug) {MS_DBG(F("It's been "), (elapsed_since_wake_up), F("ms, and "),
+            getSensorNameAndLocation(), F(" should be stable!"));}
         return true;
     }
     // If the sensor has been activated but the time hasn't passed, we still need to wait
@@ -530,7 +531,8 @@ bool Sensor::isMeasurementComplete(bool debug)
     // so the measurement time is essentially already passed
     if (!bitRead(_sensorStatus, 6))
     {
-        if (debug) MS_DBG(getSensorNameAndLocation(), F(" is not measuring and will not return a value!"));
+        if (debug) {MS_DBG(getSensorNameAndLocation(),
+            F(" is not measuring and will not return a value!"));}
         return true;
     }
 
@@ -538,9 +540,9 @@ bool Sensor::isMeasurementComplete(bool debug)
     // If the sensor is measuring and enough time has elapsed, the reading is finished
     if (elapsed_since_meas_start > _measurementTime_ms)
     {
-        if (debug) MS_DBG(F("It's been "), (elapsed_since_meas_start),
+        if (debug) {MS_DBG(F("It's been "), (elapsed_since_meas_start),
                           F("ms, and measurement by "), getSensorNameAndLocation(),
-                          F(" should be complete!"));
+                          F(" should be complete!"));}
         return true;
     }
     // If the sensor is measuring but the time hasn't passed, we still need to wait

--- a/src/SensorBase.cpp
+++ b/src/SensorBase.cpp
@@ -146,6 +146,10 @@ void Sensor::powerDown(void)
         digitalWrite(_powerPin, LOW);
         // Unset the power-on time
         _millisPowerOn = 0;
+        // Unset the activation time
+        _millisSensorActivated = 0;
+        // Unset the measurement request time
+        _millisMeasurementRequested = 0;
         // Unset the status bits for sensor power (bits 1 & 2),
         // activation (bits 3 & 4), and measurement request (bits 5 & 6)
         _sensorStatus &= 0b10000001;
@@ -227,6 +231,8 @@ bool Sensor::sleep(void)
     MS_DBG(F("Putting "), getSensorNameAndLocation(), F(" to sleep"));
     // Unset the activation time
     _millisSensorActivated = 0;
+    // Unset the measurement request time
+    _millisMeasurementRequested = 0;
     // Unset the status bits for sensor activation (bits 3 & 4) and measurement
     // request (bits 5 & 6)
     _sensorStatus &= 0b10000111;

--- a/src/SensorBase.cpp
+++ b/src/SensorBase.cpp
@@ -351,14 +351,6 @@ void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, int16_t resultV
     float float_val = resultValue;  // cast the int16_t to a float
     verifyAndAddMeasurementResult(resultNumber, float_val);
 }
-void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, uint32_t resultValue)
-{
-    MS_DBG(F("Adding "), resultValue, F(" to result array for variable "),
-           resultNumber, F(" from "), getSensorNameAndLocation(),
-           F(" without verification."));
-    sensorValues[resultNumber] +=  resultValue;
-    numberGoodMeasurementsMade[resultNumber] += 1;
-}
 
 
 void Sensor::averageMeasurements(void)

--- a/src/SensorBase.cpp
+++ b/src/SensorBase.cpp
@@ -315,7 +315,7 @@ void Sensor::clearValues(void)
 
 
 // This verifies that a measurement is good before adding it to the values to be averaged
-void Sensor::verifyAndAddMeasurementResult(int resultNumber, float resultValue)
+void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, float resultValue)
 {
     // If the new result is good and there was were only bad results, set the
     // result value as the new result and add 1 to the good result total
@@ -346,10 +346,18 @@ void Sensor::verifyAndAddMeasurementResult(int resultNumber, float resultValue)
                resultNumber, F(" from "), getSensorNameAndLocation(),
                F("; good results already in array."));
 }
-void Sensor::verifyAndAddMeasurementResult(int resultNumber, int resultValue)
+void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, int16_t resultValue)
 {
     float float_val = resultValue;
     verifyAndAddMeasurementResult(resultNumber, float_val);
+}
+void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, uint32_t resultValue)
+{
+    MS_DBG(F("Adding "), resultValue, F(" to result array for variable "),
+           resultNumber, F(" from "), getSensorNameAndLocation(),
+           F(" without verification."));
+    sensorValues[resultNumber] +=  resultValue;
+    numberGoodMeasurementsMade[resultNumber] += 1;
 }
 
 

--- a/src/SensorBase.cpp
+++ b/src/SensorBase.cpp
@@ -94,7 +94,7 @@ void Sensor::setNumberMeasurementsToAverage(int nReadings)
 {
     _measurementsToAverage = nReadings;
 }
-int Sensor::getNumberMeasurementsToAverage(void){return _measurementsToAverage;}
+uint8_t Sensor::getNumberMeasurementsToAverage(void){return _measurementsToAverage;}
 
 
 // This returns the 8-bit code for the current status of the sensor.
@@ -287,7 +287,7 @@ void Sensor::notifyVariables(void)
            F(" of value update."));
 
     // Notify variables of update
-    for (int i = 0; i < _numReturnedVars; i++)
+    for (uint8_t i = 0; i < _numReturnedVars; i++)
     {
         if (variables[i] != NULL)  // Bad things happen if try to update nullptr
         {
@@ -306,7 +306,7 @@ void Sensor::notifyVariables(void)
 void Sensor::clearValues(void)
 {
     MS_DBG(F("Clearing value array for "), getSensorNameAndLocation());
-    for (int i = 0; i < _numReturnedVars; i++)
+    for (uint8_t i = 0; i < _numReturnedVars; i++)
     {
         sensorValues[i] =  -9999;
         numberGoodMeasurementsMade[i] = 0;
@@ -348,7 +348,7 @@ void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, float resultVal
 }
 void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, int16_t resultValue)
 {
-    float float_val = resultValue;
+    float float_val = resultValue;  // cast the int16_t to a float
     verifyAndAddMeasurementResult(resultNumber, float_val);
 }
 void Sensor::verifyAndAddMeasurementResult(uint8_t resultNumber, uint32_t resultValue)
@@ -365,7 +365,7 @@ void Sensor::averageMeasurements(void)
 {
     MS_DBG(F("Averaging results from "), getSensorNameAndLocation(),
            F(" over "), _measurementsToAverage, F(" reading[s]"));
-    for (int i = 0; i < _numReturnedVars; i++)
+    for (uint8_t i = 0; i < _numReturnedVars; i++)
     {
         if (numberGoodMeasurementsMade[i] > 0)
             sensorValues[i] /=  numberGoodMeasurementsMade[i];
@@ -402,7 +402,7 @@ bool Sensor::update(void)
     waitForStability();
 
     // loop through as many measurements as requested
-    for (int j = 0; j < _measurementsToAverage; j++)
+    for (uint8_t j = 0; j < _measurementsToAverage; j++)
     {
         // start a measurement
         ret_val += startSingleMeasurement();
@@ -433,7 +433,7 @@ bool Sensor::checkPowerOn(bool debug)
     if (debug) MS_DBG(F("Checking power status:  Power to "), getSensorNameAndLocation());
     if (_powerPin >= 0)
     {
-        int powerBitNumber = log(digitalPinToBitMask(_powerPin))/log(2);
+        int8_t powerBitNumber = log(digitalPinToBitMask(_powerPin))/log(2);
 
         if (bitRead(*portInputRegister(digitalPinToPort(_powerPin)), powerBitNumber) == LOW)
         {

--- a/src/SensorBase.h
+++ b/src/SensorBase.h
@@ -47,7 +47,7 @@ public:
     // These functions get and set the number of readings to average for a sensor
     // Generally these values should be set in the constructor
     void setNumberMeasurementsToAverage(int nReadings);
-    int getNumberMeasurementsToAverage(void);
+    uint8_t getNumberMeasurementsToAverage(void);
 
     // This returns the 8-bit code for the current status of the sensor.
     // Bit 0 - 0=Has NOT been successfully set up, 1=Has been setup

--- a/src/SensorBase.h
+++ b/src/SensorBase.h
@@ -119,8 +119,11 @@ public:
     // Clears the values array
     void clearValues();
     // This verifies that a measurement is OK (ie, not -9999) before adding it to the array
-    void verifyAndAddMeasurementResult(int resultNumber, float resultValue);
-    void verifyAndAddMeasurementResult(int resultNumber, int resultValue);
+    void verifyAndAddMeasurementResult(uint8_t resultNumber, float resultValue);
+    void verifyAndAddMeasurementResult(uint8_t resultNumber, int16_t resultValue);
+    // NOTE:  for an uint32_t result, there is NO ERROR VERIFICATION
+    // That is, -9999 is accepted and averaged as a real value of 4294957297.
+    void verifyAndAddMeasurementResult(uint8_t resultNumber, uint32_t resultValue);
     void averageMeasurements(void);
 
     // These tie the variables to their parent sensor

--- a/src/SensorBase.h
+++ b/src/SensorBase.h
@@ -121,9 +121,6 @@ public:
     // This verifies that a measurement is OK (ie, not -9999) before adding it to the array
     void verifyAndAddMeasurementResult(uint8_t resultNumber, float resultValue);
     void verifyAndAddMeasurementResult(uint8_t resultNumber, int16_t resultValue);
-    // NOTE:  for an uint32_t result, there is NO ERROR VERIFICATION
-    // That is, -9999 is accepted and averaged as a real value of 4294957297.
-    void verifyAndAddMeasurementResult(uint8_t resultNumber, uint32_t resultValue);
     void averageMeasurements(void);
 
     // These tie the variables to their parent sensor

--- a/src/VariableArray.cpp
+++ b/src/VariableArray.cpp
@@ -11,7 +11,7 @@
 
 
 // Constructor
-VariableArray::VariableArray(int variableCount, Variable *variableList[])
+VariableArray::VariableArray(uint8_t variableCount, Variable *variableList[])
 {
     _variableCount = variableCount;
     arrayOfVars = variableList;
@@ -24,11 +24,11 @@ VariableArray::~VariableArray(){}
 
 
 // This counts and returns the number of calculated variables
-int VariableArray::getCalculatedVariableCount(void)
+uint8_t VariableArray::getCalculatedVariableCount(void)
 {
-    int numCalc = 0;
+    uint8_t numCalc = 0;
     // Check for unique sensors
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (arrayOfVars[i]->isCalculated) numCalc++;
     }
@@ -38,11 +38,11 @@ int VariableArray::getCalculatedVariableCount(void)
 
 
 // This counts and returns the number of sensors
-int VariableArray::getSensorCount(void)
+uint8_t VariableArray::getSensorCount(void)
 {
-    int numSensors = 0;
+    uint8_t numSensors = 0;
     // Check for unique sensors
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) numSensors++;
     }
@@ -82,7 +82,7 @@ bool VariableArray::setupSensors(void)
 
     // Check for any sensors that have been set up outside of this (ie, the modem)
     uint8_t nSensorsSetup = 0;
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -102,7 +102,7 @@ bool VariableArray::setupSensors(void)
     // We keep looping until they've all been done.
     while (nSensorsSetup < _sensorCount)
     {
-        for (int i = 0; i < _variableCount; i++)
+        for (uint8_t i = 0; i < _variableCount; i++)
         {
             bool sensorSuccess = false;
             if (isLastVarFromSensor(i)) // Skip non-unique sensors
@@ -131,7 +131,7 @@ bool VariableArray::setupSensors(void)
 
     // Now attach all of the variables to their parents
     // MS_DBG(F("Attaching variables to their parent sensors."));
-    // for (int i = 0; i < _variableCount; i++){
+    // for (uint8_t i = 0; i < _variableCount; i++){
     //     success &= arrayOfVars[i]->setup();
     // }
 
@@ -148,7 +148,7 @@ bool VariableArray::setupSensors(void)
 void VariableArray::sensorsPowerUp(void)
 {
     MS_DBG(F("Powering up sensors..."));
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -171,7 +171,7 @@ bool VariableArray::sensorsWake(void)
     uint8_t nSensorsAwake = 0;
 
     // Check for any sensors that are awake outside of being sent a "wake" command
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -189,7 +189,7 @@ bool VariableArray::sensorsWake(void)
     // We keep looping until they've all been done.
     while (nSensorsAwake < _sensorCount)
     {
-        for (int i = 0; i < _variableCount; i++)
+        for (uint8_t i = 0; i < _variableCount; i++)
         {
             if (isLastVarFromSensor(i)) // Skip non-unique sensors
             {
@@ -227,7 +227,7 @@ bool VariableArray::sensorsSleep(void)
 {
     MS_DBG(F("Putting sensors to sleep..."));
     bool success = true;
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -251,7 +251,7 @@ bool VariableArray::sensorsSleep(void)
 void VariableArray::sensorsPowerDown(void)
 {
     MS_DBG(F("Powering down sensors..."));
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -291,7 +291,7 @@ bool VariableArray::updateAllSensors(void)
 
     // Check for any sensors that didn't wake up and mark them as "complete" so
     // they will be skipped in further looping.
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {
@@ -705,7 +705,7 @@ bool VariableArray::completeUpdate(void)
 // Calculated variable results will be included
 void VariableArray::printSensorData(Stream *stream)
 {
-    for (int i = 0; i < _variableCount; i++)
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (arrayOfVars[i]->isCalculated)
         {
@@ -777,8 +777,8 @@ bool VariableArray::isLastVarFromSensor(int arrayIndex)
 // requested averaging
 uint8_t VariableArray::countMaxToAverage(void)
 {
-    int numReps = 0;
-    for (int i = 0; i < _variableCount; i++)
+    uint8_t numReps = 0;
+    for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (isLastVarFromSensor(i)) // Skip non-unique sensors
         {

--- a/src/VariableArray.cpp
+++ b/src/VariableArray.cpp
@@ -177,7 +177,8 @@ bool VariableArray::sensorsWake(void)
         {
             if (bitRead(arrayOfVars[i]->parentSensor->getStatus(), 3) == 1)  // already awake
             {
-                MS_DBG(arrayOfVars[i]->getParentSensorNameAndLocation(), F(" was already awake."));
+                MS_DBG(F("   ... Wake up of "), arrayOfVars[i]->getParentSensorNameAndLocation(),
+                       F(" has already been attempted."));
                 nSensorsAwake++;
             }
         }
@@ -378,8 +379,8 @@ bool VariableArray::updateAllSensors(void)
                         success &= sensorSuccess_result;
                         nMeasurementsCompleted[i] += 1;  // increment the number of measurements that sensor has completed
 
-                        if (sensorSuccess_result) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i], '\n');
-                        else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i], '\n');
+                        if (sensorSuccess_result) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]);
+                        else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]);
                     }
 
                 }
@@ -671,20 +672,20 @@ bool VariableArray::completeUpdate(void)
                                 arrayOfVars[i]->getParentSensorNameAndLocation());
 
                                 arrayOfVars[k]->parentSensor->powerDown();
-                                MS_DBG(F("   ... Complete. <<--- "), k, '\n');
+                                MS_DBG(F("   ... Complete. <<--- "), k);
                             }
                         }
                     }
 
                     nSensorsCompleted++;  // mark the whole sensor as done
-                    MS_DBG(F("*****--- "), nSensorsCompleted, F(" sensors now complete ---*****\n"));
+                    MS_DBG(F("*****--- "), nSensorsCompleted, F(" sensors now complete ---*****"));
                 }
             }
         }
     }
 
     // Average measurements and notify varibles of the updates
-    MS_DBG(F("----->> Averaging results and notifying all variables. ...\n"));
+    MS_DBG(F("----->> Averaging results and notifying all variables. ..."));
     for (uint8_t i = 0; i < _variableCount; i++)
     {
         if (lastSensorVariable[i])

--- a/src/VariableArray.cpp
+++ b/src/VariableArray.cpp
@@ -32,7 +32,7 @@ uint8_t VariableArray::getCalculatedVariableCount(void)
     {
         if (arrayOfVars[i]->isCalculated) numCalc++;
     }
-    MS_DBG(F("There are "), numCalc, F(" calculated variables in the group."));
+    // MS_DBG(F("There are "), numCalc, F(" calculated variables in the group."));
     return numCalc;
 }
 
@@ -46,7 +46,7 @@ uint8_t VariableArray::getSensorCount(void)
     {
         if (isLastVarFromSensor(i)) numSensors++;
     }
-    MS_DBG(F("There are "), numSensors, F(" unique sensors in the group."));
+    // MS_DBG(F("There are "), numSensors, F(" unique sensors in the group."));
     return numSensors;
 }
 
@@ -118,8 +118,8 @@ bool VariableArray::setupSensors(void)
                         success &= sensorSuccess;
                         nSensorsSetup++;
 
-                        if (!sensorSuccess) MS_DBG(F("        ... failed!"));
-                        else MS_DBG(F("        ... succeeded."));
+                        if (!sensorSuccess) {MS_DBG(F("        ... failed!"));}
+                        else {MS_DBG(F("        ... succeeded."));}
                     }
                 }
             }
@@ -129,13 +129,7 @@ bool VariableArray::setupSensors(void)
     // Power down all sensor;
     // sensorsPowerDown();
 
-    // Now attach all of the variables to their parents
-    // MS_DBG(F("Attaching variables to their parent sensors."));
-    // for (uint8_t i = 0; i < _variableCount; i++){
-    //     success &= arrayOfVars[i]->setup();
-    // }
-
-    if (success) MS_DBG(F("... Success!"));
+    if (success) {MS_DBG(F("... Success!"));}
 
     return success;
 }
@@ -208,8 +202,8 @@ bool VariableArray::sensorsWake(void)
                         // if the wake up command failed!
                         nSensorsAwake++;
 
-                        if (sensorSuccess) MS_DBG(F("        ... succeeded."));
-                        else MS_DBG(F("        ... failed!"));
+                        if (sensorSuccess) {MS_DBG(F("        ... succeeded."));}
+                        else {MS_DBG(F("        ... failed!"));}
                     }
                 }
             }
@@ -238,8 +232,8 @@ bool VariableArray::sensorsSleep(void)
             bool sensorSuccess = arrayOfVars[i]->parentSensor->sleep();
             success &= sensorSuccess;
 
-            if (sensorSuccess) MS_DBG(F("        ... successfully put to sleep."));
-            else MS_DBG(F("        ... failed to sleep!"));
+            if (sensorSuccess) {MS_DBG(F("        ... successfully put to sleep."));}
+            else {MS_DBG(F("        ... failed to sleep!"));}
         }
     }
     return success;
@@ -359,8 +353,8 @@ bool VariableArray::updateAllSensors(void)
                             bool sensorSuccess_start = arrayOfVars[i]->parentSensor->startSingleMeasurement();
                             success &= sensorSuccess_start;
 
-                            if (sensorSuccess_start) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]+1);
-                            else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]+1);
+                            if (sensorSuccess_start) {MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]+1);}
+                            else {MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]+1);}
                     }
 
                     // otherwise, it is currently measuring so...
@@ -380,8 +374,8 @@ bool VariableArray::updateAllSensors(void)
                         success &= sensorSuccess_result;
                         nMeasurementsCompleted[i] += 1;  // increment the number of measurements that sensor has completed
 
-                        if (sensorSuccess_result) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]);
-                        else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]);
+                        if (sensorSuccess_result) {MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]);}
+                        else {MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]);}
                     }
 
                 }
@@ -584,8 +578,8 @@ bool VariableArray::completeUpdate(void)
                         bool sensorSuccess_wake = arrayOfVars[i]->parentSensor->wake();
                         success &= sensorSuccess_wake;
 
-                        if (sensorSuccess_wake) MS_DBG(F("   ... Success. <<--- "), i);
-                        else MS_DBG(F("   ... Failed! <<--- "), i);
+                        if (sensorSuccess_wake) {MS_DBG(F("   ... Success. <<--- "), i);}
+                        else {MS_DBG(F("   ... Failed! <<--- "), i);}
                     }
                 }
 
@@ -620,8 +614,8 @@ bool VariableArray::completeUpdate(void)
                             bool sensorSuccess_start = arrayOfVars[i]->parentSensor->startSingleMeasurement();
                             success &= sensorSuccess_start;
 
-                            if (sensorSuccess_start) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]+1);
-                            else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]+1);
+                            if (sensorSuccess_start) {MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]+1);}
+                            else {MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]+1);}
                     }
 
                     // If a measurement is finished, get the result and tick up
@@ -643,8 +637,8 @@ bool VariableArray::completeUpdate(void)
                         nMeasurementsCompleted[i] += 1;  // increment the number of measurements that sensor has completed
                         nCompletedOnPin[powerPinIndex[i]] += 1;  // increment the number of measurements that the power pin has completed
 
-                        if (sensorSuccess_result) MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]);
-                        else MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]);
+                        if (sensorSuccess_result) {MS_DBG(F("   ... Success. <<--- "), i, '.', nMeasurementsCompleted[i]);}
+                        else {MS_DBG(F("   ... Failed! <<--- "), i, '.', nMeasurementsCompleted[i]);}
                     }
 
                 }
@@ -660,8 +654,8 @@ bool VariableArray::completeUpdate(void)
                     bool sensorSuccess_sleep = arrayOfVars[i]->parentSensor->sleep();
                     success &= sensorSuccess_sleep;
 
-                    if (sensorSuccess_sleep) MS_DBG(F("   ... Success. <<--- "), i);
-                    else MS_DBG(F("   ... Failed! <<--- "), i);
+                    if (sensorSuccess_sleep) {MS_DBG(F("   ... Success. <<--- "), i);}
+                    else {MS_DBG(F("   ... Failed! <<--- "), i);}
 
                     // Now cut the power, if ready, to this sensors and all that share the pin
                     if (nCompletedOnPin[powerPinIndex[i]] == nMeasurementsOnPin[powerPinIndex[i]])
@@ -691,9 +685,11 @@ bool VariableArray::completeUpdate(void)
     {
         if (lastSensorVariable[i])
         {
-            // MS_DBG(F("--- Averaging results from "), arrayOfVars[i]->getParentSensorNameAndLocation(), F(" ---"));
+            MS_DBG(F("--- Averaging results from "),
+                   arrayOfVars[i]->getParentSensorNameAndLocation(), F(" ---"));
             arrayOfVars[i]->parentSensor->averageMeasurements();
-            // MS_DBG(F("--- Notifying variables from "), arrayOfVars[i]->getParentSensorNameAndLocation(), F(" ---"));
+            MS_DBG(F("--- Notifying variables from "),
+                   arrayOfVars[i]->getParentSensorNameAndLocation(), F(" ---"));
             arrayOfVars[i]->parentSensor->notifyVariables();
         }
     }
@@ -745,8 +741,8 @@ void VariableArray::printSensorData(Stream *stream)
 // Check for unique sensors
 bool VariableArray::isLastVarFromSensor(int arrayIndex)
 {
-    // MS_DBG(F("Checking if "), arrayOfVars[arrayIndex]->getVarName(), F(" ("),
-    //        arrayIndex, F(") is the last variable from a sensor..."));
+    /*MS_DBG(F("Checking if "), arrayOfVars[arrayIndex]->getVarName(), F(" ("),
+           arrayIndex, F(") is the last variable from a sensor..."));*/
 
     // Calculated variables are never the last variable from a sensor, simply
     // because the don't come from a sensor at all.
@@ -787,6 +783,6 @@ uint8_t VariableArray::countMaxToAverage(void)
             numReps = max(numReps, arrayOfVars[i]->parentSensor->getNumberMeasurementsToAverage());
         }
     }
-    MS_DBG(F("The largest number of measurements to average will be "), numReps);
+    // MS_DBG(F("The largest number of measurements to average will be "), numReps);
     return numReps;
 }

--- a/src/VariableArray.h
+++ b/src/VariableArray.h
@@ -79,13 +79,13 @@ private:
     template<typename T>
     void prettyPrintArray(T arrayToPrint[])
     {
-        MS_DBG('[');
+        DEBUGGING_SERIAL_OUTPUT.print("[,\t");
         for (uint8_t i = 0; i < _variableCount; i++)
         {
-            MS_DBG(arrayToPrint[i]);
-            if ( (i+1) < _variableCount ) MS_DBG(',', '\t');
+            DEBUGGING_SERIAL_OUTPUT.print(arrayToPrint[i]);
+            DEBUGGING_SERIAL_OUTPUT.print(",\t");
         }
-        MS_DBG(']', '\n');
+        DEBUGGING_SERIAL_OUTPUT.println("]");
     }
 #else
     #define prettyPrintArray(...)

--- a/src/VariableArray.h
+++ b/src/VariableArray.h
@@ -12,7 +12,7 @@
 #define VariableArray_h
 
 // Debugging Statement
-// #define DEBUGGING_SERIAL_OUTPUT Serial
+#define DEBUGGING_SERIAL_OUTPUT Serial
 
 // Included Dependencies
 #include "ModSensorDebugger.h"

--- a/src/VariableArray.h
+++ b/src/VariableArray.h
@@ -24,7 +24,7 @@ class VariableArray
 {
 public:
     // Constructor
-    VariableArray(int variableCount, Variable *variableList[]);
+    VariableArray(uint8_t variableCount, Variable *variableList[]);
     virtual ~VariableArray();
 
     // Leave the internal variable list public
@@ -33,13 +33,13 @@ public:
     // Functions to return information about the list
 
     // This just returns the number of variables (as input in the constructor)
-    int getVariableCount(void){return _variableCount;}
+    uint8_t getVariableCount(void){return _variableCount;}
 
     // This counts and returns the number of calculated variables
-    int getCalculatedVariableCount(void);
+    uint8_t getCalculatedVariableCount(void);
 
     // This counts and returns the number of sensors
-    int getSensorCount(void);
+    uint8_t getSensorCount(void);
 
     // Public functions for interfacing with a list of sensors
     // This sets up all of the sensors in the list

--- a/src/VariableBase.cpp
+++ b/src/VariableBase.cpp
@@ -18,9 +18,9 @@ const char* Variable::VAR_BASE_UNKNOWN = "Unknown";
 
 // The constructor for a measured variable - that is, one whose values are
 // updated by a sensor.
-Variable::Variable(Sensor *parentSense, int varNum,
+Variable::Variable(Sensor *parentSense, uint8_t varNum,
                    const char *varName, const char *varUnit,
-                   unsigned int decimalResolution,
+                   uint8_t decimalResolution,
                    const char *defaultVarCode,
                    const char *UUID, const char *customVarCode)
 {
@@ -48,7 +48,7 @@ Variable::Variable(Sensor *parentSense, int varNum,
 // NOTE:  ALL arguments are required!
 Variable::Variable(float (*calcFxn)(),
                    const char *varName, const char *varUnit,
-                   unsigned int decimalResolution,
+                   uint8_t decimalResolution,
                    const char *UUID, const char *customVarCode)
 {
     isCalculated = true;
@@ -165,7 +165,7 @@ String Variable::getValueString(bool updateValue)
     // Need this because otherwise get extra spaces in strings from int
     if (_decimalResolution == 0)
     {
-        int val = int(getValue(updateValue));
+        int16_t val = int(getValue(updateValue));
         return String(val);
     }
     else

--- a/src/VariableBase.h
+++ b/src/VariableBase.h
@@ -25,9 +25,9 @@ class Variable
 public:
     // The constructor for a measured variable - that is, one whose values are
     // updated by a sensor.
-    Variable(Sensor *parentSense, int varNum,
+    Variable(Sensor *parentSense, uint8_t varNum,
              const char *varName = VAR_BASE_UNKNOWN, const char *varUnit = VAR_BASE_UNKNOWN,
-             unsigned int decimalResolution = 0,
+             uint8_t decimalResolution = 0,
              const char *defaultVarCode = VAR_BASE_UNKNOWN,
              const char *UUID = "", const char *customVarCode = "");
 
@@ -36,7 +36,7 @@ public:
      // NOTE:  ALL arguments are required!
      Variable(float (*calcFxn)(),
               const char *varName, const char *varUnit,
-              unsigned int decimalResolution,
+              uint8_t decimalResolution,
               const char *UUID, const char *customVarCode);
 
     // Destructor
@@ -85,7 +85,7 @@ private:
     uint8_t _varNum;
     const char *_varName;
     const char *_varUnit;
-    unsigned int _decimalResolution;
+    uint8_t _decimalResolution;
     const char *_defaultVarCode;
     const char *_customCode;
     const char *_UUID;

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -42,7 +42,8 @@
 #include "SensorBase.h"
 
 // Sensor Specific Defines
-#define ADS1115_ADDRESS (0x48) // 1001 000 (ADDR = GND)
+#define ADS1115_ADDRESS 0x48
+// 1001 000 (ADDR = GND)
 
 #define SQ212_NUM_VARIABLES 1
 // Using the warm-up time of the ADS1115

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -38,7 +38,8 @@
 #include "SensorBase.h"
 
 // Sensor Specific Defines
-#define ADS1115_ADDRESS (0x48) // 1001 000 (ADDR = GND)
+#define ADS1115_ADDRESS 0x48
+// 1001 000 (ADDR = GND)
 
 // low and high range are treated as completely independent, so only 2 "variables"
 // One for the raw voltage and another for the calibrated turbidity.

--- a/src/sensors/ExternalVoltage.h
+++ b/src/sensors/ExternalVoltage.h
@@ -47,7 +47,8 @@
 #include "SensorBase.h"
 
 // Sensor Specific Defines
-#define ADS1115_ADDRESS (0x48) // 1001 000 (ADDR = GND)
+#define ADS1115_ADDRESS 0x48
+// 1001 000 (ADDR = GND)
 
 #define EXT_VOLT_NUM_VARIABLES 1
 // Using the warm-up time of the ADS1115

--- a/src/sensors/KellerParent.cpp
+++ b/src/sensors/KellerParent.cpp
@@ -115,6 +115,10 @@ void KellerParent::powerDown(void)
         digitalWrite(_powerPin, LOW);
         // Unset the power-on time
         _millisPowerOn = 0;
+        // Unset the activation time
+        _millisSensorActivated = 0;
+        // Unset the measurement request time
+        _millisMeasurementRequested = 0;
         // Unset the status bits for sensor power (bits 1 & 2),
         // activation (bits 3 & 4), and measurement request (bits 5 & 6)
         _sensorStatus &= 0b10000001;

--- a/src/sensors/KellerParent.cpp
+++ b/src/sensors/KellerParent.cpp
@@ -20,7 +20,7 @@
 // The constructor - need the sensor type, modbus address, power pin, stream for data, and number of readings to average
 KellerParent::KellerParent(byte modbusAddress, Stream* stream,
                int8_t powerPin, int8_t powerPin2, int8_t enablePin, uint8_t measurementsToAverage,
-               kellerModel model, const char *sensName, int numVariables,
+               kellerModel model, const char *sensName, uint8_t numVariables,
                uint32_t warmUpTime_ms, uint32_t stabilizationTime_ms, uint32_t measurementTime_ms)
     : Sensor(sensName, numVariables,
              warmUpTime_ms, stabilizationTime_ms, measurementTime_ms,
@@ -34,7 +34,7 @@ KellerParent::KellerParent(byte modbusAddress, Stream* stream,
 }
 KellerParent::KellerParent(byte modbusAddress, Stream& stream,
                int8_t powerPin, int8_t powerPin2, int8_t enablePin, uint8_t measurementsToAverage,
-               kellerModel model, const char *sensName, int numVariables,
+               kellerModel model, const char *sensName, uint8_t numVariables,
                uint32_t warmUpTime_ms, uint32_t stabilizationTime_ms, uint32_t measurementTime_ms)
     : Sensor(sensName, numVariables,
              warmUpTime_ms, stabilizationTime_ms, measurementTime_ms,

--- a/src/sensors/KellerParent.h
+++ b/src/sensors/KellerParent.h
@@ -40,11 +40,11 @@ class KellerParent : public Sensor
 public:
     KellerParent(byte modbusAddress, Stream* stream,
              int8_t powerPin, int8_t powerPin2, int8_t enablePin = -1, uint8_t measurementsToAverage = 1,
-             kellerModel model = OTHER, const char *sensName = "Keller-Sensor", int numVariables = 3,
+             kellerModel model = OTHER, const char *sensName = "Keller-Sensor", uint8_t numVariables = 3,
              uint32_t warmUpTime_ms = 500, uint32_t stabilizationTime_ms = 5000, uint32_t measurementTime_ms = 1500);
     KellerParent(byte modbusAddress, Stream& stream,
              int8_t powerPin, int8_t powerPin2, int8_t enablePin = -1, uint8_t measurementsToAverage = 1,
-             kellerModel model = OTHER, const char *sensName = "Keller-Sensor", int numVariables = 3,
+             kellerModel model = OTHER, const char *sensName = "Keller-Sensor", uint8_t numVariables = 3,
              uint32_t warmUpTime_ms = 500, uint32_t stabilizationTime_ms = 5000, uint32_t measurementTime_ms = 1500);
     virtual ~KellerParent();
 
@@ -63,7 +63,7 @@ private:
     kellerModel _model;
     byte _modbusAddress;
     Stream* _stream;
-    int _RS485EnablePin;
+    int8_t _RS485EnablePin;
     int8_t _powerPin2;
 };
 

--- a/src/sensors/MaxBotixSonar.cpp
+++ b/src/sensors/MaxBotixSonar.cpp
@@ -107,7 +107,7 @@ bool MaxBotixSonar::addSingleMeasurementResult(void)
     // Initialize values
     bool success = false;
     int rangeAttempts = 0;
-    int result = -9999;
+    int16_t result = -9999;
 
     // Clear anything out of the stream buffer
     int junkChars = _stream->available();

--- a/src/sensors/MaxBotixSonar.cpp
+++ b/src/sensors/MaxBotixSonar.cpp
@@ -90,7 +90,7 @@ bool MaxBotixSonar::wake(void)
         MS_DBG(i, F(" - "), headerLine);
     }
     // Clear anything else out of the stream buffer
-    int junkChars = _stream->available();
+    uint8_t junkChars = _stream->available();
     if (junkChars)
     {
         MS_DBG(F("Dumping "), junkChars, F(" characters from MaxBotix stream buffer"));
@@ -106,11 +106,11 @@ bool MaxBotixSonar::addSingleMeasurementResult(void)
 {
     // Initialize values
     bool success = false;
-    int rangeAttempts = 0;
+    uint8_t rangeAttempts = 0;
     int16_t result = -9999;
 
     // Clear anything out of the stream buffer
-    int junkChars = _stream->available();
+    uint8_t junkChars = _stream->available();
     if (junkChars)
     {
         MS_DBG(F("Dumping "), junkChars, F(" characters from MaxBotix stream buffer"));

--- a/src/sensors/MaxBotixSonar.cpp
+++ b/src/sensors/MaxBotixSonar.cpp
@@ -113,9 +113,15 @@ bool MaxBotixSonar::addSingleMeasurementResult(void)
     uint8_t junkChars = _stream->available();
     if (junkChars)
     {
-        MS_DBG(F("Dumping "), junkChars, F(" characters from MaxBotix stream buffer"));
+        MS_DBG(F("Dumping "), junkChars, F(" characters from MaxBotix stream buffer:"));
         for (uint8_t i = 0; i < junkChars; i++)
-        _stream->read();
+        {
+            #ifdef DEBUGGING_SERIAL_OUTPUT
+            DEBUGGING_SERIAL_OUTPUT.print(_stream->read());
+            #else
+            _stream->read();
+            #endif            
+        }
     }
 
     // Check a measurement was *successfully* started (status bit 6 set)

--- a/src/sensors/MaxBotixSonar.h
+++ b/src/sensors/MaxBotixSonar.h
@@ -49,7 +49,7 @@ public:
     bool addSingleMeasurementResult(void) override;
 
 private:
-    int _triggerPin;
+    int8_t _triggerPin;
     Stream* _stream;
 };
 

--- a/src/sensors/MaximDS18.cpp
+++ b/src/sensors/MaximDS18.cpp
@@ -27,7 +27,7 @@ MaximDS18::MaximDS18(DeviceAddress OneWireAddress, int8_t powerPin, int8_t dataP
            powerPin, dataPin, measurementsToAverage),
     _internalOneWire(dataPin), _internalDallasTemp(&_internalOneWire)
 {
-    for (int i = 0; i < 8; i++) _OneWireAddress[i] = OneWireAddress[i];
+    for (uint8_t i = 0; i < 8; i++) _OneWireAddress[i] = OneWireAddress[i];
     // _OneWireAddress = OneWireAddress;
     _addressKnown = true;
 }
@@ -103,7 +103,7 @@ bool MaximDS18::setup(void)
         if (gotAddress)
         {
             MS_DBG(F("Sensor found at "), makeAddressString(address));
-            for (int i = 0; i < 8; i++) _OneWireAddress[i] = address[i];
+            for (uint8_t i = 0; i < 8; i++) _OneWireAddress[i] = address[i];
             _addressKnown = true;  // Now we know the address
         }
         else

--- a/src/sensors/MeaSpecMS5803.cpp
+++ b/src/sensors/MeaSpecMS5803.cpp
@@ -105,6 +105,11 @@ bool MeaSpecMS5803::addSingleMeasurementResult(void)
             temp = -9999;
             press = -9999;
         }
+        if (press == 0)  // Returns 0 when disconnected, which is highly unlikely to be a real value.
+        {
+            temp = -9999;
+            press = -9999;
+        }
 
         MS_DBG(F("Temperature: "), temp);
         MS_DBG(F("Pressure: "), press);

--- a/src/sensors/MeaSpecMS5803.cpp
+++ b/src/sensors/MeaSpecMS5803.cpp
@@ -92,6 +92,9 @@ bool MeaSpecMS5803::addSingleMeasurementResult(void)
     {
         MS_DBG(F("Getting values from "), getSensorNameAndLocation());
         // Read values
+        // NOTE:  These functions actually include the request to begin
+        // a measurement and the wait for said measurement to finish.
+        // It's pretty fast (max of 11 ms) so we'll just wait.
         temp = MS5803_internal.getTemperature(CELSIUS, ADC_512);
         press = MS5803_internal.getPressure(ADC_4096);
 

--- a/src/sensors/MeaSpecMS5803.cpp
+++ b/src/sensors/MeaSpecMS5803.cpp
@@ -38,7 +38,7 @@
 
 // The constructor - because this is I2C, only need the power pin
 MeaSpecMS5803::MeaSpecMS5803(int8_t powerPin, uint8_t i2cAddressHex,
-                             int maxPressure, uint8_t measurementsToAverage)
+                             int16_t maxPressure, uint8_t measurementsToAverage)
      : Sensor("MeaSpecMS5803", MS5803_NUM_VARIABLES,
               MS5803_WARM_UP_TIME_MS, MS5803_STABILIZATION_TIME_MS, MS5803_MEASUREMENT_TIME_MS,
               powerPin, -1, measurementsToAverage)

--- a/src/sensors/MeaSpecMS5803.h
+++ b/src/sensors/MeaSpecMS5803.h
@@ -72,7 +72,7 @@ class MeaSpecMS5803 : public Sensor
 {
 public:
     MeaSpecMS5803(int8_t powerPin, uint8_t i2cAddressHex = 0x76,
-                  int maxPressure = 14, uint8_t measurementsToAverage = 1);
+                  int16_t maxPressure = 14, uint8_t measurementsToAverage = 1);
     ~MeaSpecMS5803();
 
     bool setup(void) override;
@@ -82,7 +82,7 @@ public:
 protected:
     MS5803 MS5803_internal;
     uint8_t _i2cAddressHex;
-    int _maxPressure;
+    int16_t _maxPressure;
 };
 
 

--- a/src/sensors/ProcessorStats.cpp
+++ b/src/sensors/ProcessorStats.cpp
@@ -102,6 +102,7 @@ ProcessorStats::ProcessorStats(const char *version)
              -1, -1, 1)
 {
     _version = version;
+    sampNum = 0;
 
     #if defined(ARDUINO_AVR_ENVIRODIY_MAYFLY) || defined(ARDUINO_AVR_SODAQ_MBILI)
         _batteryPin = A6;
@@ -203,6 +204,11 @@ bool ProcessorStats::addSingleMeasurementResult(void)
     #endif
 
     verifyAndAddMeasurementResult(PROCESSOR_RAM_VAR_NUM, sensorValue_freeRam);
+
+    // bump up the sample number
+    sampNum += 1;
+
+    verifyAndAddMeasurementResult(PROCESSOR_SAMPNUM_VAR_NUM, sampNum);
 
     // Unset the time stamp for the beginning of this measurement
     _millisMeasurementRequested = 0;

--- a/src/sensors/ProcessorStats.cpp
+++ b/src/sensors/ProcessorStats.cpp
@@ -192,7 +192,7 @@ bool ProcessorStats::addSingleMeasurementResult(void)
     MS_DBG(F("Getting Free RAM"));
 
     #if defined __AVR__
-    extern int __heap_start, *__brkval;
+    extern int16_t __heap_start, *__brkval;
     int16_t v;
     float sensorValue_freeRam = (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
 

--- a/src/sensors/ProcessorStats.cpp
+++ b/src/sensors/ProcessorStats.cpp
@@ -127,7 +127,7 @@ String ProcessorStats::getSensorLocation(void) {return BOARD;}
 #if defined(ARDUINO_ARCH_SAMD)
     extern "C" char *sbrk(int i);
 
-    int FreeRam () {
+    int16_t FreeRam () {
       char stack_dummy = 0;
       return &stack_dummy - sbrk(0);
     }
@@ -193,7 +193,7 @@ bool ProcessorStats::addSingleMeasurementResult(void)
 
     #if defined __AVR__
     extern int __heap_start, *__brkval;
-    int v;
+    int16_t v;
     float sensorValue_freeRam = (int) &v - (__brkval == 0 ? (int) &__heap_start : (int) __brkval);
 
     #elif defined(ARDUINO_ARCH_SAMD)

--- a/src/sensors/ProcessorStats.h
+++ b/src/sensors/ProcessorStats.h
@@ -25,7 +25,7 @@
 #include "SensorBase.h"
 
 // Sensor Specific Defines
-#define PROCESSOR_NUM_VARIABLES 2
+#define PROCESSOR_NUM_VARIABLES 3
 #define PROCESSOR_WARM_UP_TIME_MS 0
 #define PROCESSOR_STABILIZATION_TIME_MS 0
 #define PROCESSOR_MEASUREMENT_TIME_MS 0
@@ -35,6 +35,9 @@
 
 #define PROCESSOR_RAM_RESOLUTION 0
 #define PROCESSOR_RAM_VAR_NUM 1
+
+#define PROCESSOR_SAMPNUM_RESOLUTION 0
+#define PROCESSOR_SAMPNUM_VAR_NUM 2
 
 
 // The "Main" class for the Processor
@@ -52,7 +55,8 @@ public:
 
 private:
     const char *_version;
-    int _batteryPin;
+    int8_t _batteryPin;
+    uint32_t sampNum;
 };
 
 
@@ -83,6 +87,21 @@ public:
                  "FreeRam", UUID, customVarCode)
     {}
     ~ProcessorStats_FreeRam(){}
+};
+
+
+// Defines the "Sample Number" This is a board diagnostic
+class ProcessorStats_SampleNumber : public Variable
+{
+public:
+    ProcessorStats_SampleNumber(Sensor *parentSense,
+                           const char *UUID = "", const char *customVarCode = "")
+      : Variable(parentSense, PROCESSOR_SAMPNUM_VAR_NUM,
+                 "Free SRAM", "Bit",
+                 PROCESSOR_SAMPNUM_RESOLUTION,
+                 "FreeRam", UUID, customVarCode)
+    {}
+    ~ProcessorStats_SampleNumber(){}
 };
 
 #endif  // Header Guard

--- a/src/sensors/ProcessorStats.h
+++ b/src/sensors/ProcessorStats.h
@@ -97,9 +97,9 @@ public:
     ProcessorStats_SampleNumber(Sensor *parentSense,
                            const char *UUID = "", const char *customVarCode = "")
       : Variable(parentSense, PROCESSOR_SAMPNUM_VAR_NUM,
-                 "Free SRAM", "Bit",
+                 "sequenceNumber", "Dimensionless",
                  PROCESSOR_SAMPNUM_RESOLUTION,
-                 "FreeRam", UUID, customVarCode)
+                 "SampNum", UUID, customVarCode)
     {}
     ~ProcessorStats_SampleNumber(){}
 };

--- a/src/sensors/ProcessorStats.h
+++ b/src/sensors/ProcessorStats.h
@@ -56,7 +56,7 @@ public:
 private:
     const char *_version;
     int8_t _batteryPin;
-    uint32_t sampNum;
+    int16_t sampNum;
 };
 
 

--- a/src/sensors/RainCounterI2C.cpp
+++ b/src/sensors/RainCounterI2C.cpp
@@ -77,7 +77,7 @@ bool RainCounterI2C::addSingleMeasurementResult(void)
     MS_DBG(F("Tips: "), tips);
 
     verifyAndAddMeasurementResult(BUCKET_RAIN_VAR_NUM, rain);
-    verifyAndAddMeasurementResult(BUCKET_TIPS_VAR_NUM, int(tips));
+    verifyAndAddMeasurementResult(BUCKET_TIPS_VAR_NUM, tips);
 
     // Unset the time stamp for the beginning of this measurement
     _millisMeasurementRequested = 0;

--- a/src/sensors/RainCounterI2C.cpp
+++ b/src/sensors/RainCounterI2C.cpp
@@ -55,7 +55,7 @@ bool RainCounterI2C::addSingleMeasurementResult(void)
     uint8_t Byte2 = 0; // High byte of data
 
     float rain = -9999; // Number of mm of rain
-    int tips = -9999; // Number of tip events
+    int16_t tips = -9999; // Number of tip events
 
     // Get data from external tip counter
     // if the 'requestFrom' returns 0, it means no bytes were received

--- a/src/sensors/SDI12Sensors.cpp
+++ b/src/sensors/SDI12Sensors.cpp
@@ -289,7 +289,7 @@ bool SDI12Sensors::startSingleMeasurement(void)
     if (!wasActive) _SDI12Internal.end();
 
     // Verify the number of results the sensor will send
-    // int numVariables = sdiResponse.substring(4,5).toInt();
+    // uint8_t numVariables = sdiResponse.substring(4,5).toInt();
     // if (numVariables != _numReturnedVars)
     // {
     //     MS_DBG(numVariables, F(" results expected"));
@@ -348,7 +348,7 @@ bool SDI12Sensors::addSingleMeasurementResult(void)
         while (_SDI12Internal.available() < 3 && (millis() - startTime) < 1500) {}
         MS_DBG(F("   Receiving results from "), getSensorNameAndLocation());
         _SDI12Internal.read();  // ignore the repeated SDI12 address
-        for (int i = 0; i < _numReturnedVars; i++)
+        for (uint8_t i = 0; i < _numReturnedVars; i++)
         {
             float result = _SDI12Internal.parseFloat();
             // The SDI-12 library should return -9999 on timeout
@@ -376,7 +376,7 @@ bool SDI12Sensors::addSingleMeasurementResult(void)
         // If there's no measurement, need to make sure we send over all
         // of the "failed" result values
         MS_DBG(F("   "), getSensorNameAndLocation(), F(" is not currently measuring!"));
-       for (int i = 0; i < _numReturnedVars; i++)
+       for (uint8_t i = 0; i < _numReturnedVars; i++)
        {
            verifyAndAddMeasurementResult(i, -9999);
        }

--- a/src/sensors/SDI12Sensors.cpp
+++ b/src/sensors/SDI12Sensors.cpp
@@ -155,8 +155,8 @@ bool SDI12Sensors::getSensorInfo(void)
     bool wasActive = _SDI12Internal.isActive();
     // If it wasn't active, activate it now.
     // Use begin() instead of just setActive() to ensure timer is set correctly.
-    if (wasActive) MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
-                          F(" was already active!"));
+    if (wasActive) {MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
+                          F(" was already active!"));}
     if (!wasActive) _SDI12Internal.begin();
     // Empty the buffer
     _SDI12Internal.clearBuffer();
@@ -250,8 +250,8 @@ bool SDI12Sensors::startSingleMeasurement(void)
     MS_DBG(F("   Activating SDI-12 instance for "), getSensorNameAndLocation());
     // Check if this the currently active SDI-12 Object
     wasActive = _SDI12Internal.isActive();
-    if (wasActive) MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
-                          F(" was already active!"));
+    if (wasActive) {MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
+                          F(" was already active!"));}
     // If it wasn't active, activate it now.
     // Use begin() instead of just setActive() to ensure timer is set correctly.
     if (!wasActive) _SDI12Internal.begin();
@@ -328,8 +328,8 @@ bool SDI12Sensors::addSingleMeasurementResult(void)
         MS_DBG(F("   Activating SDI-12 instance for "), getSensorNameAndLocation());
         // Check if this the currently active SDI-12 Object
         bool wasActive = _SDI12Internal.isActive();
-        if (wasActive) MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
-                              F(" was already active!"));
+        if (wasActive) {MS_DBG(F("   SDI-12 instance for "), getSensorNameAndLocation(),
+                              F(" was already active!"));}
         // If it wasn't active, activate it now.
         // Use begin() instead of just setActive() to ensure timer is set correctly.
         if (!wasActive) _SDI12Internal.begin();

--- a/src/sensors/SDI12Sensors.cpp
+++ b/src/sensors/SDI12Sensors.cpp
@@ -378,7 +378,7 @@ bool SDI12Sensors::addSingleMeasurementResult(void)
         MS_DBG(F("   "), getSensorNameAndLocation(), F(" is not currently measuring!"));
        for (uint8_t i = 0; i < _numReturnedVars; i++)
        {
-           verifyAndAddMeasurementResult(i, -9999);
+           verifyAndAddMeasurementResult(i, (float)-9999);
        }
     }
 

--- a/src/sensors/SDI12Sensors.cpp
+++ b/src/sensors/SDI12Sensors.cpp
@@ -68,9 +68,11 @@ bool SDI12Sensors::setup(void)
     // Force the timeout value to be -9999 (This should be library default.)
     _SDI12Internal.setTimeoutValue(-9999);
 
+    #ifdef __AVR__
     // Allow the SDI-12 library access to interrupts
     MS_DBG(F("Enabling interrupts for SDI12 on pin "), _dataPin);
     enableInterrupt(_dataPin, SDI12::handleInterrupt, CHANGE);
+    #endif
 
     retVal &= getSensorInfo();
 
@@ -191,19 +193,19 @@ bool SDI12Sensors::getSensorInfo(void)
         MS_DBG(F("   SDI12 Address:"), sdi12Address);
         float sdi12Version = sdiResponse.substring(1,3).toFloat();
         sdi12Version /= 10;
-        MS_DBG(F(", SDI12 Version:"), sdi12Version);
+        MS_DBG(F("   SDI12 Version:"), sdi12Version);
         _sensorVendor = sdiResponse.substring(3,11);
         _sensorVendor.trim();
-        MS_DBG(F(", Sensor Vendor:"), _sensorVendor);
+        MS_DBG(F("   Sensor Vendor:"), _sensorVendor);
         _sensorModel = sdiResponse.substring(11,17);
         _sensorModel.trim();
-        MS_DBG(F(", Sensor Model:"), _sensorModel);
+        MS_DBG(F("   Sensor Model:"), _sensorModel);
         _sensorVersion = sdiResponse.substring(17,20);
         _sensorVersion.trim();
-        MS_DBG(F(", Sensor Version:"), _sensorVersion);
+        MS_DBG(F("   Sensor Version:"), _sensorVersion);
         _sensorSerialNumber = sdiResponse.substring(20);
         _sensorSerialNumber.trim();
-        MS_DBG(F(", Sensor Serial Number:"), _sensorSerialNumber);
+        MS_DBG(F("   Sensor Serial Number:"), _sensorSerialNumber);
         return true;
     }
     else return false;

--- a/src/sensors/SDI12Sensors.h
+++ b/src/sensors/SDI12Sensors.h
@@ -23,6 +23,8 @@
 #include "VariableBase.h"
 #include "SensorBase.h"
 #include <SDI12_ExtInts.h>
+// NOTE:  Could use the "regular" sdi-12 library with build flag -D SDI12_EXTERNAL_PCINT
+// Unfortunately, that is not compatible with the Arduino IDE
 
 // The main class for SDI-12 Sensors
 class SDI12Sensors : public Sensor

--- a/src/sensors/YosemitechParent.cpp
+++ b/src/sensors/YosemitechParent.cpp
@@ -18,7 +18,7 @@
 // The constructor - need the sensor type, modbus address, power pin, stream for data, and number of readings to average
 YosemitechParent::YosemitechParent(byte modbusAddress, Stream* stream,
                                    int8_t powerPin, int8_t powerPin2, int8_t enablePin, uint8_t measurementsToAverage,
-                                   yosemitechModel model, const char *sensName, int numVariables,
+                                   yosemitechModel model, const char *sensName, uint8_t numVariables,
                                    uint32_t warmUpTime_ms, uint32_t stabilizationTime_ms, uint32_t measurementTime_ms)
     : Sensor(sensName, numVariables,
              warmUpTime_ms, stabilizationTime_ms, measurementTime_ms,
@@ -32,7 +32,7 @@ YosemitechParent::YosemitechParent(byte modbusAddress, Stream* stream,
 }
 YosemitechParent::YosemitechParent(byte modbusAddress, Stream& stream,
                                    int8_t powerPin, int8_t powerPin2, int8_t enablePin, uint8_t measurementsToAverage,
-                                   yosemitechModel model, const char *sensName, int numVariables,
+                                   yosemitechModel model, const char *sensName, uint8_t numVariables,
                                    uint32_t warmUpTime_ms, uint32_t stabilizationTime_ms, uint32_t measurementTime_ms)
     : Sensor(sensName, numVariables,
              warmUpTime_ms, stabilizationTime_ms, measurementTime_ms,
@@ -87,7 +87,7 @@ bool YosemitechParent::wake(void)
 
     // Send the command to begin taking readings, trying up to 5 times
     bool success = false;
-    int ntries = 0;
+    uint8_t ntries = 0;
     MS_DBG(F("Start Measurement on "), getSensorNameAndLocation());
     while (!success && ntries < 5)
     {
@@ -136,7 +136,7 @@ bool YosemitechParent::sleep(void)
 
     // Send the command to begin taking readings, trying up to 5 times
     bool success = false;
-    int ntries = 0;
+    uint8_t ntries = 0;
     MS_DBG(F("Stop Measurement on "), getSensorNameAndLocation());
     while (!success && ntries < 5)
     {

--- a/src/sensors/YosemitechParent.cpp
+++ b/src/sensors/YosemitechParent.cpp
@@ -148,6 +148,8 @@ bool YosemitechParent::sleep(void)
     {
         // Unset the activation time
         _millisSensorActivated = 0;
+        // Unset the measurement request time
+        _millisMeasurementRequested = 0;
         // Unset the status bits for sensor activation (bits 3 & 4) and measurement
         // request (bits 5 & 6)
         _sensorStatus &= 0b10000111;
@@ -196,6 +198,10 @@ void YosemitechParent::powerDown(void)
         digitalWrite(_powerPin, LOW);
         // Unset the power-on time
         _millisPowerOn = 0;
+        // Unset the activation time
+        _millisSensorActivated = 0;
+        // Unset the measurement request time
+        _millisMeasurementRequested = 0;
         // Unset the status bits for sensor power (bits 1 & 2),
         // activation (bits 3 & 4), and measurement request (bits 5 & 6)
         _sensorStatus &= 0b10000001;

--- a/src/sensors/YosemitechParent.h
+++ b/src/sensors/YosemitechParent.h
@@ -33,11 +33,11 @@ class YosemitechParent : public Sensor
 public:
     YosemitechParent(byte modbusAddress, Stream* stream,
                      int8_t powerPin, int8_t powerPin2, int8_t enablePin = -1, uint8_t measurementsToAverage = 1,
-                     yosemitechModel model = UNKNOWN, const char *sensName = "Yosemitech-Sensor", int numVariables = 2,
+                     yosemitechModel model = UNKNOWN, const char *sensName = "Yosemitech-Sensor", uint8_t numVariables = 2,
                      uint32_t warmUpTime_ms = 1500, uint32_t stabilizationTime_ms = 20000, uint32_t measurementTime_ms = 2000);
     YosemitechParent(byte modbusAddress, Stream& stream,
                      int8_t powerPin, int8_t powerPin2, int8_t enablePin = -1, uint8_t measurementsToAverage = 1,
-                     yosemitechModel model = UNKNOWN, const char *sensName = "Yosemitech-Sensor", int numVariables = 2,
+                     yosemitechModel model = UNKNOWN, const char *sensName = "Yosemitech-Sensor", uint8_t numVariables = 2,
                      uint32_t warmUpTime_ms = 1500, uint32_t stabilizationTime_ms = 20000, uint32_t measurementTime_ms = 2000);
     virtual ~YosemitechParent();
 
@@ -58,7 +58,7 @@ private:
     yosemitechModel _model;
     byte _modbusAddress;
     Stream* _stream;
-    int _RS485EnablePin;
+    int8_t _RS485EnablePin;
     int8_t _powerPin2;
 };
 


### PR DESCRIPTION
Added a variable to the processor for sample number.  NOTE:  this is actually a count of the number of results requested from the processor.  It is only intended to be a helper for qc, not a truly accurate count of number of samples.

Fixed problem where power was going off before sensors finished.

Specified more int sizes

Added an extra sanity check on MS5803 - should now show -9999 for disconnected sensor instead of pressure of 0.