### PR TITLE
Adding KellerNanolevel support - requires KellerModbus lib update

### DIFF
--- a/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
+++ b/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino
@@ -506,18 +506,29 @@ RainCounterI2C tbi2c(RainCounterI2CAddress, depthPerTipEvent);
 #include <AltSoftSerial.h>
 AltSoftSerial modbusSerial;
 
+const int8_t modbusSensorPower = 22;  // Pin to switch power on and off (-1 if unconnected)
+const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
+const int8_t rs485AdapterPower = 22;// Pin to switch RS485 adapter power on and off (-1 if unconnected)
 // ==========================================================================
 //    Keller Acculevel High Accuracy Submersible Level Transmitter
 // ==========================================================================
 #include <sensors/KellerAcculevel.h>
 byte acculevelModbusAddress = 0x01;  // The modbus address of KellerAcculevel
-const int8_t rs485AdapterPower = 22;  // Pin to switch RS485 adapter power on and off (-1 if unconnected)
-const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (-1 if unconnected)
-const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
+//const int8_t rs485AdapterPower = 22;  // Pin to switch RS485 adapter power on and off (-1 if unconnected)
+//const int8_t modbusSensorPower = A3;  // Pin to switch sensor power on and off (-1 if unconnected)
+//const int8_t max485EnablePin = -1;  // Pin connected to the RE/DE on the 485 chip (-1 if unconnected)
 const uint8_t acculevelNumberReadings = 5;  // The manufacturer recommends taking and averaging a few readings
 // Create and return the Keller Acculevel sensor object
 KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, acculevelNumberReadings);
 
+// ==========================================================================
+//    Keller Nanolevel High Accuracy Submersible Level Transmitter
+// ==========================================================================
+#include <sensors/KellerNanolevel.h>
+byte nanolevelModbusAddress = 0x01;  // The modbus address of KellerNanolevel
+const uint8_t nanolevelNumberReadings = 3;  // The manufacturer recommends taking and averaging a few readings
+// Create and return the Keller Nanolevel sensor object
+KellerNanolevel nanolevelfn(nanolevelModbusAddress, modbusSerial, rs485AdapterPower, modbusSensorPower, max485EnablePin, nanolevelNumberReadings);
 
 // ==========================================================================
 //    Yosemitech Y504 Dissolved Oxygen Sensor

--- a/src/sensors/KellerNanolevel.h
+++ b/src/sensors/KellerNanolevel.h
@@ -1,0 +1,98 @@
+/*
+ *KellerNanolevel.h
+ *This file is part of the EnviroDIY modular sensors library for Arduino
+ *
+ *Initial library developement done by Anthony Aufdenkampe <aaufdenkampe@limno.com>,updated by Neil Hancock.
+ *
+ *This file is for Modbus communication to  Keller Series 30, Class 5, Group 20 sensors,
+ *that are Software version 5.20-12.28 and later (i.e. made after the 2012 in the 28th week)
+ *Only tested the Acculevel
+ *
+ *Documentation for the Keller Protocol commands and responses, along with
+ *information about the various variables, can be found
+ *in the EnviroDIY KellerModbus library at:
+ * https://github.com/EnviroDIY/KellerModbus
+*/
+
+#ifndef KellerNanolevel_h
+#define KellerNanolevel_h
+
+// Included Dependencies
+#include "VariableBase.h"
+#include "sensors/KellerParent.h"
+
+// Sensor Specific Defines
+#define KellerNanolevel_WARM_UP_TIME_MS 500
+#define KellerNanolevel_STABILIZATION_TIME_MS 5000
+#define KellerNanolevel_MEASUREMENT_TIME_MS 1500
+
+#define KellerNanolevel_PRESSURE_RESOLUTION 5
+
+#define KellerNanolevel_TEMP_RESOLUTION 2
+
+#define KellerNanolevel_HEIGHT_RESOLUTION 4
+
+
+// The main class for the Keller Sensors
+class KellerNanolevel : public KellerParent
+{
+public:
+    // Constructors with overloads
+    KellerNanolevel(byte modbusAddress, Stream* stream, int8_t powerPin, int8_t powerPin2 = -1,
+                   int8_t enablePin = -1, uint8_t measurementsToAverage = 1)
+     : KellerParent(modbusAddress, stream, powerPin, powerPin2, enablePin,measurementsToAverage,
+                    Nanolevel_kellerModel, "KellerNanolevel", KELLER_NUM_VARIABLES,
+                    KellerNanolevel_WARM_UP_TIME_MS, KellerNanolevel_STABILIZATION_TIME_MS, KellerNanolevel_MEASUREMENT_TIME_MS)
+    {}
+    KellerNanolevel(byte modbusAddress, Stream& stream, int8_t powerPin, int8_t powerPin2 = -1,
+                   int8_t enablePin = -1, uint8_t measurementsToAverage = 1)
+     : KellerParent(modbusAddress, stream, powerPin, powerPin2, enablePin, measurementsToAverage,
+                    Nanolevel_kellerModel, "KellerNanolevel", KELLER_NUM_VARIABLES,
+                    KellerNanolevel_WARM_UP_TIME_MS, KellerNanolevel_STABILIZATION_TIME_MS, KellerNanolevel_MEASUREMENT_TIME_MS)
+    {}
+    // Destructor
+    ~KellerNanolevel(){}
+};
+
+
+// Defines the PressureGauge (vented & barometricPressure corrected) variable
+class KellerNanolevel_Pressure : public Variable
+{
+public:
+    KellerNanolevel_Pressure(Sensor *parentSense, const char *UUID = "", const char *customVarCode = "")
+     : Variable(parentSense, KELLER_PRESSURE_VAR_NUM,
+                "pressureGauge", "millibar",
+                KellerNanolevel_PRESSURE_RESOLUTION,
+                "kellerPress", UUID, customVarCode)
+    {}
+    ~KellerNanolevel_Pressure(){}
+};
+
+
+// Defines the Temperature Variable
+class KellerNanolevel_Temp : public Variable
+{
+public:
+    KellerNanolevel_Temp(Sensor *parentSense, const char *UUID = "", const char *customVarCode = "")
+     : Variable(parentSense, KELLER_TEMP_VAR_NUM,
+                "temperature", "degreeCelsius",
+                KellerNanolevel_TEMP_RESOLUTION,
+                "kellerTemp", UUID, customVarCode)
+    {}
+    ~KellerNanolevel_Temp(){}
+};
+
+// Defines the gageHeight (Water level with regard to an arbitrary gage datum) Variable
+class KellerNanolevel_Height : public Variable
+{
+public:
+    KellerNanolevel_Height(Sensor *parentSense, const char *UUID = "", const char *customVarCode = "")
+     : Variable(parentSense, KELLER_HEIGHT_VAR_NUM,
+                "gaugeHeight", "meter",
+                KellerNanolevel_HEIGHT_RESOLUTION,
+                "kellerHeight", UUID, customVarCode)
+    {}
+    ~KellerNanolevel_Height(){}
+};
+
+#endif  // Header Guard

--- a/src/sensors/KellerParent.cpp
+++ b/src/sensors/KellerParent.cpp
@@ -72,7 +72,7 @@ bool KellerParent::setup(void)
 
     // This sensor begin is just setting more pin modes, etc, no sensor power required
     // This realy can't fail so adding the return value is just for show
-    retVal &= sensor.begin(_modbusAddress, _stream, _RS485EnablePin);
+    retVal &= sensor.begin(_model,_modbusAddress, _stream, _RS485EnablePin);
 
     return retVal;
 }


### PR DESCRIPTION
First pass PR - is this in the right ball park?  @SRGDamia1  @aufdenkampe  .
For my private build https://github.com/neilh10/ModularSensors/tree/work_nanolevel I've had this running with two Keller Nanolevels for over a month and the Modbus has worked well.
The results are at https://data.envirodiy.org/sites/LCC45a3/ - the gage Height & Temperature are a test station.

In building examples\logging_to_EnviroDIY.ino with these changes against ModularSensors:develop I get an error elsewhere. Can't figure out why.
To test, and using an updated KellerModbus I update platformio.ini to
src_dir = ./

lib_deps =
    ;EnviroDIY_ModularSensors@=0.16.2
    https://github.com/neilh10/KellerModbus#work_km_nanolevel
    https://github.com/EnviroDIY/ModularSensors.git#develop
    https://github.com/PaulStoffregen/AltSoftSerial.git
    https://github.com/EnviroDIY/SoftwaterSerial_ExternalInts.git

In file included from .piolibdeps\EnviroDIY_ModularSensors\src/sensors/Decagon5TM.h:35:0,
from C:/Users/neilh77/Documents/Arduino/env03pr/ModularSensors/examples/logging_to_EnviroDIY/logging_to_EnviroDIY.ino:737:
.piolibdeps\EnviroDIY_ModularSensors\src/sensors/SDI12Sensors.h:28:27: fatal error: SDI12_ExtInts.h: No such file or directory