### PR TITLE
version bump to 0.25.1 & change to SDI-12

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = ModularSensors
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.25.0
+PROJECT_NUMBER         = 0.25.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "EnviroDIY_ModularSensors",
-    "version": "0.25.0",
+    "version": "0.25.1",
     "description": "A library that allows access to multiple sensors through a unified interface.  This allows the user to simply access many sensors to log the data or send the data to data repositories like the EnviroDIY data portal.",
     "keywords": "modular, sensor, sensors, datalogger, logger, low power, sleeping, EnviroDIY, ModularSensors, Mayfly, WikiWatershed, Monitor My Watershed, ThingSpeak",
     "platforms": "atmelavr, atmelsam",
@@ -222,11 +222,11 @@
             "frameworks": "arduino"
         },
         {
-            "name": "Arduino-SDI-12",
+            "name": "SDI-12",
             "library id": "1486",
-            "version": "=1.3.6",
+            "version": "=2.1.0",
             "url": "https://github.com/EnviroDIY/Arduino-SDI-12.git",
-            "note": "EnviroDIY SDI-12 Library",
+            "note": "EnviroDIY SDI-12 Library for Arduino",
             "authors": [
                 "Kevin M. Smith",
                 "Sara Damiano",
@@ -296,7 +296,7 @@
         {
             "name": "TinyGSM",
             "version": "https://github.com/EnviroDIY/TinyGSM.git",
-            "version_note": "=0.9.19",
+            "version_note": "=0.10.6",
             "note": "A small Arduino library for GPRS modules.",
             "authors": [
                 "Volodymyr Shymanskyy",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=EnviroDIY_ModularSensors
-version=0.25.0
+version=0.25.1
 author=Sara Damiano <sdamiano@stroudcenter.org>, Shannon Hicks <shicks@stroudcenter.org>
 maintainer=Sara Damiano <sdamiano@stroudcenter.org>
 sentence=A library that allows access to multiple sensors through a unified interface.

--- a/src/ModSensorDebugger.h
+++ b/src/ModSensorDebugger.h
@@ -22,7 +22,7 @@
 /**
  * @brief The current library version number
  */
-#define MODULAR_SENSORS_VERSION "0.25.0"
+#define MODULAR_SENSORS_VERSION "0.25.1"
 
 #ifndef STANDARD_SERIAL_OUTPUT
 // #if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)


### PR DESCRIPTION
@srgdamia1, master won't build from scratch, given the change in the SDI-12 library name with https://github.com/EnviroDIY/Arduino-SDI-12/commit/1c5fe812d870cef1fadc8b0534b50c3a222ebe89 and https://github.com/EnviroDIY/Arduino-SDI-12/releases/tag/v2.1.0
Bumping version to get a new entry with PIO Library registry.