### PR TITLE
Add sensor to read Insitu Level Troll series depth gauges

### DIFF
--- a/examples/test_lt500/.gitignore
+++ b/examples/test_lt500/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/examples/test_lt500/platformio.ini
+++ b/examples/test_lt500/platformio.ini
@@ -1,0 +1,43 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+description = ModularSensors example logging data to an SD card
+
+[env:mayfly]
+monitor_speed = 115200
+board = mayfly
+platform = atmelavr
+framework = arduino
+lib_ldf_mode = deep+
+lib_ignore =
+    RTCZero
+    Adafruit NeoPixel
+    Adafruit GFX Library
+    Adafruit SSD1306
+    Adafruit ADXL343
+    Adafruit STMPE610
+    Adafruit TouchScreen
+    Adafruit ILI9341
+build_flags =
+    -DSDI12_EXTERNAL_PCINT
+    -DNEOSWSERIAL_EXTERNAL_PCINT
+    -DMQTT_MAX_PACKET_SIZE=240
+    -DTINY_GSM_RX_BUFFER=64
+    -DTINY_GSM_YIELD_MS=2
+lib_deps =
+    ;envirodiy/EnviroDIY_ModularSensors
+;  ^^ Use this when working from an official release of the library
+    https://github.com/EnviroDIY/ModularSensors.git#develop
+;  ^^ Use this when if you want to pull from the develop branch
+    https://github.com/PaulStoffregen/AltSoftSerial.git
+    https://github.com/SRGDamia1/NeoSWSerial.git
+    https://github.com/EnviroDIY/SoftwareSerial_ExternalInts.git
+;  ^^ These are software serial port emulator libraries, you may not need them

--- a/examples/test_lt500/src/simple_logging.cpp
+++ b/examples/test_lt500/src/simple_logging.cpp
@@ -1,0 +1,227 @@
+/** =========================================================================
+ * @file simple_logging.ino
+ * @brief A simple data logging example.
+ *
+ * @author Sara Geleskie Damiano <sdamiano@stroudcenter.org>
+ * @copyright (c) 2017-2020 Stroud Water Research Center (SWRC)
+ *                          and the EnviroDIY Development Team
+ *            This example is published under the BSD-3 license.
+ *
+ * Build Environment: Visual Studios Code with PlatformIO
+ * Hardware Platform: EnviroDIY Mayfly Arduino Datalogger
+ *
+ * DISCLAIMER:
+ * THIS CODE IS PROVIDED "AS IS" - NO WARRANTY IS GIVEN.
+ * ======================================================================= */
+
+// ==========================================================================
+//  Include the libraries required for any data logger
+// ==========================================================================
+/** Start [includes] */
+// The Arduino library is needed for every Arduino program.
+#include <Arduino.h>
+
+// EnableInterrupt is used by ModularSensors for external and pin change
+// interrupts and must be explicitly included in the main program.
+#include <EnableInterrupt.h>
+
+// Include the main header for ModularSensors
+#include <ModularSensors.h>
+/** End [includes] */
+
+
+// ==========================================================================
+//  Data Logging Options
+// ==========================================================================
+/** Start [logging_options] */
+// The name of this program file
+const char* sketchName = "simple_logging.ino";
+// Logger ID, also becomes the prefix for the name of the data file on SD card
+const char* LoggerID = "XXXXX";
+// How frequently (in minutes) to log data
+const uint8_t loggingInterval = 5;
+// Your logger's timezone.
+const int8_t timeZone = -5;  // Eastern Standard Time
+// NOTE:  Daylight savings time will not be applied!  Please use standard time!
+
+// Set the input and output pins for the logger
+// NOTE:  Use -1 for pins that do not apply
+const int32_t serialBaud = 115200;  // Baud rate for debugging
+const int8_t  greenLED   = 8;       // Pin for the green LED
+const int8_t  redLED     = 9;       // Pin for the red LED
+const int8_t  buttonPin  = 21;      // Pin for debugging mode (ie, button pin)
+const int8_t  wakePin    = 31;  // MCU interrupt/alarm pin to wake from sleep
+// Mayfly 0.x D31 = A7
+// Set the wake pin to -1 if you do not want the main processor to sleep.
+// In a SAMD system where you are using the built-in rtc, set wakePin to 1
+const int8_t sdCardPwrPin   = -1;  // MCU SD card power pin
+const int8_t sdCardSSPin    = 12;  // SD card chip select/slave select pin
+const int8_t sensorPowerPin = 22;  // MCU pin controlling main sensor power
+/** End [logging_options] */
+
+
+// ==========================================================================
+//  Using the Processor as a Sensor
+// ==========================================================================
+/** Start [processor_sensor] */
+#include <sensors/ProcessorStats.h>
+
+// Create the main processor chip "sensor" - for general metadata
+const char*    mcuBoardVersion = "v0.5b";
+ProcessorStats mcuBoard(mcuBoardVersion);
+/** End [processor_sensor] */
+
+
+// ==========================================================================
+//    Insitu Aqua/Level Troll Pressure, Temperature, and Depth Sensor
+// ==========================================================================
+#include <sensors/InsituTrollSdi12a.h>
+
+const char*   ITROLLSDI12address   = "1";  // SDI12 Address ITROLL
+const uint8_t ITROLLNumberReadings = 2;    // The number of readings to average
+const int8_t  IT_SDI12Power =
+    sensorPowerPin;  // Pin to switch power on and off (-1 if unconnected)
+const int8_t IT_SDI12Data = 7;  // The SDI12 data pin
+
+// Create a  ITROLL sensor object
+InsituTrollSdi12a itrollPhy(*ITROLLSDI12address, IT_SDI12Power, IT_SDI12Data,
+                           ITROLLNumberReadings);
+
+// ==========================================================================
+//  Maxim DS3231 RTC (Real Time Clock)
+// ==========================================================================
+/** Start [ds3231] */
+#include <sensors/MaximDS3231.h>  // Includes wrapper functions for Maxim DS3231 RTC
+
+// Create a DS3231 sensor object, using this constructor function:
+MaximDS3231 ds3231(1);
+/** End [ds3231] */
+
+
+// ==========================================================================
+//    Settings for Additional Sensors
+// ==========================================================================
+// Additional sensors can setup here, similar to the RTC, but only if
+//   they have been supported with ModularSensors wrapper functions. See:
+//   https://github.com/EnviroDIY/ModularSensors/wiki#just-getting-started
+// Syntax for the include statement and constructor function for each sensor is
+// at
+//   https://github.com/EnviroDIY/ModularSensors/wiki#these-sensors-are-currently-supported
+//   or can be copied from the `menu_a_la_carte.ino` example
+
+
+// ==========================================================================
+//  Creating the Variable Array[s] and Filling with Variable Objects
+// ==========================================================================
+/** Start [variable_arrays] */
+Variable* variableList[] = {
+    new InsituTrollSdi12a_Depth(&itrollPhy),
+    new InsituTrollSdi12a_Temp(&itrollPhy),
+    new ProcessorStats_SampleNumber(&mcuBoard),
+    new ProcessorStats_FreeRam(&mcuBoard),
+    new ProcessorStats_Battery(&mcuBoard), new MaximDS3231_Temp(&ds3231),
+    
+    // Additional sensor variables can be added here, by copying the syntax
+    //   for creating the variable pointer (FORM1) from the
+    //   `menu_a_la_carte.ino` example
+    // The example code snippets in the wiki are primarily FORM2.
+};
+// Count up the number of pointers in the array
+int variableCount = sizeof(variableList) / sizeof(variableList[0]);
+
+// Create the VariableArray object
+VariableArray varArray;
+/** End [variable_arrays] */
+
+
+// ==========================================================================
+//  The Logger Object[s]
+// ==========================================================================
+/** Start [loggers] */
+// Create a logger instance
+Logger dataLogger;
+/** End [loggers] */
+
+
+// ==========================================================================
+//  Working Functions
+// ==========================================================================
+/** Start [working_functions] */
+// Flashes the LED's on the primary board
+void greenredflash(uint8_t numFlash = 4, uint8_t rate = 75) {
+    for (uint8_t i = 0; i < numFlash; i++) {
+        digitalWrite(greenLED, HIGH);
+        digitalWrite(redLED, LOW);
+        delay(rate);
+        digitalWrite(greenLED, LOW);
+        digitalWrite(redLED, HIGH);
+        delay(rate);
+    }
+    digitalWrite(redLED, LOW);
+}
+/** End [working_functions] */
+
+
+// ==========================================================================
+//  Arduino Setup Function
+// ==========================================================================
+/** Start [setup] */
+void setup() {
+    // Start the primary serial connection
+    Serial.begin(serialBaud);
+
+    // Print a start-up note to the first serial port
+    Serial.print(F("Now running "));
+    Serial.print(sketchName);
+    Serial.print(F(" on Logger "));
+    Serial.println(LoggerID);
+    Serial.println();
+
+    Serial.print(F("Using ModularSensors Library version "));
+    Serial.println(MODULAR_SENSORS_VERSION);
+
+    // Set up pins for the LED's
+    pinMode(greenLED, OUTPUT);
+    digitalWrite(greenLED, LOW);
+    pinMode(redLED, OUTPUT);
+    digitalWrite(redLED, LOW);
+    // Blink the LEDs to show the board is on and starting up
+    greenredflash();
+
+    // Set the timezones for the logger/data and the RTC
+    // Logging in the given time zone
+    Logger::setLoggerTimeZone(timeZone);
+    // It is STRONGLY RECOMMENDED that you set the RTC to be in UTC (UTC+0)
+    Logger::setRTCTimeZone(0);
+
+    // Set information pins
+    dataLogger.setLoggerPins(wakePin, sdCardSSPin, sdCardPwrPin, buttonPin,
+                             greenLED);
+
+    // Begin the variable array[s], logger[s], and publisher[s]
+    varArray.begin(variableCount, variableList);
+    dataLogger.begin(LoggerID, loggingInterval, &varArray);
+
+    // Set up the sensors
+    Serial.println(F("Setting up sensors..."));
+    varArray.setupSensors();
+
+    // Create the log file, adding the default header to it
+    // Do this last so we have the best chance of getting the time correct and
+    // all sensor names correct
+    dataLogger.createLogFile(true);  // true = write a new header
+
+    // Call the processor sleep
+    dataLogger.systemSleep();
+}
+/** End [setup] */
+
+
+// ==========================================================================
+//  Arduino Loop Function
+// ==========================================================================
+/** Start [loop] */
+void loop() {
+    dataLogger.logData();
+}
+/** End [loop] */

--- a/src/sensors/InsituTrollSdi12a.h
+++ b/src/sensors/InsituTrollSdi12a.h
@@ -1,0 +1,384 @@
+/*
+ * @file InsituTrollSdi12a.h
+ * @copyright 2020 Stroud Water Research Center
+ * Part of the EnviroDIY modular sensors
+ * @author Neil Hancock  https://github.com/neilh10/ModularSensors/
+ * @author Sara Geleskie Damiano <sdamiano@stroudcenter.org>
+ *
+ * @brief Contains the InsituTrollSdi12a subclass of the SDI12Sensors class
+ * along with the variable subclasses InsituTrollSdi12a_Pressure,
+ * InsituTrollSdi12a_Temp, and InsituTrollSdi12a_Depth
+ *
+ * These are used for the Insitu Troll.
+ * The order and units are the default settings for the ITROLL
+ *
+ * This depends on the EnviroDIY SDI-12 library and the SDI12Sensors super
+ * class.
+ *
+ */
+/* clang-format off */
+/**
+ * @defgroup sensor_instutroll Insitu LevelTroll 400 500 700
+ * Classes for the Insitru LevelTroll feature sensors  pressure, temperature, and depth.
+ * 
+ * @ingroup sdi12_group
+ *
+ * @tableofcontents
+ * @m_footernavigation
+ *
+ * @section sensor_instutroll_intro Introduction
+ *
+ * > A slim 1.8 cm diameter sensor, 
+ * > depth measuremente temperature compensated to 0.1% (0.05%) across Full Scale depth range and across temperature range. 
+ * >
+ * > Has an internal logger for reliable data collection.
+ * >
+ * > Reports sensor serial number and model in uSD .csv file
+
+ *
+ * The Insitu Aqua/Level Troll require 8-36VDC
+ * This can be achieved a Polo #boost device, instructions are at the end
+ *
+ * @warning Coming from the factory, Troll sensors are set at SDI-12 address '0'.
+ *
+ * The Insitu Aqua/Level Trolls are programmed through WinSitu.
+ * 
+ * The SDI address needs to be changed to what the class is set to - default is '1'.
+ *
+ * Parameters are very flexible and need to be aligned used WinSitu with this module.
+ * 
+ * The depth sensor third paramter may need to be created. The expected
+ * paramters and order are Pressure (PSI),  Temperature (C),  Depth (ft). 
+ *
+ * Tested with Level Troll 500.
+ * 
+ * @section sensor_instutroll_datasheet Sensor Datasheet
+ * Documentation for the SDI-12 Protocol commands and responses
+ * The Insitu Level/Aqua Troll can be found at:
+ * 
+ * https://in-situ.com/en/pub/media/support/documents/SDI-12_Commands_Tech_Note.pdf
+ * 
+ * https://in-situ.com/us/support/documents/sdi-12-commands-and-level-troll-400500700-responses
+ *
+ * @section sensor_instutroll_flags Build flags
+ * @see @ref sdi12_group_flags
+ *
+ * @menusnip{instutroll}
+ */
+/* clang-format on */
+
+// Header Guards
+#ifndef SRC_SENSORS_INSITUTROLLSDI12_H_
+#define SRC_SENSORS_INSITUTROLLSDI12_H_
+
+// Included Dependencies
+#include "sensors/SDI12Sensors.h"
+
+// Sensor Specific Defines
+/** @ingroup sensor_insitutroll */
+/**@{*/
+/// @brief Sensor::_numReturnedValues; the Troll 500 can report 3 values.
+#define ITROLLA_NUM_VARIABLES 3
+
+/**
+ * @anchor sensor_insitutroll_timing
+ * @name Sensor Timing
+ * The sensor timing for a Insitu Troll
+ */
+/**@{*/
+/// @brief Sensor::_warmUpTime_ms; maximum warm-up time in SDI-12 mode: 500ms
+#define ITROLLA_WARM_UP_TIME_MS 500
+
+
+/// @brief Sensor::_stabilizationTime_ms; the Troll 500 is stable as soon as it
+/// warms up (0ms stabilization).
+#define ITROLLA_STABILIZATION_TIME_MS 0
+
+/// @brief Sensor::_measurementTime_ms; maximum measurement duration: 500ms.
+#define ITROLLA_MEASUREMENT_TIME_MS 500
+
+/**
+ * @anchor sensor_insitutroll_pressure
+ * @name Pressure
+ * The pressue variable from a Insitu Troll
+ * - Range is 0 – x (depends on range eg 5psig)
+
+ *
+ * {{ @ref InsituTrollSdi12a_Pressure::InsituTrollSdi12a_Pressure }}
+ */
+/**@{*/
+/**
+ * @brief Decimals places in string representation; conductivity should have 1.
+ *
+ * 0 are reported, adding extra digit to resolution to allow the proper number
+ * of significant figures for averaging - resolution is 0.001 mS/cm = 1 µS/cm
+ */
+#define ITROLLA_PRESSURE_RESOLUTION 5
+/// @brief Sensor variable number; pressure is stored in sensorValues[0].
+#define ITROLLA_PRESSURE_VAR_NUM 0
+/// @brief Variable name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/variablename/);
+/// "specificConductance"
+#define ITROLLA_PRESSURE_VAR_NAME "pressureGauge"
+/// @brief Variable unit name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/units/);
+/// "pounds per square inch" (psi)
+#define ITROLLA_PRESSURE_UNIT_NAME "psi"
+/// @brief Default variable short code; "ITROLLpressure"
+#define ITROLLA_PRESSURE_DEFAULT_CODE "ITROLLpressure"
+/**@}*/
+
+/**
+ * @anchor sensor_insitutroll_temp
+ * @name Temperature
+ * The temperature variable from a Insitu Troll
+ * - Range is -11°C to +49°C
+ * - Accuracy is ±1°C
+ *
+ * {{ @ref InsituTrollSdi12a_Temp::InsituTrollSdi12a_Temp }}
+ */
+/**@{*/
+/**
+ * @brief Decimals places in string representation; temperature should have 2.
+ *
+ * 1 is reported, adding extra digit to resolution to allow the proper number
+ * of significant figures for averaging  - resolution is 0.1°C
+ */
+#define ITROLLA_TEMP_RESOLUTION 2
+/// @brief Sensor variable number; temperature is stored in sensorValues[1].
+#define ITROLLA_TEMP_VAR_NUM 1
+/// @brief Variable name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/variablename/);
+/// "temperature"
+#define ITROLLA_TEMP_TEMP_VAR_NAME "temperature"
+/// @brief Variable unit name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/units/);
+/// "degreeCelsius" (°C)
+#define ITROLLA_TEMP_TEMP_UNIT_NAME "degreeCelsius"
+/// @brief Default variable short code; "ITROLLtemp"
+#define ITROL_TEMP_DEFAULT_CODE "ITROLLtemp"
+/**@}*/
+
+/**
+ * @anchor sensor_insitutroll_depth
+ * @name Water Depth
+ * The water depth variable from a Insitu Troll
+ * - Range is 0 to 3.5m to 350m depending on model
+ * - Accuracy is ±0.05% of full scale
+ *
+ * {{ @ref InsituTrollSdi12a_Depth::InsituTrollSdi12a_Depth }}
+ */
+/**@{*/
+/**
+ * @brief Decimals places in string representation; depth should have 1.
+ *
+ * 0 are reported, adding extra digit to resolution to allow the proper number
+ * of significant figures for averaging - resolution is 2 mm
+ */
+#define ITROLLA_DEPTH_RESOLUTION 5
+/// @brief Sensor variable number; depth is stored in sensorValues[2].
+#define ITROLLA_DEPTH_VAR_NUM 2
+/// @brief Variable name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/variablename/);
+/// "waterDepth"
+#define ITROLLA_DEPTH_VAR_NAME "waterDepth"
+/// @brief Variable unit name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/units/);
+/// "millimeter"
+#define ITROLLA_DEPTH_UNIT_NAME "feet"
+/// @brief Default variable short code; "ITROLLdepth"
+#define ITROLLA_DEPTH_DEFAULT_CODE "ITROLLdepth"
+/**@}*/
+
+
+/* clang-format off */
+/**
+ * @brief The Sensor sub-class for the
+ * [Insitu Level/Aqua Troll pressure, temperature, and depth sensor](@ref sensor_insitutroll)
+ *
+ * @ingroup sensor_insitutroll
+ */
+/* clang-format on */
+
+class InsituTrollSdi12a : public SDI12Sensors {
+ public:
+    // Constructors with overloads
+    /**
+     * @brief Construct a new ITROLL object.
+     *
+     * The SDI-12 address of the sensor, the Arduino pin controlling power
+     * on/off, and the Arduino pin sending and receiving data are required for
+     * the sensor constructor.  Optionally, you can include a number of distinct
+     * readings to average.  The data pin must be a pin that supports pin-change
+     * interrupts.
+     *
+     * @param SDI12address The SDI-12 address; can be a char,
+     * char*, or int.
+     * @warning The SDI-12 address **must** be changed from the factory
+     * programmed value of "0" before the sensor can be used with
+     * ModularSensors!
+     * @param powerPin The pin on the mcu controlling power to the sensor.
+     * Use -1 if it is continuously powered.
+     * - The ITROLL requires a power supply, which can be turned off
+     * between measurements
+     * @param dataPin The pin on the mcu connected to the data line of the
+     * SDI-12 circuit.
+     * @param measurementsToAverage The number of measurements to take and
+     * average before giving a "final" result from the sensor; optional with a
+     * default value of 1.
+     */
+    InsituTrollSdi12a(char SDI12address, int8_t powerPin, int8_t dataPin,
+                      uint8_t measurementsToAverage = 1)
+        : SDI12Sensors(SDI12address, powerPin, dataPin, measurementsToAverage,
+                       "InsituTrollSdi12a", ITROLLA_NUM_VARIABLES,
+                       ITROLLA_WARM_UP_TIME_MS, ITROLLA_STABILIZATION_TIME_MS,
+                       ITROLLA_MEASUREMENT_TIME_MS) {}
+    InsituTrollSdi12a(char* SDI12address, int8_t powerPin, int8_t dataPin,
+                      uint8_t measurementsToAverage = 1)
+        : SDI12Sensors(SDI12address, powerPin, dataPin, measurementsToAverage,
+                       "InsituTrollSdi12a", ITROLLA_NUM_VARIABLES,
+                       ITROLLA_WARM_UP_TIME_MS, ITROLLA_STABILIZATION_TIME_MS,
+                       ITROLLA_MEASUREMENT_TIME_MS) {}
+    InsituTrollSdi12a(int SDI12address, int8_t powerPin, int8_t dataPin,
+                      uint8_t measurementsToAverage = 1)
+        : SDI12Sensors(SDI12address, powerPin, dataPin, measurementsToAverage,
+                       "InsituTrollSdi12a", ITROLLA_NUM_VARIABLES,
+                       ITROLLA_WARM_UP_TIME_MS, ITROLLA_STABILIZATION_TIME_MS,
+                       ITROLLA_MEASUREMENT_TIME_MS) {}
+    /**
+     * @brief Destroy the ITROL object
+     */
+    ~InsituTrollSdi12a() {}
+};
+
+
+/* clang-format off */
+/**
+ * @brief The Variable sub-class used for the
+ * [pressure output](@ref sensor_insitutroll_pressure) from a
+ * [Insitu Troll 3-in-1 water level sensor.](@ref sensor_insitutroll)
+ *
+ * @ingroup sensor_insitutroll
+ */
+/* clang-format on */
+class InsituTrollSdi12a_Pressure : public Variable {
+ public:
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Pressure object.
+     *
+     * @param parentSense The parent InsituTrollSdi12a providing values.
+     * @param uuid A universally unique identifier (UUID or GUID) for the
+     * variable; optional with the default value of an empty string.
+     * @param varCode A short code to help identify the variable in files;
+     * optional with a default value of "ITROLLPressure".
+     */
+    InsituTrollSdi12a_Pressure(
+        Sensor* parentSense, const char* uuid = "",
+        const char* varCode = ITROLLA_PRESSURE_DEFAULT_CODE)
+        : Variable(parentSense, (const uint8_t)ITROLLA_PRESSURE_VAR_NUM,
+                   (uint8_t)ITROLLA_PRESSURE_RESOLUTION,
+                   ITROLLA_PRESSURE_VAR_NAME, ITROLLA_PRESSURE_UNIT_NAME,
+                   varCode, uuid) {}
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Pressure object.
+     *
+     * @note This must be tied with a parent InsituTrollSdi12a before it can be
+     * used.
+     */
+    InsituTrollSdi12a_Pressure()
+        : Variable((const uint8_t)ITROLLA_PRESSURE_VAR_NUM,
+                   (uint8_t)ITROLLA_PRESSURE_RESOLUTION,
+                   ITROLLA_PRESSURE_VAR_NAME, ITROLLA_PRESSURE_UNIT_NAME,
+                   ITROLLA_PRESSURE_DEFAULT_CODE) {}
+    /**
+     * @brief Destroy the InsituTrollSdi12a_Pressure object - no action needed.
+     */
+    ~InsituTrollSdi12a_Pressure() {}
+};
+
+
+/* clang-format off */
+/**
+ * @brief The Variable sub-class used for the
+ * [temperature Output](@ref sensor_insitutroll_temp) from a
+ * [Insitu Troll 3-in-1 water level sensor.](@ref sensor_insitutroll)
+ *
+ * @ingroup sensor_insitutroll
+ */
+/* clang-format on */
+class InsituTrollSdi12a_Temp : public Variable {
+ public:
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Temp object.
+     *
+     * @param parentSense The parent InsituTrollSdi12a providing the values.
+     * @param uuid A universally unique identifier (UUID or GUID) for the
+     * variable; optional with the default value of an empty string.
+     * @param varCode A short code to help identify the variable in files;
+     * optional with a default value of "ITROLLtemp".
+     */
+    InsituTrollSdi12a_Temp(Sensor* parentSense, const char* uuid = "",
+                           const char* varCode = ITROL_TEMP_DEFAULT_CODE)
+        : Variable(parentSense, (const uint8_t)ITROLLA_TEMP_VAR_NUM,
+                   (uint8_t)ITROLLA_TEMP_RESOLUTION, ITROLLA_TEMP_TEMP_VAR_NAME,
+                   ITROLLA_TEMP_TEMP_UNIT_NAME, varCode, uuid) {}
+
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Temp object.
+     *
+     * @note This must be tied with a parent InsituTrollSdi12a before it can be
+     * used.
+     */
+    InsituTrollSdi12a_Temp()
+        : Variable((const uint8_t)ITROLLA_TEMP_VAR_NUM,
+                   (uint8_t)ITROLLA_TEMP_RESOLUTION, ITROLLA_TEMP_TEMP_VAR_NAME,
+                   ITROLLA_TEMP_TEMP_UNIT_NAME, ITROL_TEMP_DEFAULT_CODE) {}
+    /**
+     * @brief Destroy the InsituTrollSdi12a_Temp object - no action needed.
+     */
+    ~InsituTrollSdi12a_Temp() {}
+};
+
+
+/* clang-format off */
+/**
+ * @brief The Variable sub-class used for the
+ * [depth output](@ref sensor_insitutroll_depth) from a
+ * [Insitu Troll 3-in-1 water level sensor.](@ref sensor_insitutroll)
+ *
+ * @ingroup sensor_insitutroll
+ */
+/* clang-format on */
+class InsituTrollSdi12a_Depth : public Variable {
+ public:
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Depth object.
+     *
+     * @param parentSense The parent InsituTrollSdi12a providing the values.
+     * @param uuid A universally unique identifier (UUID or GUID) for the
+     * variable; optional with the default value of an empty string.
+     * @param varCode A short code to help identify the variable in files;
+     * optional with a default value of "ITROLLdepth".
+     */
+    InsituTrollSdi12a_Depth(Sensor* parentSense, const char* uuid = "",
+                            const char* varCode = ITROLLA_DEPTH_DEFAULT_CODE)
+        : Variable(parentSense, (const uint8_t)ITROLLA_DEPTH_VAR_NUM,
+                   (uint8_t)ITROLLA_DEPTH_RESOLUTION, ITROLLA_DEPTH_VAR_NAME,
+                   ITROLLA_DEPTH_UNIT_NAME, varCode, uuid) {}
+    /**
+     * @brief Construct a new InsituTrollSdi12a_Depth object.
+     *
+     * @note This must be tied with a parent InsituTrollSdi12a before it can be
+     * used.
+     */
+    InsituTrollSdi12a_Depth()
+        : Variable((const uint8_t)ITROLLA_DEPTH_VAR_NUM,
+                   (uint8_t)ITROLLA_DEPTH_RESOLUTION, ITROLLA_DEPTH_VAR_NAME,
+                   ITROLLA_DEPTH_UNIT_NAME, ITROLLA_DEPTH_DEFAULT_CODE) {}
+    /**
+     * @brief Destroy the InsituTrollSdi12a_Depth object - no action needed.
+     */
+    ~InsituTrollSdi12a_Depth() {}
+};
+/**@}*/
+#endif  // SRC_SENSORS_INSITUTROLLSDI12_H_


### PR DESCRIPTION
This adds a sensor   src/sensors/InsituTrollSdi12a.h
This has been tested against an Insitu LT500 depth gauge.

It also includes a test build   examples/test_lt500/ to check it builds, using simple logging as a base.  This is expected to be deleted or the example moved to another file.

I have run a clang on it so it hopefully meets all those requirements
I've run doxygen on it, so it at looks attractive, and I thinks the output makes sense.  However this was referencing it to hydros 21, and I don't follow how doxygen pulls it all together. Seems to work though.

I really appreciate the core support of the @SRGDamia1 of Stroud Water Research Center, and assign all copyrights to Stroud Water Research Center.