### PR TITLE
Add fxn to match UUIDs, set min battery to 3.55

### DIFF
--- a/examples/DRWI_CitSci/DRWI_CitSci.ino
+++ b/examples/DRWI_CitSci/DRWI_CitSci.ino
@@ -155,21 +155,40 @@ DecagonCTD ctd(*CTDSDI12address, SDI12Power, SDI12Data, CTDNumberReadings);
 // ==========================================================================
 
 Variable *variableList[] = {
-    new DecagonCTD_Cond(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Temp(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Depth(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new CampbellOBS3_Turbidity(&osb3low, "12345678-abcd-1234-ef00-1234567890ab", "TurbLow"),
-    new CampbellOBS3_Turbidity(&osb3high, "12345678-abcd-1234-ef00-1234567890ab", "TurbHigh"),
-    new ProcessorStats_Battery(&mcuBoard, "12345678-abcd-1234-ef00-1234567890ab"),
-    new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-ef00-1234567890ab"),
-    new Modem_RSSI(&modem, "12345678-abcd-1234-ef00-1234567890ab"),
-    new Modem_SignalPercent(&modem, "12345678-abcd-1234-ef00-1234567890ab"),
+    new DecagonCTD_Cond(&ctd),
+    new DecagonCTD_Temp(&ctd),
+    new DecagonCTD_Depth(&ctd),
+    new CampbellOBS3_Turbidity(&osb3low, "", "TurbLow"),
+    new CampbellOBS3_Turbidity(&osb3high, "", "TurbHigh"),
+    new ProcessorStats_Battery(&mcuBoard),
+    new MaximDS3231_Temp(&ds3231),
+    new Modem_RSSI(&modem),
+    new Modem_SignalPercent(&modem),
 };
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+// Check the order of your variables in the variable list!!!
+// Be VERY certain that they match the order of your UUID's!
+// Rearrange the variables in the variable list if necessary to match!
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+const char *REGISTRATION_TOKEN = "12345678-abcd-1234-ef00-1234567890ab"; // Device registration token
+const char *SAMPLING_FEATURE = "12345678-abcd-1234-ef00-1234567890ab";   // Sampling feature UUID
+const char *UUIDs[] = {
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+};
+
 // Count up the number of pointers in the array
 int variableCount = sizeof(variableList) / sizeof(variableList[0]);
 
 // Create the VariableArray object
-VariableArray varArray(variableCount, variableList);
+VariableArray varArray(variableCount, variableList, UUIDs);
 
 
 // ==========================================================================
@@ -185,8 +204,8 @@ Logger dataLogger(LoggerID, loggingInterval, &varArray);
 // ==========================================================================
 // Device registration and sampling feature information can be obtained after
 // registration at http://data.WikiWatershed.org
-const char *registrationToken = "12345678-abcd-1234-ef00-1234567890ab";   // Device registration token
-const char *samplingFeature = "12345678-abcd-1234-ef00-1234567890ab";     // Sampling feature UUID
+const char *registrationToken = REGISTRATION_TOKEN; // Device registration token
+const char *samplingFeature = SAMPLING_FEATURE;     // Sampling feature UUID
 
 // Create a data publisher for the EnviroDIY/WikiWatershed POST endpoint
 #include <publishers/EnviroDIYPublisher.h>
@@ -311,7 +330,7 @@ void setup()
     }
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 
@@ -330,7 +349,7 @@ void loop()
         dataLogger.systemSleep();
     }
     // At moderate voltage, log data but don't send it over the modem
-    else if (getBatteryVoltage() < 3.7)
+    else if (getBatteryVoltage() < 3.55)
     {
         dataLogger.logData();
     }

--- a/examples/DRWI_LTE/DRWI_LTE.ino
+++ b/examples/DRWI_LTE/DRWI_LTE.ino
@@ -161,21 +161,40 @@ DecagonCTD ctd(*CTDSDI12address, SDI12Power, SDI12Data, CTDNumberReadings);
 // ==========================================================================
 
 Variable *variableList[] = {
-    new DecagonCTD_Cond(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Temp(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Depth(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new CampbellOBS3_Turbidity(&osb3low, "12345678-abcd-1234-ef00-1234567890ab", "TurbLow"),
-    new CampbellOBS3_Turbidity(&osb3high, "12345678-abcd-1234-ef00-1234567890ab", "TurbHigh"),
-    new ProcessorStats_Battery(&mcuBoard, "12345678-abcd-1234-ef00-1234567890ab"),
-    new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-ef00-1234567890ab"),
-    new Modem_RSSI(&modem, "12345678-abcd-1234-ef00-1234567890ab"),
-    new Modem_SignalPercent(&modem, "12345678-abcd-1234-ef00-1234567890ab"),
+    new DecagonCTD_Cond(&ctd),
+    new DecagonCTD_Temp(&ctd),
+    new DecagonCTD_Depth(&ctd),
+    new CampbellOBS3_Turbidity(&osb3low, "", "TurbLow"),
+    new CampbellOBS3_Turbidity(&osb3high, "", "TurbHigh"),
+    new ProcessorStats_Battery(&mcuBoard),
+    new MaximDS3231_Temp(&ds3231),
+    new Modem_RSSI(&modem),
+    new Modem_SignalPercent(&modem),
 };
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+// Check the order of your variables in the variable list!!!
+// Be VERY certain that they match the order of your UUID's!
+// Rearrange the variables in the variable list if necessary to match!
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+const char *REGISTRATION_TOKEN = "12345678-abcd-1234-ef00-1234567890ab"; // Device registration token
+const char *SAMPLING_FEATURE = "12345678-abcd-1234-ef00-1234567890ab";   // Sampling feature UUID
+const char *UUIDs[] = {
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+};
+
 // Count up the number of pointers in the array
 int variableCount = sizeof(variableList) / sizeof(variableList[0]);
 
 // Create the VariableArray object
-VariableArray varArray(variableCount, variableList);
+VariableArray varArray(variableCount, variableList, UUIDs);
 
 
 // ==========================================================================
@@ -191,8 +210,8 @@ Logger dataLogger(LoggerID, loggingInterval, &varArray);
 // ==========================================================================
 // Device registration and sampling feature information can be obtained after
 // registration at http://data.WikiWatershed.org
-const char *registrationToken = "12345678-abcd-1234-ef00-1234567890ab";   // Device registration token
-const char *samplingFeature = "12345678-abcd-1234-ef00-1234567890ab";     // Sampling feature UUID
+const char *registrationToken = REGISTRATION_TOKEN; // Device registration token
+const char *samplingFeature = SAMPLING_FEATURE;     // Sampling feature UUID
 
 // Create a data publisher for the EnviroDIY/WikiWatershed POST endpoint
 #include <publishers/EnviroDIYPublisher.h>
@@ -329,7 +348,7 @@ void setup()
     }
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 
@@ -348,7 +367,7 @@ void loop()
         dataLogger.systemSleep();
     }
     // At moderate voltage, log data but don't send it over the modem
-    else if (getBatteryVoltage() < 3.7)
+    else if (getBatteryVoltage() < 3.55)
     {
         dataLogger.logData();
     }

--- a/examples/DRWI_NoCellular/DRWI_NoCellular.ino
+++ b/examples/DRWI_NoCellular/DRWI_NoCellular.ino
@@ -123,19 +123,36 @@ DecagonCTD ctd(*CTDSDI12address, SDI12Power, SDI12Data, CTDNumberReadings);
 // ==========================================================================
 
 Variable *variableList[] = {
-    new DecagonCTD_Cond(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Temp(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new DecagonCTD_Depth(&ctd, "12345678-abcd-1234-ef00-1234567890ab"),
-    new CampbellOBS3_Turbidity(&osb3low, "12345678-abcd-1234-ef00-1234567890ab", "TurbLow"),
-    new CampbellOBS3_Turbidity(&osb3high, "12345678-abcd-1234-ef00-1234567890ab", "TurbHigh"),
-    new ProcessorStats_Battery(&mcuBoard, "12345678-abcd-1234-ef00-1234567890ab"),
-    new MaximDS3231_Temp(&ds3231, "12345678-abcd-1234-ef00-1234567890ab")
+    new DecagonCTD_Cond(&ctd),
+    new DecagonCTD_Temp(&ctd),
+    new DecagonCTD_Depth(&ctd),
+    new CampbellOBS3_Turbidity(&osb3low, "", "TurbLow"),
+    new CampbellOBS3_Turbidity(&osb3high, "", "TurbHigh"),
+    new ProcessorStats_Battery(&mcuBoard),
+    new MaximDS3231_Temp(&ds3231),
 };
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+// Check the order of your variables in the variable list!!!
+// Be VERY certain that they match the order of your UUID's!
+// Rearrange the variables in the variable list if necessary to match!
+// *** CAUTION --- CAUTION --- CAUTION --- CAUTION --- CAUTION ***
+const char *REGISTRATION_TOKEN = "12345678-abcd-1234-ef00-1234567890ab"; // Device registration token
+const char *SAMPLING_FEATURE = "12345678-abcd-1234-ef00-1234567890ab";   // Sampling feature UUID
+const char *UUIDs[] = {
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+    "12345678-abcd-1234-ef00-1234567890ab",
+};
+
 // Count up the number of pointers in the array
 int variableCount = sizeof(variableList) / sizeof(variableList[0]);
 
 // Create the VariableArray object
-VariableArray varArray(variableCount, variableList);
+VariableArray varArray(variableCount, variableList, UUIDs);
 
 
 // ==========================================================================
@@ -145,13 +162,12 @@ VariableArray varArray(variableCount, variableList);
 // Create a new logger instance
 Logger dataLogger(LoggerID, loggingInterval, &varArray);
 
-
 // Device registration and sampling feature information
 // This should be obtained after registration at http://data.envirodiy.org
 // This is needed so the logger file will be "drag-and-drop" ready for manual
 // upload to the portal.
-const char *registrationToken = "12345678-abcd-1234-ef00-1234567890ab";   // Device registration token
-const char *samplingFeature = "12345678-abcd-1234-ef00-1234567890ab";     // Sampling feature UUID
+const char *registrationToken = REGISTRATION_TOKEN; // Device registration token
+const char *samplingFeature = SAMPLING_FEATURE;     // Sampling feature UUID
 
 
 // ==========================================================================
@@ -245,7 +261,7 @@ void setup()
     }
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -449,7 +449,7 @@ void setup()
     modem.modemSleepPowerDown();
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 

--- a/examples/logging_to_MMW/logging_to_MMW.ino
+++ b/examples/logging_to_MMW/logging_to_MMW.ino
@@ -333,7 +333,7 @@ void setup()
     }
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 
@@ -353,7 +353,7 @@ void loop()
         dataLogger.systemSleep();
     }
     // At moderate voltage, log data but don't send it over the modem
-    else if (getBatteryVoltage() < 3.7)
+    else if (getBatteryVoltage() < 3.55)
     {
         dataLogger.logData();
     }

--- a/examples/logging_to_ThingSpeak/logging_to_ThingSpeak.ino
+++ b/examples/logging_to_ThingSpeak/logging_to_ThingSpeak.ino
@@ -349,7 +349,7 @@ void loop()
         dataLogger.systemSleep();
     }
     // At moderate voltage, log data but don't send it over the modem
-    else if (getBatteryVoltage() < 3.7)
+    else if (getBatteryVoltage() < 3.55)
     {
         dataLogger.logData();
     }

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1305,6 +1305,16 @@ Variable *variableList[] = {
     calculatedVar,
 };
 
+// If you would prefer, you can enter all the UUID's separately in one array and
+// then give that array as input to the variable array constructor or run
+// the variable array "matchUUIDs(UUIDs)" function.  Be cautious when doing this
+// though beccause order is CRUCIAL!
+// const char *UUIDs[] = {
+//     "12345678-abcd-1234-ef00-1234567890ab",
+//     ...
+//     "12345678-abcd-1234-ef00-1234567890ab",
+// };
+
 /*
 // FORM2: Fill array with already created and named variable pointers
 // NOTE:  Forms one and two can be mixed
@@ -1325,6 +1335,7 @@ int variableCount = sizeof(variableList) / sizeof(variableList[0]);
 
 // Create the VariableArray object
 VariableArray varArray(variableCount, variableList);
+// VariableArray varArray(variableCount, variableList, UUIDs);
 
 
 // ==========================================================================
@@ -1542,7 +1553,7 @@ void setup()
     }
 
     // Call the processor sleep
-    Serial.println(F("Putting processor to sleep"));
+    Serial.println(F("Putting processor to sleep\n"));
     dataLogger.systemSleep();
 }
 
@@ -1562,7 +1573,7 @@ void loop()
         dataLogger.systemSleep();
     }
     // At moderate voltage, log data but don't send it over the modem
-    else if (getBatteryVoltage() < 3.65)
+    else if (getBatteryVoltage() < 3.55)
     {
         dataLogger.logData();
     }

--- a/library.json
+++ b/library.json
@@ -304,7 +304,7 @@
         {
             "name": "TinyGSM",
             "version": "https://github.com/EnviroDIY/TinyGSM.git",
-            "version_note": "=0.9.17",
+            "version_note": "=0.9.19",
             "note": "A small Arduino library for GPRS modules.",
             "authors": [
                 "Volodymyr Shymanskyy",

--- a/src/LoggerBase.cpp
+++ b/src/LoggerBase.cpp
@@ -1566,10 +1566,10 @@ void Logger::begin()
 
     if (_samplingFeatureUUID != NULL)
     {
-        MS_DBG(F("Sampling feature UUID is:"), _samplingFeatureUUID);
+        PRINTOUT(F("Sampling feature UUID is:"), _samplingFeatureUUID);
     }
 
-    PRINTOUT(F("Logger portion of setup finished."));
+    PRINTOUT(F("Logger portion of setup finished.\n"));
 }
 
 

--- a/src/VariableArray.cpp
+++ b/src/VariableArray.cpp
@@ -18,10 +18,27 @@ VariableArray::VariableArray(uint8_t variableCount, Variable *variableList[])
     _maxSamplestoAverage = countMaxToAverage();
     _sensorCount = getSensorCount();
 }
+VariableArray::VariableArray(uint8_t variableCount, Variable *variableList[], const char *uuids[])
+  : arrayOfVars(variableList), _variableCount(variableCount)
+{
+    _maxSamplestoAverage = countMaxToAverage();
+    _sensorCount = getSensorCount();
+    matchUUIDs(uuids);
+}
+
 // Destructor
 VariableArray::~VariableArray(){}
 
+void VariableArray::VariableArray::begin(uint8_t variableCount, Variable *variableList[], const char *uuids[])
+{
+    _variableCount = variableCount;
+    arrayOfVars = variableList;
 
+    _maxSamplestoAverage = countMaxToAverage();
+    _sensorCount = getSensorCount();
+    matchUUIDs(uuids);
+    checkVariableUUIDs();
+}
 void VariableArray::begin(uint8_t variableCount, Variable *variableList[])
 {
     _variableCount = variableCount;
@@ -65,6 +82,15 @@ uint8_t VariableArray::getSensorCount(void)
     return numSensors;
 }
 
+// This matches UUID's from an array of pointers to the variable array
+void VariableArray::matchUUIDs(const char *uuids[])
+{
+    for (uint8_t i = 0; i < _variableCount; i++)
+    {
+        arrayOfVars[i]->setVarUUID(uuids[i]);
+        // MS_DBG(F("Assigned UUID"), uuids[i], F("to variable"), arrayOfVars[i]->getVarCode());
+    }
+}
 
 // Public functions for interfacing with a list of sensors
 // This sets up all of the sensors in the list
@@ -935,6 +961,13 @@ bool VariableArray::checkVariableUUIDs(void)
             }
         }
     }
-    if (success) PRINTOUT(F("All variable UUID's appear to be correctly formed."));
+    if (success)
+        PRINTOUT(F("All variable UUID's appear to be correctly formed.\n"));
+    // Print out all UUID's to check
+    for (uint8_t i = 0; i < _variableCount; i++)
+    {
+        PRINTOUT(arrayOfVars[i]->getVarUUID(), F("->"), arrayOfVars[i]->getVarCode());
+    }
+    PRINTOUT(' ');
     return success;
 }

--- a/src/VariableArray.h
+++ b/src/VariableArray.h
@@ -37,6 +37,7 @@ public:
     // Constructors
     VariableArray();
     VariableArray(uint8_t variableCount, Variable *variableList[]);
+    VariableArray(uint8_t variableCount, Variable *variableList[], const char *uuids[]);
     ~VariableArray();
 
     // "Begins" the VariableArray - attaches the number and array of variables
@@ -47,6 +48,7 @@ public:
     // actually have been created unless we wait until in the setup or loop
     // function of the main program.
     void begin(uint8_t variableCount, Variable *variableList[]);
+    void begin(uint8_t variableCount, Variable *variableList[], const char *uuids[]);
     void begin();
 
     // Leave the internal variable list public
@@ -62,6 +64,9 @@ public:
 
     // This counts and returns the number of sensors
     uint8_t getSensorCount(void);
+
+    // This matches UUID's from an array of pointers to the variable array
+    void matchUUIDs(const char *uuids[]);
 
     // Public functions for interfacing with a list of sensors
     // This sets up all of the sensors in the list


### PR DESCRIPTION
Allows copy-pasting all UUID's from the box on monitor my watershed again - I'm not really sure why I didn't implement this earlier, other than that I wasn't deploying many stations and hadn't reached a critical level of annoyance at the amount of clicking and copy pasting.