### PR TITLE
Add Alphasense CO2 Sensors; Redirect ADS1X15 dependency to Adafruit

### DIFF
--- a/library.json
+++ b/library.json
@@ -148,13 +148,13 @@
     },
     {
       "name": "Adafruit ADS1X15",
-      "library id": "344",
-      "version_note": "=1.2.0",
-      "version": "https://github.com/soligen2010/Adafruit_ADS1X15.git#7d67b451f739e9a63f40f2d6d139ab582258572b",
-      "note": "Driver for TI's ADS1015: 12-bit Differential or Single-Ended ADC with PGA and Comparator.  This fork removes bugs in the Adafruit original library.",
-      "authors_note": ["soligen2010"],
-      "frameworks_note": "arduino",
-      "platforms_note": "*"
+      "owner": "adafruit",
+      "url": "https://github.com/adafruit/Adafruit_ADS1X15",
+      "version": "~2.4.2",
+      "note": "Driver for TI's ADS1X15: 12 and 16-bit Differential or Single-Ended ADC with PGA and Comparator.",
+      "authors": ["Adafruit"],
+      "frameworks": "arduino",
+      "platforms": "atmelavr, atmelsam"
     },
     {
       "name": "Adafruit AM2315",

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file AlphasenseCO2.cpp
+ * @copyright 2017-2022 Stroud Water Research Center
+ * Part of the EnviroDIY ModularSensors library for Arduino
+ * @copyright 2017-2023 Stroud Water Research Center
+ * Part of the EnviroDIY ModularSensors library for Arduino
+ * @author Written by Anthony Aufdenkampe <aaufdenkampe@limno.com>
+ * and Bella Henkel <bella.henkel@mnsu.edu>
+ * Adapted from ApogeeSQ212.h and https://github.com/bellahenkel/Soil-Sensing-Device
+ *
+ * @brief Implements the AlphasenseCO2 class.
+ */
+
+
+#include "AlphasenseCO2.h"
+#include <Adafruit_ADS1X15.h>
+
+
+// The constructor - need the power pin and the data pin
+AlphasenseCO2::AlphasenseCO2(int8_t powerPin,
+                         uint8_t i2cAddress, uint8_t measurementsToAverage)
+    : Sensor("AlphasenseCO2", ALPHASENSE_CO2_NUM_VARIABLES, ALPHASENSE_CO2_WARM_UP_TIME_MS,
+             ALPHASENSE_CO2_STABILIZATION_TIME_MS, ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin,
+             -1, measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
+      _i2cAddress(i2cAddress) {}
+
+// Destructor
+AlphasenseCO2::~AlphasenseCO2() {}
+
+
+String AlphasenseCO2::getSensorLocation(void) {
+#ifndef MS_USE_ADS1015
+    String sensorLocation = F("ADS1115_0x");
+#else
+    String sensorLocation = F("ADS1015_0x");
+#endif
+    sensorLocation += String(_i2cAddress, HEX);
+    sensorLocation += F("; differential between channels 2 and 3");
+    return sensorLocation;
+}
+
+
+bool AlphasenseCO2::addSingleMeasurementResult(void) {
+    // Variables to store the results in
+    int16_t adcCounts = -9999;
+    float adcVoltage  = -9999;
+    float co2Current  = -9999;
+    float calibResult = -9999;
+
+    // Check a measurement was *successfully* started (status bit 6 set)
+    // Only go on to get a result if it was
+    if (bitRead(_sensorStatus, 6)) {
+        MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+// Create an Auxillary ADD object
+// We create and set up the ADC object here so that each sensor using
+// the ADC may set the gain appropriately without effecting others.
+#ifndef MS_USE_ADS1015
+        Adafruit_ADS1115 ads;  // Use this for the 16-bit version
+#else
+        Adafruit_ADS1015 ads(_i2cAddress);  // Use this for the 12-bit version
+#endif
+        // ADS Library default settings:
+        //  - TI1115 (16 bit)
+        //    - single-shot mode (powers down between conversions)
+        //    - 128 samples per second (8ms conversion time)
+        //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+        //  - TI1015 (12 bit)
+        //    - single-shot mode (powers down between conversions)
+        //    - 1600 samples per second (625µs conversion time)
+        //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+
+        // Bump the gain up to 1x = +/- 4.096V range
+        // Sensor return range is 0-2.5V, but the next gain option is 2x which
+        // only allows up to 2.048V
+        ads.setGain(GAIN_ONE);
+        // Begin ADC
+        ads.begin(_i2cAddress);
+
+        // Read Analog to Digital Converter (ADC)
+        // Taking this reading includes the 8ms conversion delay.
+        // We're allowing the ADS1115 library to do the bit-to-volts conversion
+        // for us
+        // Measure the voltage difference across two pins from the CO2 sensor
+        adcCounts = ads.readADC_Differential_2_3();
+        // Convert ADC counts value to voltage (V)
+        adcVoltage = ads.computeVolts(adcCounts)
+        MS_DBG(F("  ads.readADC_Differential_2_3() converted to volts:"), 
+               adcVoltage);
+        
+
+        if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+            // Skip results out of range
+            // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in series
+            co2Current = (adcVoltage / 250) * 1000;
+            // Convert current to ppm (using a formula recommended by the sensor manufacturer)
+            calibResult = 312.5 * co2Current - 1250;
+            MS_DBG(F("  calibResult:"), calibResult);
+        } else {
+            // set invalid voltages back to -9999
+            adcVoltage = -9999;
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(), F("is not currently measuring!"));
+    }
+
+    verifyAndAddMeasurementResult(ALPHASENSE_CO2_VAR_NUM, calibResult);
+    verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM, adcVoltage);
+
+    // Unset the time stamp for the beginning of this measurement
+    _millisMeasurementRequested = 0;
+    // Unset the status bits for a measurement request (bits 5 & 6)
+    _sensorStatus &= 0b10011111;
+
+    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -7,7 +7,7 @@
  * Adapted from ApogeeSQ212.h and https://github.com/bellahenkel/Soil-Sensing-Device
  * Edited by Sara Geleskie Damiano <sdamiano@stroudcenter.org>
  *
- * @brief Contains the AlphasenseCO2 sensor subclass and the variable subclasses
+ * @brief Contains the AlphasenseCO2 sensor class and the variable subclasses
  * AlphasenseCO2_CO2 and AlphasenseCO2_Voltage.
  *
  * These are used for the Alphasense IRC-A1 Nondispersive Infrared (NDIR) 
@@ -244,7 +244,7 @@ class AlphasenseCO2 : public Sensor {
      */
     AlphasenseCO2(int8_t powerPin, 
                 uint8_t i2cAddress            = ADS1115_ADDRESS,
-                uint8_t measurementsToAverage = 1);
+                uint8_t measurementsToAverage = 7);
     /**
      * @brief Destroy the AlphasenseCO2 object - no action needed
      */

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -1,0 +1,355 @@
+/**
+ * @file AlphasenseCO2.h
+ * @copyright 2017-2023 Stroud Water Research Center
+ * Part of the EnviroDIY ModularSensors library for Arduino
+ * @author Written by Anthony Aufdenkampe <aaufdenkampe@limno.com>
+ * and Bella Henkel <bella.henkel@mnsu.edu>
+ * Adapted from ApogeeSQ212.h and https://github.com/bellahenkel/Soil-Sensing-Device
+ * Edited by Sara Geleskie Damiano <sdamiano@stroudcenter.org>
+ *
+ * @brief Contains the AlphasenseCO2 sensor subclass and the variable subclasses
+ * AlphasenseCO2_CO2 and AlphasenseCO2_Voltage.
+ *
+ * These are used for the Alphasense IRC-A1 Nondispersive Infrared (NDIR) 
+ * Carbon Dioxide (CO2) sensor. This library will almost certainly also work with 
+ * the Alphasense IRC-AT CO2 sensor (which uses a thermopile detector), although the
+ * warmup and stabilization times might be different.
+ *
+* This depends on the Adafruit ADS1X15 v2.x library.
+ */
+/* clang-format off */
+/**
+ * @defgroup sensor_alphasense_co2 Alphasense IRC-A1 CO2
+ * Classes for the Alphasense IRC-A1 Nondispersive Infrared (NDIR) 
+ * Carbon Dioxide (CO2) sensor.
+ *
+ * @ingroup analog_group
+ *
+ * @tableofcontents
+ * @m_footernavigation
+ *
+ * @section sensor_alphasense_co2_intro Introduction
+ * The [Alphasense IRC-A1 Nondispersive Infrared (NDIR) Carbon Dioxide (CO2)
+ * sensor](https://www.alphasense.com/products/carbon-dioxide/)
+ * The CO2 sensor requires a 2-5 V DC power source with a
+ * current draw of 20 to 60 mA.  The power supply to the sensor can be
+ * stopped between measurements.
+ *
+ * To convert the sensor's analog 4-20 mA signal to a high resolution digital
+ * signal, the sensor must be attached to an analog-to-digital converter with
+ * an resistor in series. Furthermore, 
+ * https://www.alphasense.com/products/ndir-safety/
+ * https://www.alphasense.com/wp-content/uploads/2018/04/IRC-A1.pdf
+ * https://www.alphasense.com/wp-content/uploads/2017/09/NDIR-Transmitter.pdf
+ * https://www.alphasense.com/wp-content/uploads/2022/10/AAN_202-04_App-Note_V0.pdf
+ * https://www.alphasense.com/wp-content/uploads/2022/10/AAN_201-06_App-Note_V0.pdf
+ * 
+ * See the
+ * [ADS1115](@ref analog_group) for details on the ADC conversion.
+ *
+ *
+ * @section sensor_alphasense_co2_datasheet Sensor Datasheet
+ * [Datasheet](https://www.alphasense.com/wp-content/uploads/2018/04/IRC-A1.pdf)
+ *
+ * @section sensor_alphasense_co2_flags Build flags
+ * - ```-D MS_USE_ADS1015```
+ *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
+ * - ```-D ALPHASENSE_CO2_CALIBRATION_FACTOR=x```
+ *      - Changes the calibration factor from 1 to x
+ *
+ * @section sensor_alphasense_co2_ctor Sensor Constructor
+ * {{ @ref AlphasenseCO2::AlphasenseCO2 }}
+ *
+ * ___
+ * @section sensor_alphasense_co2_examples Example Code
+ * The Alphasense CO2 sensor is used in the @menulink{alphasense_co2} example.
+ *
+ * @menusnip{alphasense_co2}
+ */
+/* clang-format on */
+
+// Header Guards
+#ifndef SRC_SENSORS_ALPHASENSECO2_H_
+#define SRC_SENSORS_ALPHASENSECO2_H_
+
+// Debugging Statement
+// #define MS_ALPHASENSECO2_DEBUG
+
+#ifdef MS_ALPHASENSECO2_DEBUG
+#define MS_DEBUGGING_STD "AlphasenseCO2"
+#endif
+
+// Included Dependencies
+#include "ModSensorDebugger.h"
+#undef MS_DEBUGGING_STD
+#include "VariableBase.h"
+#include "SensorBase.h"
+
+/** @ingroup sensor_alphasense_co2 */
+/**@{*/
+
+// Sensor Specific Defines
+/// @brief Sensor::_numReturnedValues; the Alphasense CO2 sensor can report 2 values, raw
+/// voltage and calculated CO2.
+#define ALPHASENSE_CO2_NUM_VARIABLES 2
+/// @brief Sensor::_incCalcValues; CO2 is calculated from the raw voltage.
+#define ALPHASENSE_CO2_INC_CALC_VARIABLES 1
+
+/**
+ * @anchor sensor_alphasense_co2_timing
+ * @name Sensor Timing
+ * The sensor timing for an Alphasense IRC-A1 CO2
+ */
+/**@{*/
+/**
+ * @brief Sensor::_warmUpTime_ms; 
+ * The TI ADS1x15 to warm up time is 2 ms, and we get 
+ * Alphasense CO2 sensor readings in <200 ms second.
+ */
+#define ALPHASENSE_CO2_WARM_UP_TIME_MS 200
+/**
+ * @brief Sensor::_stabilizationTime_ms; 
+ * The manufacturer provides the following stablization times:
+ *   - To final zero ± 100ppm: < 30 s @ 20°C 
+ *   - To specification: < 30 minutes @ 20°C
+ * We found that values leveled off after ~35 s. See:
+ * https://github.com/bellahenkel/Soil-Sensing-Device/tree/main/examples/getValuesCO2 *
+ */
+#define ALPHASENSE_CO2_STABILIZATION_TIME_MS 35000
+/**
+ * @brief Sensor::_measurementTime_ms;
+ * The Alphasense IRC-A1 CO2 sensor will return a new number every 200 ms,
+ * but there appears to be a cyclic response with a ~7 sec period, 
+ * so we recommend averaging 1 s measurements over 28 seconds (3 periods)
+ */
+#define ALPHASENSE_CO2_MEASUREMENT_TIME_MS 1000
+/**@}*/
+
+/**
+ * @anchor sensor_alphasense_co2_co2
+ * @name CO2 Concentration
+ * The CO2 variable from an Alphasense IRC-A1 CO2
+ * - Accuracy is ± 1%FS or ± 50 ppm (for IAQ type)
+ * - Range is 0 − 5000 ppm (for IAQ type)
+ * - Resolution: < 1 ppm
+ *   - 16-bit ADC (ADS1115): < 1 ppm (5 significant figures)
+ *   - 12-bit ADC (ADS1015): worse
+ *
+ * {{ @ref AlphasenseCO2_CO2 }}
+ */
+/**@{*/
+/// Variable number; CO2 is stored in sensorValues[0].
+#define ALPHASENSE_CO2_VAR_NUM 0
+/// @brief Variable name in [ODM2 controlled
+/// vocabulary](http://vocabulary.odm2.org/variablename/);
+/// "radiationIncomingPAR"
+#define ALPHASENSE_CO2_VAR_NAME "carbonDioxide"
+/// @brief Variable unit name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/units/);
+/// "partPerMillion" (ppm)
+#define ALPHASENSE_CO2_UNIT_NAME "partPerMillion"
+/// @brief Default variable short code; "AlphasenseCO2ppm"
+#define ALPHASENSE_CO2_DEFAULT_CODE "AlphasenseCO2ppm"
+
+#ifdef MS_USE_ADS1015
+/// @brief Decimals places in string representation; CO2 should have 0 when
+/// using an ADS1015.
+#define ALPHASENSE_CO2_RESOLUTION 0
+#else
+/// @brief Decimals places in string representation; CO2 should have 4 when
+/// using an ADS1115.
+#define ALPHASENSE_CO2_RESOLUTION 4
+#endif
+/**@}*/
+
+/**
+ * @anchor sensor_alphasense_co2_voltage
+ * @name Voltage
+ * The voltage variable from an Alphasense IRC-A1 CO2
+ * - Range is 0 to 3.6V [when ADC is powered at 3.3V]
+ * - Accuracy is ± 0.5%
+ *   - 16-bit ADC (ADS1115): < 0.25% (gain error), <0.25 LSB (offset error)
+ *   - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): < 0.15%
+ * (gain error), <3 LSB (offset error)
+ * - Resolution [assuming the ADC is powered at 3.3V with inbuilt gain set to 1
+ * (0-4.096V)]:
+ *   - 16-bit ADC (ADS1115): 0.125 mV (ADS1115)
+ *   - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): 2 mV
+ * (ADS1015)
+ *
+ * {{ @ref AlphasenseCO2_Voltage }}
+ */
+/**@{*/
+/// Variable number; voltage is stored in sensorValues[1].
+#define ALPHASENSE_CO2_VOLTAGE_VAR_NUM 1
+/// @brief Variable name in [ODM2 controlled
+/// vocabulary](http://vocabulary.odm2.org/variablename/); "voltage"
+#define ALPHASENSE_CO2_VOLTAGE_VAR_NAME "voltage"
+/// @brief Variable unit name in
+/// [ODM2 controlled vocabulary](http://vocabulary.odm2.org/units/); "volt" (V)
+#define ALPHASENSE_CO2_VOLTAGE_UNIT_NAME "volt"
+/// @brief Default variable short code; "AlphasenseCO2Voltage"
+#define ALPHASENSE_CO2_VOLTAGE_DEFAULT_CODE "AlphasenseCO2Voltage"
+#ifdef MS_USE_ADS1015
+/// @brief Decimals places in string representation; voltage should have 1 when
+/// used with an ADS1015.
+#define ALPHASENSE_CO2_VOLTAGE_RESOLUTION 1
+#else
+/// @brief Decimals places in string representation; voltage should have 4 when
+/// used with an ADS1115.
+#define ALPHASENSE_CO2_VOLTAGE_RESOLUTION 4
+#endif
+/**@}*/
+
+/**
+ * @brief The calibration factor between output in volts and CO2
+ * (microeinsteinPerSquareMeterPerSecond) 1 µmol mˉ² sˉ¹ per mV (reciprocal of
+ * sensitivity)
+ */
+#ifndef ALPHASENSE_CO2_CALIBRATION_FACTOR
+#define ALPHASENSE_CO2_CALIBRATION_FACTOR 1
+#endif
+
+/// The assumed address of the ADS1115, 1001 000 (ADDR = GND)
+#define ADS1115_ADDRESS 0x48
+
+/**
+ * @brief The Sensor sub-class for the [Alphasense IRC-A1 CO2](@ref sensor_alphasense_co2) sensor
+ *
+ * @ingroup sensor_alphasense_co2
+ */
+class AlphasenseCO2 : public Sensor {
+ public:
+    /**
+     * @brief Construct a new Alphasense IRC-A1 CO2 object - need the power pin and the
+     * on the ADS1x15. Designed to read differential voltage between
+     * ads channels 2 and 3
+     *
+     * @note ModularSensors only supports connecting the ADS1x15 to the primary
+     * hardware I2C instance defined in the Arduino core. Connecting the ADS to
+     * a secondary hardware or software I2C instance is *not* supported!
+     *
+     * @param powerPin The pin on the mcu controlling power to the 
+     * Alphasense CO2 sensor.  Use -1 if it is continuously powered.
+     * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
+     * - The ADS1115 requires 2.0-5.5V but is assumed to be powered at 3.3V
+     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
+     * = GND)
+     * @param measurementsToAverage The number of measurements to take and
+     * average before giving a "final" result from the sensor; optional with a
+     * default value of 7 [seconds], which is one period of the cycle.
+     * @note  The ADS is expected to be either continuously powered or have
+     * its power controlled by the same pin as the Alphasense CO2 sensor.  This library does
+     * not support any other configuration.
+     */
+    AlphasenseCO2(int8_t powerPin, 
+                uint8_t i2cAddress            = ADS1115_ADDRESS,
+                uint8_t measurementsToAverage = 1);
+    /**
+     * @brief Destroy the AlphasenseCO2 object - no action needed
+     */
+    ~AlphasenseCO2();
+
+    /**
+     * @brief Report the I1C address of the ADS and the channel that the Alphasense CO2 sensor
+     * is attached to.
+     *
+     * @return **String** Text describing how the sensor is attached to the mcu.
+     */
+    String getSensorLocation(void) override;
+
+    /**
+     * @copydoc Sensor::addSingleMeasurementResult()
+     */
+    bool addSingleMeasurementResult(void) override;
+
+ private:
+    uint8_t _i2cAddress;
+};
+
+
+/* clang-format off */
+/**
+ * @brief The Variable sub-class used for the
+ * [carbon dioxide (CO2) output](@ref sensor_alphasense_co2_co2)
+ * from an [Alphasense IRC-A1 CO2](@ref sensor_alphasense_co2).
+ *
+ * @ingroup sensor_alphasense_co2
+ */
+/* clang-format on */
+class AlphasenseCO2_CO2 : public Variable {
+ public:
+    /**
+     * @brief Construct a new AlphasenseCO2_CO2 object.
+     *
+     * @param parentSense The parent AlphasenseCO2 providing the result
+     * values.
+     * @param uuid A universally unique identifier (UUID or GUID) for the
+     * variable; optional with the default value of an empty string.
+     * @param varCode A short code to help identify the variable in files;
+     * optional with a default value of "radiationIncomingPAR".
+     */
+    explicit AlphasenseCO2_CO2(AlphasenseCO2* parentSense, const char* uuid = "",
+                             const char* varCode = ALPHASENSE_CO2_DEFAULT_CODE)
+        : Variable(parentSense, (const uint8_t)ALPHASENSE_CO2_VAR_NUM,
+                   (uint8_t)ALPHASENSE_CO2_RESOLUTION, ALPHASENSE_CO2_VAR_NAME,
+                   ALPHASENSE_CO2_UNIT_NAME, varCode, uuid) {}
+    /**
+     * @brief Construct a new AlphasenseCO2_CO2 object.
+     *
+     * @note This must be tied with a parent AlphasenseCO2 before it can be used.
+     */
+    AlphasenseCO2_CO2()
+        : Variable((const uint8_t)ALPHASENSE_CO2_VAR_NUM,
+                   (uint8_t)ALPHASENSE_CO2_RESOLUTION, ALPHASENSE_CO2_VAR_NAME,
+                   ALPHASENSE_CO2_UNIT_NAME, ALPHASENSE_CO2_DEFAULT_CODE) {}
+    /**
+     * @brief Destroy the AlphasenseCO2_CO2 object - no action needed.
+     */
+    ~AlphasenseCO2_CO2() {}
+};
+
+
+/* clang-format off */
+/**
+ * @brief The Variable sub-class used for the
+ * [raw voltage output](@ref sensor_alphasense_co2_voltage) from an
+ * [Alphasense IRC-A1 CO2](@ref sensor_alphasense_co2).
+ *
+ * @ingroup sensor_alphasense_co2
+ */
+/* clang-format on */
+class AlphasenseCO2_Voltage : public Variable {
+ public:
+    /**
+     * @brief Construct a new AlphasenseCO2_Voltage object.
+     *
+     * @param parentSense The parent AlphasenseCO2 providing the result
+     * values.
+     * @param uuid A universally unique identifier (UUID or GUID) for the
+     * variable; optional with the default value of an empty string.
+     * @param varCode A short code to help identify the variable in files;
+     * optional with a default value of "AlphasenseCO2Voltage".
+     */
+    explicit AlphasenseCO2_Voltage(
+        AlphasenseCO2* parentSense, const char* uuid = "",
+        const char* varCode = ALPHASENSE_CO2_VOLTAGE_DEFAULT_CODE)
+        : Variable(parentSense, (const uint8_t)ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
+                   (uint8_t)ALPHASENSE_CO2_VOLTAGE_RESOLUTION, ALPHASENSE_CO2_VOLTAGE_VAR_NAME,
+                   ALPHASENSE_CO2_VOLTAGE_UNIT_NAME, varCode, uuid) {}
+    /**
+     * @brief Construct a new AlphasenseCO2_Voltage object.
+     *
+     * @note This must be tied with a parent AlphasenseCO2 before it can be used.
+     */
+    AlphasenseCO2_Voltage()
+        : Variable((const uint8_t)ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
+                   (uint8_t)ALPHASENSE_CO2_VOLTAGE_RESOLUTION, ALPHASENSE_CO2_VOLTAGE_VAR_NAME,
+                   ALPHASENSE_CO2_VOLTAGE_UNIT_NAME, ALPHASENSE_CO2_VOLTAGE_DEFAULT_CODE) {}
+    /**
+     * @brief Destroy the AlphasenseCO2_Voltage object - no action needed.
+     */
+    ~AlphasenseCO2_Voltage() {}
+};
+/**@}*/
+#endif  // SRC_SENSORS_ALPHASENSECO2_H_

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -43,6 +43,7 @@ String ApogeeSQ212::getSensorLocation(void) {
 
 bool ApogeeSQ212::addSingleMeasurementResult(void) {
     // Variables to store the results in
+    int16_t adcCounts = -9999;
     float adcVoltage  = -9999;
     float calibResult = -9999;
 
@@ -78,10 +79,10 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
-        // We're allowing the ADS1115 library to do the bit-to-volts conversion
-        // for us
-        adcVoltage =
-            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        // Measure the ADC raw count
+        adcCounts = ads.readADC_SingleEnded(_adsChannel);
+        // Convert ADC raw counts value to voltage (V)
+        adcVoltage = ads.computeVolts(adcCounts)
         MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -12,7 +12,7 @@
 
 
 #include "ApogeeSQ212.h"
-#include <Adafruit_ADS1015.h>
+#include <Adafruit_ADS1X15.h>
 
 
 // The constructor - need the power pin and the data pin
@@ -55,9 +55,9 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
 // We create and set up the ADC object here so that each sensor using
 // the ADC may set the gain appropriately without effecting others.
 #ifndef MS_USE_ADS1015
-        Adafruit_ADS1115 ads(_i2cAddress);  // Use this for the 16-bit version
+        Adafruit_ADS1115 ads;  // Use this for the 16-bit version
 #else
-        Adafruit_ADS1015 ads(_i2cAddress);  // Use this for the 12-bit version
+        Adafruit_ADS1015 ads;  // Use this for the 12-bit version
 #endif
         // ADS Library default settings:
         //  - TI1115 (16 bit)
@@ -74,15 +74,15 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
         // only allows up to 2.048V
         ads.setGain(GAIN_ONE);
         // Begin ADC
-        ads.begin();
+        ads.begin(_i2cAddress);
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
         // We're allowing the ADS1115 library to do the bit-to-volts conversion
         // for us
         adcVoltage =
-            ads.readADC_SingleEnded_V(_adsChannel);  // Getting the reading
-        MS_DBG(F("  ads.readADC_SingleEnded_V("), _adsChannel, F("):"),
+            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 
         if (adcVoltage < 3.6 && adcVoltage > -0.3) {

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -12,7 +12,7 @@
  *
  * These are used for the Apogee SQ-212 quantum light sensor.
  *
- * This depends on the soligen2010 fork of the Adafruit ADS1015 library.
+ * This depends on the Adafruit ADS1X15 v2.x library.
  */
 /* clang-format off */
 /**

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -9,7 +9,7 @@
 
 
 #include "CampbellOBS3.h"
-#include <Adafruit_ADS1015.h>
+#include <Adafruit_ADS1X15.h>
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
@@ -55,7 +55,7 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
 // We create and set up the ADC object here so that each sensor using
 // the ADC may set the gain appropriately without effecting others.
 #ifndef MS_USE_ADS1015
-        Adafruit_ADS1115 ads(_i2cAddress);  // Use this for the 16-bit version
+        Adafruit_ADS1115 ads;  // Use this for the 16-bit version
 #else
         Adafruit_ADS1015 ads(_i2cAddress);  // Use this for the 12-bit version
 #endif
@@ -74,7 +74,7 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         // only allows up to 2.048V
         ads.setGain(GAIN_ONE);
         // Begin ADC
-        ads.begin();
+        ads.begin(_i2cAddress);
 
         // Print out the calibration curve
         MS_DBG(F("  Input calibration Curve:"), _x2_coeff_A, F("x^2 +"),
@@ -85,8 +85,8 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         // We're allowing the ADS1115 library to do the bit-to-volts conversion
         // for us
         adcVoltage =
-            ads.readADC_SingleEnded_V(_adsChannel);  // Getting the reading
-        MS_DBG(F("  ads.readADC_SingleEnded_V("), _adsChannel, F("):"),
+            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 
         if (adcVoltage < 3.6 && adcVoltage > -0.3) {

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -43,6 +43,7 @@ String CampbellOBS3::getSensorLocation(void) {
 
 bool CampbellOBS3::addSingleMeasurementResult(void) {
     // Variables to store the results in
+    int16_t adcCounts = -9999;
     float adcVoltage  = -9999;
     float calibResult = -9999;
 
@@ -82,10 +83,10 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
-        // We're allowing the ADS1115 library to do the bit-to-volts conversion
-        // for us
-        adcVoltage =
-            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        // Measure the ADC raw count
+        adcCounts = ads.readADC_SingleEnded(_adsChannel);
+        // Convert ADC raw counts value to voltage (V)
+        adcVoltage = ads.computeVolts(adcCounts)
         MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 

--- a/src/sensors/CampbellRainVUE10.h
+++ b/src/sensors/CampbellRainVUE10.h
@@ -30,7 +30,7 @@
  * accurate precipitation and intensity measurements.
  *
  * The sensor is implemented as a sub-classes of the SDI12Sensors class.
- * It requires a continuous 6 to 18 Vdc power supply. As backup, ann internal
+ * It requires a continuous 6 to 18 Vdc power supply. As backup, an internal
  * 240 mAh lithium battery (3V Coin Cell CR2032) provides up to 15 days of
  * continual operation after power loss.
  * It draws < 80 µA when inactive and 1 mA while measuring.

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -43,6 +43,7 @@ String TIADS1x15::getSensorLocation(void) {
 
 bool TIADS1x15::addSingleMeasurementResult(void) {
     // Variables to store the results in
+    int16_t adcCounts = -9999;
     float adcVoltage  = -9999;
     float calibResult = -9999;
 
@@ -76,10 +77,10 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
-        // We're allowing the ADS1115 library to do the bit-to-volts conversion
-        // for us
-        adcVoltage =
-            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        // Measure the ADC raw count
+        adcCounts = ads.readADC_SingleEnded(_adsChannel);
+        // Convert ADC raw counts value to voltage (V)
+        adcVoltage = ads.computeVolts(adcCounts)
         MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -12,7 +12,7 @@
 
 
 #include "TIADS1x15.h"
-#include <Adafruit_ADS1015.h>
+#include <Adafruit_ADS1X15.h>
 
 
 // The constructor - need the power pin the data pin, and gain if non standard
@@ -55,7 +55,7 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
 // We create and set up the ADC object here so that each sensor using
 // the ADC may set the gain appropriately without effecting others.
 #ifndef MS_USE_ADS1015
-        Adafruit_ADS1115 ads(_i2cAddress);  // Use this for the 16-bit version
+        Adafruit_ADS1115 ads;  // Use this for the 16-bit version
 #else
         Adafruit_ADS1015 ads(_i2cAddress);  // Use this for the 12-bit version
 #endif
@@ -72,15 +72,15 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
         // Bump the gain up to 1x = +/- 4.096V range
         ads.setGain(GAIN_ONE);
         // Begin ADC
-        ads.begin();
+        ads.begin(_i2cAddress);
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
         // We're allowing the ADS1115 library to do the bit-to-volts conversion
         // for us
         adcVoltage =
-            ads.readADC_SingleEnded_V(_adsChannel);  // Getting the reading
-        MS_DBG(F("  ads.readADC_SingleEnded_V("), _adsChannel, F("):"),
+            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 
         if (adcVoltage < 3.6 && adcVoltage > -0.3) {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -9,7 +9,7 @@
 
 
 #include "TurnerCyclops.h"
-#include <Adafruit_ADS1015.h>
+#include <Adafruit_ADS1X15.h>
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
@@ -55,7 +55,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
 // We create and set up the ADC object here so that each sensor using
 // the ADC may set the gain appropriately without effecting others.
 #ifndef MS_USE_ADS1015
-        Adafruit_ADS1115 ads(_i2cAddress);  // Use this for the 16-bit version
+        Adafruit_ADS1115 ads;  // Use this for the 16-bit version
 #else
         Adafruit_ADS1015 ads(_i2cAddress);  // Use this for the 12-bit version
 #endif
@@ -74,7 +74,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         // only allows up to 2.048V
         ads.setGain(GAIN_ONE);
         // Begin ADC
-        ads.begin();
+        ads.begin(_i2cAddress);
 
         // Print out the calibration curve
         MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
@@ -85,8 +85,8 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         // We're allowing the ADS1115 library to do the bit-to-volts conversion
         // for us
         adcVoltage =
-            ads.readADC_SingleEnded_V(_adsChannel);  // Getting the reading
-        MS_DBG(F("  ads.readADC_SingleEnded_V("), _adsChannel, F("):"),
+            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 
         if (adcVoltage < 3.6 && adcVoltage > -0.3) {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -43,6 +43,7 @@ String TurnerCyclops::getSensorLocation(void) {
 
 bool TurnerCyclops::addSingleMeasurementResult(void) {
     // Variables to store the results in
+    int16_t adcCounts = -9999;
     float adcVoltage  = -9999;
     float calibResult = -9999;
 
@@ -82,10 +83,10 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
 
         // Read Analog to Digital Converter (ADC)
         // Taking this reading includes the 8ms conversion delay.
-        // We're allowing the ADS1115 library to do the bit-to-volts conversion
-        // for us
-        adcVoltage =
-            ads.readADC_SingleEnded(_adsChannel);  // Getting the reading
+        // Measure the ADC raw count
+        adcCounts = ads.readADC_SingleEnded(_adsChannel);
+        // Convert ADC raw counts value to voltage (V)
+        adcVoltage = ads.computeVolts(adcCounts)
         MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"),
                adcVoltage);
 


### PR DESCRIPTION
This PR is primarily to add the [Alphasense IRC-A1 Nondispersive Infrared (NDIR) Carbon Dioxide (CO2) sensor](https://www.alphasense.com/products/carbon-dioxide/) to the list of supported sensors.
- #459

It also paves the way for other Alphasense gas sensors to be implemented.

Last, bundled into this PR is a code fix to support the following change in the dependency for the Mayfly's Analog-to-Digital Converter (ADC):
- #456 
There are many competing reasons to switch this core dependency, as described in the issue.

This PR is not yet 100% ready, as some testing is first required to confirm that everything is working on sensors that use the ADS1X15.  I also need to complete documentation for the Alphasense sensor, primarily via adding a block to the `menu-a-la-carte.ino` example.

This PR begins such review.