### PR TITLE
Analog abstraction

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -67,3 +67,4 @@ reviews:
     drafts: true
     base_branches:
       - master
+      - develop

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -99,7 +99,7 @@ Previously the I2C address of the ADS1x15 was an optional input parameter which 
 The input parameter for the I2C address has been *removed* and the input for the number of measurements to average has been moved up in the order!
 For users who used the default values, this will have no affect.
 For users who provided both a custom I2C address and a custom number of measurements, this will cause a compiler error.
-For uses who provided a custom I2C address *but not a custom number of measurements* this will cause a *silent failure* because the custom I2C address will be used as the measurement count and the default I2C address will be used.
+For users who provided a custom I2C address *but not a custom number of measurements* this will cause a *silent failure* because the custom I2C address will be used as the measurement count and the default I2C address will be used.
 Users who need a custom I2C address for the ADS1x15 must construct a TIADS1x15Base object with the correct address and pass a pointer to that object to the constructor.
 - **AnalogElecConductivity**
   - *Renamed* configuration defines to have the prefix `ANALOGELECCONDUCTIVITY` and moved other defaults to defines.
@@ -151,7 +151,7 @@ To achieve the same functionality as the old `updateAllSensors()` function (ie, 
 - Moved outdated examples to a new "Outdated" folder, with a subfolder for the DRWI examples
 - When importing TinyGSM for the modem objects, the specific modem client headers are now imported directly rather than importing the TinyGsmClient.h header which defines typedefs for the sub-types.
 - Moved the define for the default address used for a TI ADS from multiple individual files to the ModSensorConfig and renamed to `MS_DEFAULT_ADS1X15_ADDRESS`.
-- Within ModSensorConfig removed the default `MS_PROCESSOR_ADC_RESOLUTION` for all processors and clarified that the 12 bit default only applies to SAMD processors.
+- Within ModSensorConfig removed the default `MS_PROCESSOR_ADC_RESOLUTION` for all processors and clarified that the 12-bit default only applies to SAMD processors.
 This is *not* breaking because only AVR and SAMD processors were supported anyway.
 
 ### Added
@@ -214,7 +214,7 @@ This affects the following classes:
 - Fixed major bug where sensors with two power pins where either was shared with another sensor may be turned off inappropriately when one of the other sensors was turned off.
 - Correctly retry NIST sync on XBees when a not-sane timestamp is returned.
 - Improved ADC bit-width handling with explicit type casting for safer arithmetic operations.
-Enhanced null-pointer validation and error handling across analog voltage reading paths.
+- Enhanced null-pointer validation and error handling across analog voltage reading paths.
 
 ***
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -83,7 +83,7 @@ The logging interval has been added as a required parameter for the constructor!
 - **AlphasenseCO2** and **TurnerTurbidityPlus**
   - **BREAKING**  The constructors for both of these analog-based classes have changed!
 Previously the constructor required an enum object for the supported differential channels.
-The new constructor requires of two different analog channel numbers as inputs for the differential voltage measurement.
+The new constructor requires two different analog channel numbers as inputs for the differential voltage measurement.
 If you are using code from a previous version of the library, make sure to update your code to use the new constructor and provide the correct analog channel inputs for the differential voltage measurement.
   - Moved resistor settings and calibration values into the following preprocessor defines that can be modified to tweak the library if necessary:
     - `ALPHASENSE_CO2_SENSE_RESISTOR_OHM` (defaults to `250.0f`)
@@ -144,7 +144,7 @@ Use `completeUpdate(false, false, false, false)` instead.
 The two functions have been consolidated into one function with four arguments, one each for power on, wake, sleep, and power off.
 To achieve the same functionality as the old `updateAllSensors()` function (ie, only updating values), set all the arguments to false.
 
-#### Library Wide
+#### Library-Wide
 
 - Bumped several dependencies - including crucial bug fixes to SensorModbusMaster.
 - Applied many suggestions from Code Rabbit AI.
@@ -194,7 +194,7 @@ This affects the following classes:
   - TurnerCyclops
   - TurnerTurbidityPlus
 
-#### Library Wide
+#### Library-Wide
 
 - Added KnownProcessors.h and moved define values for supported built-in sensors on known processors to that file.
   - This affects ProcessorStats and the Everlight ALS PT-19.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -196,7 +196,7 @@ This affects the following classes:
 
 #### Library Wide
 
-- Added KnownProcessors.h and moved defines valued for supported built-in sensors on known processors to that file.
+- Added KnownProcessors.h and moved define values for supported built-in sensors on known processors to that file.
   - This affects ProcessorStats and the Everlight ALS PT-19.
 - Added a new example specific to the [EnviroDIY Monitoring Station Kit](https://www.envirodiy.org/product/envirodiy-monitoring-station-kit/).
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,25 +6,112 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- @tableofcontents{XML:1,HTML:1} -->
+
+<!--! @m_footernavigation -->
+
+<!--! @if GITHUB -->
+
+- [ChangeLog](#changelog)
+  - [Unreleased](#unreleased)
+  - [0.37.0](#0370)
+  - [0.36.0](#0360)
+  - [0.35.1](#0351)
+  - [0.35.0](#0350)
+  - [\[0.34.1\]](#0341)
+  - [0.34.0](#0340)
+  - [0.33.4](#0334)
+  - [0.33.3](#0333)
+  - [0.33.2](#0332)
+  - [0.33.1 - 2022-04-11](#0331---2022-04-11)
+  - [0.33.0 - 2022-04-01](#0330---2022-04-01)
+  - [0.32.2 - 2021-11-23](#0322---2021-11-23)
+  - [0.32.0 - 2021-11-19](#0320---2021-11-19)
+  - [0.31.2 - 2021-11-03](#0312---2021-11-03)
+  - [0.31.0 - 2021-11-02](#0310---2021-11-02)
+  - [0.30.0 - 2021-07-06](#0300---2021-07-06)
+  - [0.29.1 - 2021-07-01](#0291---2021-07-01)
+  - [0.29.0 - 2021-05-19](#0290---2021-05-19)
+  - [0.28.5 - 2021-05-11](#0285---2021-05-11)
+  - [0.28.4 - 2021-05-05](#0284---2021-05-05)
+  - [0.28.3 - 2021-03-24](#0283---2021-03-24)
+  - [\[0.28.01\] - 2021-02-10](#02801---2021-02-10)
+  - [0.28.0 - 2021-02-10](#0280---2021-02-10)
+  - [0.27.8 - 2021-01-19](#0278---2021-01-19)
+  - [0.27.7 - 2021-01-19](#0277---2021-01-19)
+  - [0.27.6 - 2021-01-19](#0276---2021-01-19)
+  - [0.27.5 - 2020-12-15](#0275---2020-12-15)
+  - [0.25.0 - 2020-06-25](#0250---2020-06-25)
+  - [0.24.1 - 2020-03-02](#0241---2020-03-02)
+  - [0.23.13 - 2019-09-19](#02313---2019-09-19)
+  - [0.23.11 - 2019-09-11](#02311---2019-09-11)
+  - [0.22.5 - 2019-06-24](#0225---2019-06-24)
+  - [0.21.4 - 2019-05-02](#0214---2019-05-02)
+  - [0.21.3 - 2019-05-02](#0213---2019-05-02)
+  - [0.21.2 - 2019-03-19](#0212---2019-03-19)
+  - [0.21.0 - 2019-03-06](#0210---2019-03-06)
+  - [0.19.6 - 2019-02-27](#0196---2019-02-27)
+  - [0.19.3 - 2019-01-15](#0193---2019-01-15)
+  - [0.19.2 - 2018-12-22](#0192---2018-12-22)
+  - [0.17.2 - 2018-11-27](#0172---2018-11-27)
+  - [0.12.2 - 2018-09-25](#0122---2018-09-25)
+  - [0.11.6 - 2018-05-11](#0116---2018-05-11)
+  - [0.11.3 - 2018-05-03](#0113---2018-05-03)
+  - [0.9.0 - 2018-04-17](#090---2018-04-17)
+  - [0.6.10 - 2018-02-26](#0610---2018-02-26)
+  - [0.6.9 - 2018-02-26](#069---2018-02-26)
+  - [0.5.4-beta - 2018-01-18](#054-beta---2018-01-18)
+  - [\[0.3.0\]-beta - 2017-06-07](#030-beta---2017-06-07)
+  - [\[0.2.5\]-beta - 2017-05-31](#025-beta---2017-05-31)
+  - [\[0.2.4\]-beta - 2017-05-17](#024-beta---2017-05-17)
+  - [\[0.2.2\]-beta - 2017-05-09](#022-beta---2017-05-09)
+
+<!--! @endif -->
+
 ***
 
 ## [Unreleased]
 
 ### Changed
 
-- Made the enabling and disabling of the watchdog the very first and very last steps of sleep to keep the watchdog enabled through the whole getting ready for bed and waking up process.
-- **ANB pH**
+#### Individual Sensors
+
+- **ANBpH**
   - **BREAKING** The constructor has changed!
 The logging interval has been added as a required parameter for the constructor!
   - Changed timing slightly and simplified timing logic.
-- **Renamed** The EnviroDIYPublisher has been renamed the MonitorMyWatershedPublisher.
-This reflects changes to the website from years ago.
-There is a shell file and typedef to maintain backwards compatibility.
-- Changed capitalization of `setInitialShortIntervals(#)` function
-  - Previously the 'i' of initial was not capitalized.
-  - The old `setinitialShortIntervals` remains available via compatibility shim in LoggerBase.h, so existing code is unaffected.
-- Bumped several dependencies - including crucial bug fixes to SensorModbusMaster.
-- Re-wrote most of the logic for looping variables within the complete update function of the VariableArray.
+- **AlphasenseCO2** and **TurnerTurbidityPlus**
+  - **BREAKING**  The constructors for both of these analog-based classes have changed!
+Previously the constructor required an enum object for the supported differential channels.
+The new constructor requires of two different analog channel numbers as inputs for the differential voltage measurement.
+If you are using code from a previous version of the library, make sure to update your code to use the new constructor and provide the correct analog channel inputs for the differential voltage measurement.
+  - Moved resistor settings and calibration values into the following preprocessor defines that can be modified to tweak the library if necessary:
+    - `ALPHASENSE_CO2_SENSE_RESISTOR_OHM` (defaults to `250.0f`)
+    - `ALPHASENSE_CO2_MFG_SCALE` (defaults to `312.5f`)
+    - `ALPHASENSE_CO2_MFG_OFFSET` (defaults to `1250.0f`)
+    - `ALPHASENSE_CO2_VOLTAGE_MULTIPLIER` (defaults to `1.0f`)
+    - `TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS` (defaults to `50`)
+    - `TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS` (defaults to `8000`)
+    - `TURBIDITY_PLUS_CALIBRATION_EPSILON` (defaults to `1e-4f`)
+- **ApogeeSQ212**, **TIADS1x15**, **CampbellOBS3**, and **TurnerCyclops**
+  - *Potentially breaking* The constructors for all of these analog-based classes have changed!
+Previously the I2C address of the ADS1x15 was an optional input parameter which came *before* the optional input parameter for the number of measurements to average.
+The input parameter for the I2C address has been *removed* and the input for the number of measurements to average has been moved up in the order!
+For users who used the default values, this will have no affect.
+For users who provided both a custom I2C address and a custom number of measurements, this will cause a compiler error.
+For uses who provided a custom I2C address *but not a custom number of measurements* this will cause a *silent failure* because the custom I2C address will be used as the measurement count and the default I2C address will be used.
+Users who need a custom I2C address for the ADS1x15 must construct a TIADS1x15Base object with the correct address and pass a pointer to that object to the constructor.
+- **AnalogElecConductivity**
+  - *Renamed* configuration defines to have the prefix `ANALOGELECCONDUCTIVITY` and moved other defaults to defines.
+This affects the following defines:
+    - `ANALOGELECCONDUCTIVITY_RSERIES_OHMS` (formerly `RSERIES_OHMS_DEF`)
+    - `ANALOGELECCONDUCTIVITY_KONST` (formerly `SENSOREC_KONST_DEF`)
+    - `ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO` (formerly a hardcoded value of `0.999f`)
+- **EverlightALSPT19**
+  - Moved the calibration constant between current and lux to the `ALSPT19_UA_PER_1000LUX` preprocessor define.
+
+#### All Sensors
+
 - Simplified the `addSingleMeasurementResult()` function of all sensors to use an internal function to help set the bits and timing values and to quit sooner if the measurement was not started successfully.
   - The `verifyAndAddMeasurementResult()` is now consistently used in all sensors and is only called when the sensor successfully returned a measurement response.
   - Also removed all places where sensor values were re-set to -9999 after a measurement failed and then that -9999 was sent to the `verifyAndAddMeasurementResult()` function.
@@ -32,6 +119,23 @@ These resets were an awkward attempt to deal with bad values before feeding any 
 This was probably a hold-over from incorrect implementation and calling of the clearValues function deep in the library history.
   - Also made the return from the `addSingleMeasurementResult()` function consistently false for a bad sensor response and true for a good one - where it's possible to tell the difference.
 - The Sensor::clearValues() function now resets the attempt and retry counts in addition to setting all values in the value array to -9999.
+
+#### Individual Publishers
+
+- *Renamed* The EnviroDIYPublisher has been renamed the MonitorMyWatershedPublisher.
+This reflects changes to the website from years ago.
+There is a shell file and typedef to maintain backwards compatibility.
+
+#### All Publishers
+
+- Changed capitalization of `setInitialShortIntervals(#)` function
+  - Previously the 'i' of initial was not capitalized.
+  - The old `setinitialShortIntervals` remains available via compatibility shim in LoggerBase.h, so existing code is unaffected.
+
+#### Loggers and Variable Arrays
+
+- Made the enabling and disabling of the watchdog the very first and very last steps of sleep to keep the watchdog enabled through the whole getting ready for bed and waking up process.
+- Re-wrote most of the logic for looping variables within the complete update function of the VariableArray.
 - Re-wrote some of the logic of the `completeUpdate()` function.
 Also added optional arguments to the `completeUpdate()` function to allow users to specify if the sensors should be powered/woken.
   - The `updateAllSensors()` function is now deprecated.
@@ -39,11 +143,24 @@ Use `completeUpdate(false, false, false, false)` instead.
     - Previously the `updateAllSensors()` function asked all sensors to update their values, skipping all power, wake, and sleep steps while the `completeUpdate()` function duplicated that functionality and added the power, wake, and sleep.
 The two functions have been consolidated into one function with four arguments, one each for power on, wake, sleep, and power off.
 To achieve the same functionality as the old `updateAllSensors()` function (ie, only updating values), set all the arguments to false.
+
+#### Library Wide
+
+- Bumped several dependencies - including crucial bug fixes to SensorModbusMaster.
 - Applied many suggestions from Code Rabbit AI.
 - Moved outdated examples to a new "Outdated" folder, with a subfolder for the DRWI examples
 - When importing TinyGSM for the modem objects, the specific modem client headers are now imported directly rather than importing the TinyGsmClient.h header which defines typedefs for the sub-types.
+- Moved the define for the default address used for a TI ADS from multiple individual files to the ModSensorConfig and renamed to `MS_DEFAULT_ADS1X15_ADDRESS`.
+- Within ModSensorConfig removed the default `MS_PROCESSOR_ADC_RESOLUTION` for all processors and clarified that the 12 bit default only applies to SAMD processors.
+This is *not* breaking because only AVR and SAMD processors were supported anyway.
 
 ### Added
+
+#### New Sensors
+
+- **NEW SENSOR** Added a new sensor for simple analog voltage using the built-in processor ADC
+
+#### Features for All Sensors
 
 - **Added support for retrying measurements for all sensors**.
   - Each sensor now supports a number of possible retry attempts for when the sensor returns a bad or no value.
@@ -65,8 +182,21 @@ These values should generally be set in the specific sensor constructors and onl
   - `setMeasurementTime(uint32_t measurementTime_ms)`
   - `getMeasurementTime()`
 - Added the functions `Sensor::clearStatus()`,`Sensor::clearPowerStatus()`,`Sensor::clearWakeStatus()`,and `Sensor::clearMeasurementStatus()` which reset some or all of the sensor status bits and related timing variables.
-- **NEW SENSOR** Added a new sensor for simple analog voltage using the built-in processor ADC
-- Added KnownProcessors.h and moved defines values for supported built-in sensors on known processors to that file.
+- Added an abstract AnalogVoltageBase class with two concrete classes for analog voltage measurements: ProcessorAnalogBase and TIADS1x15Base.
+All supported analog sensors can now accept a pointer to an object of any concrete subclass of the AnalogVoltageBase class to use for raw voltage measurements.
+By default the existing analog sensors will create an AnalogVoltageBase class object internally for whichever type of ADC (processor or ADS1x15) the sensor was originally coded to use.
+This affects the following classes:
+  - AlphasenseCO2
+  - AnalogElecConductivity
+  - ApogeeSQ212
+  - CampbellOBS3
+  - EverlightALSPT19
+  - TurnerCyclops
+  - TurnerTurbidityPlus
+
+#### Library Wide
+
+- Added KnownProcessors.h and moved defines valued for supported built-in sensors on known processors to that file.
   - This affects ProcessorStats and the Everlight ALS PT-19.
 - Added a new example specific to the [EnviroDIY Monitoring Station Kit](https://www.envirodiy.org/product/envirodiy-monitoring-station-kit/).
 
@@ -83,6 +213,8 @@ These values should generally be set in the specific sensor constructors and onl
 
 - Fixed major bug where sensors with two power pins where either was shared with another sensor may be turned off inappropriately when one of the other sensors was turned off.
 - Correctly retry NIST sync on XBees when a not-sane timestamp is returned.
+- Improved ADC bit-width handling with explicit type casting for safer arithmetic operations.
+Enhanced null-pointer validation and error handling across analog voltage reading paths.
 
 ***
 
@@ -1210,4 +1342,4 @@ Our first release of the modular sensors library to support easily logging data 
 
 <!--! @m_footernavigation -->
 
-<!-- cspell:words isnan GPST arounds strcat strcpy PULLUP TIINA Wextra setinitialShortIntervals -->
+<!-- cspell:words isnan GPST arounds strcat strcpy PULLUP TIINA Wextra setinitialShortIntervals RSeries AnalogElecConductivity Konst SensorEC -->

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -184,7 +184,7 @@ These values should generally be set in the specific sensor constructors and onl
 - Added the functions `Sensor::clearStatus()`,`Sensor::clearPowerStatus()`,`Sensor::clearWakeStatus()`,and `Sensor::clearMeasurementStatus()` which reset some or all of the sensor status bits and related timing variables.
 - Added an abstract AnalogVoltageBase class with two concrete classes for analog voltage measurements: ProcessorAnalogBase and TIADS1x15Base.
 All supported analog sensors can now accept a pointer to an object of any concrete subclass of the AnalogVoltageBase class to use for raw voltage measurements.
-By default the existing analog sensors will create an AnalogVoltageBase class object internally for whichever type of ADC (processor or ADS1x15) the sensor was originally coded to use.
+By default, existing analog sensors will create an internal concrete AnalogVoltageBase subclass instance for whichever ADC type (processor or ADS1x15) the sensor was originally coded to use.
 This affects the following classes:
   - AlphasenseCO2
   - AnalogElecConductivity

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,7 +97,7 @@ If you are using code from a previous version of the library, make sure to updat
   - *Potentially breaking* The constructors for all of these analog-based classes have changed!
 Previously the I2C address of the ADS1x15 was an optional input parameter which came *before* the optional input parameter for the number of measurements to average.
 The input parameter for the I2C address has been *removed* and the input for the number of measurements to average has been moved up in the order!
-For users who used the default values, this will have no affect.
+For users who used the default values, this will have no effect.
 For users who provided both a custom I2C address and a custom number of measurements, this will cause a compiler error.
 For users who provided a custom I2C address *but not a custom number of measurements* this will cause a *silent failure* because the custom I2C address will be used as the measurement count and the default I2C address will be used.
 Users who need a custom I2C address for the ADS1x15 must construct a TIADS1x15Base object with the correct address and pass a pointer to that object to the constructor.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -227,7 +227,7 @@ This affects the following classes:
 
 ### Changed
 
-- **BREAKING** Converted the watch-dog classes in to static classes with all static function and a **deleted constructor**.
+- **BREAKING** Converted the watch-dog classes into static classes with all static function and a **deleted constructor**.
   - Any code that attempted to interact with the watchdog (ie, with a "complex loop") must now call the extendedWatchDog class directly, ie: `extendedWatchDog::resetWatchDog();` rather than `dataLogger.watchDogTimer.resetWatchDog();`
 - **BREAKING** Renamed `markedLocalEpochTime` to `markedLocalUnixTime` to clarify the start of the epoch that we're marking down.
 - **BREAKING** Renamed `markedUTCEpochTime` to `markedUTCUnixTime` to clarify the start of the epoch that we're marking down.
@@ -249,7 +249,7 @@ I realized this was a problem for analog values I tried to read that reported co
   - `Logger::setRTClock(UTCEpochSeconds)`; use `loggerClock::setRTClock(ts, utcOffset, epoch)` in new code.
   - `Logger::isRTCSane()`; use `loggerClock::isRTCSane()` in new code.
   - `Logger::wakeISR()`; use `loggerClock::rtcISR()` in new code.
-- Support timestamps as time_t objects instead of uint32_t where every sensible.
+- Support timestamps as time_t objects instead of uint32_t wherever sensible.
   - The size of a uint32_t is always 32 bits, but the size of the time_t object varies by processor - for some it is 32 bits, for other 64.
 - Changed the watchdog from a fixed 15 minute reset timer to 2x the logging interval (or at least 5 minutes).
 - Modified all examples which define a sercom serial port for SAMD21 processors to require the defines for the supported processors.
@@ -275,7 +275,7 @@ This should only make a difference for my compilation tests, real users should p
 
 ### Added
 
-- **CONFIGURATION** Added a two configuration files (ModSensorConfig.h and ModSensorDebugConfig.h) that all files read from to check for configuration-related defines.
+- **CONFIGURATION** Added two configuration files (ModSensorConfig.h and ModSensorDebugConfig.h) that all files read from to check for configuration-related defines.
 This allows Arduino IDE users who are unable to use build flags to more easily configure the library or enable debugging.
 It also allows PlatformIO users to avoid the time-consuming re-compile of all their libraries required when changing build flags.
   - **ALL** library configuration build flags previously in any other header file for the library have been moved into the ModSensorConfig.h file, including ADC, SDI-12, and variable array options.
@@ -290,7 +290,7 @@ If no epoch start is given, it is assumed to be UNIX (January 1, 1970).
   - The supported epochs are given in the enum epochStart.
 - Storing _buttonPinMode internally.
 - Added a single define (`MS_OUTPUT`) to use for all outputs from ModularSensors.
-- Added support for sending printouts and debugging to two different serial ports.  This is useful for devices (like SAMD) that use a built in USB serial port which is turned off when the device sleeps.  If `MS_2ND_OUTPUT` is defined, output will go to *both* `MS_2ND_OUTPUT` and to `MS_OUTPUT`.
+- Added support for sending printouts and debugging to two different serial ports. This is useful for devices (like SAMD) that use a built in USB serial port which is turned off when the device sleeps.  If `MS_2ND_OUTPUT` is defined, output will go to *both* `MS_2ND_OUTPUT` and to `MS_OUTPUT`.
 - Added example code for flashing boards with a neo-pixel in the menu example.
 - **NEW SENSOR** Added support for [Geolux HydroCam](https://www.geolux-radars.com/hydrocam)
 - **NEW SENSOR** Added support for [ANB Sensors pH Sensors](https://www.anbsensors.com/)
@@ -1043,7 +1043,7 @@ Support for all Atlas Scientific I2C sensors, compiler-safe begin functions
 
 ## [0.19.6] - 2019-02-27
 
-Modem Improvements & ADS1X15 Generalization
+Modem Improvements & ADS1x15 Generalization
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.2579301.svg)](https://doi.org/10.5281/zenodo.2579301)
 

--- a/cspell.json
+++ b/cspell.json
@@ -258,6 +258,8 @@
     "tiads1x15",
     "TINYGSM",
     "TINYUSB",
+    "TurbHigh",
+    "TurbLow",
     "u_blox",
     "u-blox",
     "ubee",

--- a/cspell.json
+++ b/cspell.json
@@ -158,7 +158,7 @@
     "IMEI",
     "IMSI",
     "INSITU",
-    "kilaohms",
+    "kiloohms",
     "LOGGERBASE",
     "LOGGERMODEM",
     "LTEBee",

--- a/examples/AWS_IoT_Core/AWS_IoT_Core.ino
+++ b/examples/AWS_IoT_Core/AWS_IoT_Core.ino
@@ -99,7 +99,7 @@ const int8_t modemLEDPin =
     redLED;  // MCU pin connected an LED to show modem status
 
 // Network connection information
-const char* wifiId = "YourWiFiSSID";  // The WiFi access point
+const char* wifiId  = "YourWiFiSSID";      // The WiFi access point
 const char* wifiPwd = "YourWiFiPassword";  // The WiFi password
 
 // Create the loggerModem object
@@ -145,8 +145,8 @@ const int8_t alsData = A8;  // The ALS PT-19 data pin
 #else
 const int8_t alsData = A4;  // The ALS PT-19 data pin
 #endif
-const int8_t  alsSupply     = 3.3;  // The ALS PT-19 supply power voltage
-const int8_t  alsResistance = 10;   // The ALS PT-19 loading resistance (in kΩ)
+const float   alsSupply     = 3.3f;  // The ALS PT-19 supply power voltage
+const int8_t  alsResistance = 10;    // The ALS PT-19 loading resistance (in kΩ)
 const uint8_t alsNumberReadings = 10;
 
 // Create a Everlight ALS-PT19 sensor object

--- a/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_2G/DRWI_2G.ino
+++ b/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_2G/DRWI_2G.ino
@@ -112,7 +112,6 @@ MaximDS3231 ds3231(1);
 
 const int8_t  OBS3Power = sensorPowerPin;  // Power pin (-1 if unconnected)
 const uint8_t OBS3NumberReadings = 10;
-const uint8_t ADSi2c_addr        = 0x48;  // The I2C address of the ADS1115 ADC
 // Campbell OBS 3+ *Low* Range Calibration in Volts
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 const float  OBSLow_A         = 0.000E+00;  // "A" value (X^2) [*low* range]
@@ -121,7 +120,7 @@ const float  OBSLow_C         = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NumberReadings);
 
 
 // Campbell OBS 3+ *High* Range Calibration in Volts
@@ -132,7 +131,7 @@ const float  OBSHigh_C         = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NumberReadings);
 /** End [obs3] */
 
 
@@ -217,7 +216,7 @@ Logger dataLogger(LoggerID, loggingInterval, &varArray);
 // Create a data publisher for the Monitor My Watershed POST endpoint
 #include <publishers/MonitorMyWatershedPublisher.h>
 MonitorMyWatershedPublisher MonitorMWPost(dataLogger, registrationToken,
-                                 samplingFeature);
+                                          samplingFeature);
 /** End [publishers] */
 
 

--- a/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_DigiLTE/DRWI_DigiLTE.ino
+++ b/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_DigiLTE/DRWI_DigiLTE.ino
@@ -120,7 +120,6 @@ MaximDS3231 ds3231(1);
 
 const int8_t  OBS3Power = sensorPowerPin;  // Power pin (-1 if unconnected)
 const uint8_t OBS3NumberReadings = 10;
-const uint8_t ADSi2c_addr        = 0x48;  // The I2C address of the ADS1115 ADC
 // Campbell OBS 3+ *Low* Range Calibration in Volts
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 const float  OBSLow_A         = 0.000E+00;  // "A" value (X^2) [*low* range]
@@ -129,7 +128,7 @@ const float  OBSLow_C         = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NumberReadings);
 
 
 // Campbell OBS 3+ *High* Range Calibration in Volts
@@ -140,7 +139,7 @@ const float  OBSHigh_C         = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NumberReadings);
 /** End [obs3] */
 
 

--- a/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_Mayfly1/DRWI_Mayfly1.ino
+++ b/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_Mayfly1/DRWI_Mayfly1.ino
@@ -85,7 +85,7 @@ const int8_t modemLEDPin = redLED;  // MCU pin connected an LED to show modem
 // Network connection information
 const char* apn =
     "YourAPN";  // APN connection name, typically Hologram unless you have a
-                 // different provider's SIM card. Change as needed
+                // different provider's SIM card. Change as needed
 
 // Create the modem object
 SIMComSIM7080 modem7080(&modemSerial, modemVccPin, modemStatusPin,

--- a/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_NoCellular/DRWI_NoCellular.ino
+++ b/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_NoCellular/DRWI_NoCellular.ino
@@ -83,7 +83,6 @@ MaximDS3231 ds3231(1);
 
 const int8_t  OBS3Power = sensorPowerPin;  // Power pin (-1 if unconnected)
 const uint8_t OBS3NumberReadings = 10;
-const uint8_t ADSi2c_addr        = 0x48;  // The I2C address of the ADS1115 ADC
 // Campbell OBS 3+ *Low* Range Calibration in Volts
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 const float  OBSLow_A         = 0.000E+00;  // "A" value (X^2) [*low* range]
@@ -92,7 +91,7 @@ const float  OBSLow_C         = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NumberReadings);
 
 
 // Campbell OBS 3+ *High* Range Calibration in Volts
@@ -103,7 +102,7 @@ const float  OBSHigh_C         = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NumberReadings);
 /** End [obs3] */
 
 

--- a/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_SIM7080LTE/DRWI_SIM7080LTE.ino
+++ b/examples/OutdatedExamples/DRWI_CitizenScience/DRWI_SIM7080LTE/DRWI_SIM7080LTE.ino
@@ -86,7 +86,7 @@ const int8_t modemLEDPin = redLED;  // MCU pin connected an LED to show modem
 // Network connection information
 const char* apn =
     "YourAPN";  // APN connection name, typically Hologram unless you have a
-                 // different provider's SIM card. Change as needed
+                // different provider's SIM card. Change as needed
 
 // Create the modem object
 SIMComSIM7080 modem7080(&modemSerial, modemVccPin, modemStatusPin,
@@ -144,7 +144,6 @@ MeterHydros21 hydros(*hydrosSDI12address, SDI12Power, SDI12Data,
 
 const int8_t  OBS3Power = sensorPowerPin;  // Power pin (-1 if unconnected)
 const uint8_t OBS3NumberReadings = 10;
-const uint8_t ADSi2c_addr        = 0x48;  // The I2C address of the ADS1115 ADC
 // Campbell OBS 3+ *Low* Range Calibration in Volts
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 const float  OBSLow_A         = 0.000E+00;  // "A" value (X^2) [*low* range]
@@ -153,7 +152,7 @@ const float  OBSLow_C         = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NumberReadings);
 
 
 // Campbell OBS 3+ *High* Range Calibration in Volts
@@ -164,7 +163,7 @@ const float  OBSHigh_C         = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NumberReadings);
 /** End [obs3] */
 
 

--- a/examples/baro_rho_correction/baro_rho_correction.ino
+++ b/examples/baro_rho_correction/baro_rho_correction.ino
@@ -483,3 +483,5 @@ void loop() {
     }
 }
 /** End [loop] */
+
+// cspell: words baro

--- a/examples/double_logger/double_logger.ino
+++ b/examples/double_logger/double_logger.ino
@@ -77,7 +77,7 @@ const int8_t modemLEDPin = redLED;   // MCU pin connected an LED to show modem
                                      // status (-1 if unconnected)
 
 // Network connection information
-const char* wifiId = "YourWiFiSSID";  // The WiFi access point
+const char* wifiId  = "YourWiFiSSID";      // The WiFi access point
 const char* wifiPwd = "YourWiFiPassword";  // The WiFi password
 
 DigiXBeeWifi modemXBWF(&modemSerial, modemVccPin, modemStatusPin,
@@ -360,3 +360,5 @@ void loop() {
     logger1min.systemSleep();
 }
 /** End [loop] */
+
+// cspell: words modemXBWF

--- a/examples/logging_to_ThingSpeak/logging_to_ThingSpeak.ino
+++ b/examples/logging_to_ThingSpeak/logging_to_ThingSpeak.ino
@@ -76,7 +76,7 @@ const int8_t modemLEDPin =
     redLED;  // MCU pin connected an LED to show modem status
 
 // Network connection information
-const char* wifiId = "YourWiFiSSID";  // The WiFi access point
+const char* wifiId  = "YourWiFiSSID";      // The WiFi access point
 const char* wifiPwd = "YourWiFiPassword";  // The WiFi password
 
 // Create the loggerModem object
@@ -118,7 +118,6 @@ MaximDS3231 ds3231(1);
 
 const int8_t  OBS3Power = sensorPowerPin;  // Power pin (-1 if unconnected)
 const uint8_t OBS3NumberReadings = 10;
-const uint8_t ADSi2c_addr        = 0x48;  // The I2C address of the ADS1115 ADC
 // Campbell OBS 3+ *Low* Range Calibration in Volts
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 const float  OBSLow_A         = 0.000E+00;  // "A" value (X^2) [*low* range]
@@ -127,7 +126,7 @@ const float  OBSLow_C         = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NumberReadings);
 
 
 // Campbell OBS 3+ *High* Range Calibration in Volts
@@ -138,7 +137,7 @@ const float  OBSHigh_C         = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NumberReadings);
 /** End [obs3] */
 
 
@@ -350,3 +349,5 @@ void loop() {
     }
 }
 /** End [loop] */
+
+// cSpell: words TurbHigh TurbLow setRESTAPIKey

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1001,8 +1001,8 @@ Variable* ds3231Temp =
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t      AlphasenseCO2Power = sensorPowerPin;  // Power pin
-tiads1x15_adsDiffMux_t AlphasenseDiffMux =
-    tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3;  // Differential voltage config
+aco2_adsDiffMux_t AlphasenseDiffMux =
+    DIFF_MUX_2_3;  // Differential voltage config
 const uint8_t AlphasenseCO2ADSi2c_addr =
     0x48;  // The I2C address of the ADS1115 ADC
 
@@ -2301,7 +2301,7 @@ Variable* cyclopsRedChloro = new TurnerCyclops_RedChlorophyll(
 const int8_t     turbidityPlusPower = sensorPowerPin;  // Power pin
 const int8_t     turbidityPlusWiper = relayPowerPin;   // Wiper pin
 ttp_adsDiffMux_t turbidityPlusDiffMux =
-    tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3;  // Differential voltage config
+    DIFF_MUX_2_3;  // Differential voltage config
 const uint8_t turbidityPlusNumberReadings = 10;
 const uint8_t turbidityPlusADSi2c_addr =
     0x48;                                 // The I2C address of the ADS1115 ADC

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -998,23 +998,35 @@ Variable* ds3231Temp =
 // ==========================================================================
 /** Start [alphasense_co2] */
 #include <sensors/AlphasenseCO2.h>
+#include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t      AlphasenseCO2Power = sensorPowerPin;  // Power pin
-aco2_adsDiffMux_t AlphasenseDiffMux =
-    DIFF_MUX_2_3;  // Differential voltage config
-const uint8_t AlphasenseCO2ADSi2c_addr =
-    0x48;  // The I2C address of the ADS1115 ADC
+const int8_t  asCO2Power    = sensorPowerPin;  // Power pin
+const int8_t  asCO2Channel1 = 2;               // First differential channel
+const int8_t  asCO2Channel2 = 3;               // Second differential channel
+const uint8_t asCO2Meas     = 1;               // Second differential channel
 
 // Create an Alphasense CO2 sensor object
-AlphasenseCO2 alphasenseCO2(AlphasenseCO2Power, AlphasenseDiffMux,
-                            AlphasenseCO2ADSi2c_addr);
+AlphasenseCO2 alphasenseCO2(asCO2Power, asCO2Channel1, asCO2Channel2,
+                            asCO2Meas);
 
 // Create PAR and raw voltage variable pointers for the CO2
 Variable* asCO2        = new AlphasenseCO2_CO2(&alphasenseCO2,
                                                "12345678-abcd-1234-ef00-1234567890ab");
 Variable* asco2voltage = new AlphasenseCO2_Voltage(
     &alphasenseCO2, "12345678-abcd-1234-ef00-1234567890ab");
+
+// create a custom analog reader based on the TI ADS1115 (optional)
+float         AsCO2Multiplier = 1.0f;      // factor for a voltage divider
+adsGain_t     AsCO2AdsGain    = GAIN_ONE;  // gain of the ADS1115
+float         AsCO2adsSupply  = 3.3f;      // supply voltage of the ADS1115
+const uint8_t AsCO2i2c_addr   = 0x48;      // The I2C address of the ADS1115 ADC
+TIADS1x15Base AsCO2ADS(AsCO2Multiplier, AsCO2AdsGain, AsCO2adsSupply,
+                       AsCO2i2c_addr);
+
+// Create an Alphasense CO2 sensor object with the custom TIADS1x15Base
+AlphasenseCO2 alphasenseCO2_c(asCO2Power, asCO2Channel1, asCO2Channel2,
+                              asCO2Meas, &AsCO2ADS);
 /** End [alphasense_co2] */
 #endif
 
@@ -1035,14 +1047,14 @@ Variable* asco2voltage = new AlphasenseCO2_Voltage(
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 byte anbModbusAddress =
     0x55;  // The modbus address of ANB pH Sensor (0x55 is the default)
-const int8_t  anbPower          = sensorPowerPin;  // ANB pH Sensor power pin
-const int8_t  alAdapterPower    = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  al485EnablePin    = -1;              // Adapter RE/DE pin
-const uint8_t anbNumberReadings = 1;
+const int8_t  anbPower       = sensorPowerPin;  // ANB pH Sensor power pin
+const int8_t  alAdapterPower = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  al485EnablePin = -1;              // Adapter RE/DE pin
+const uint8_t anbNReadings   = 1;
 
 // Create an ANB pH sensor object
 ANBpH anbPH(anbModbusAddress, modbusSerial, anbPower, loggingInterval,
-            alAdapterPower, al485EnablePin, anbNumberReadings);
+            alAdapterPower, al485EnablePin, anbNReadings);
 
 // Create all of the variable pointers for the ANB pH sensor
 Variable* anbPHValue = new ANBpH_pH(&anbPH,
@@ -1120,20 +1132,32 @@ Variable* dhtHI   = new AOSongDHT_HI(&dht,
 // ==========================================================================
 /** Start [apogee_sq212] */
 #include <sensors/ApogeeSQ212.h>
+#include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  SQ212Power       = sensorPowerPin;  // Power pin
-const int8_t  SQ212ADSChannel  = 3;     // The ADS channel for the SQ212
-const uint8_t SQ212ADSi2c_addr = 0x48;  // The I2C address of the ADS1115 ADC
+const int8_t  sq212Power      = sensorPowerPin;  // Power pin
+const int8_t  sq212ADSChannel = 3;  // The ADS channel for the SQ212
+const uint8_t sq212Readings   = 1;  // The ADS channel for the SQ212
 
-// Create an Apogee SQ212 sensor object
-ApogeeSQ212 SQ212(SQ212Power, SQ212ADSChannel, SQ212ADSi2c_addr);
+// Create an Apogee SQ212 sensor object with the default voltage reader
+ApogeeSQ212 sq212(sq212Power, sq212ADSChannel);
 
 // Create PAR and raw voltage variable pointers for the SQ212
 Variable* sq212PAR =
-    new ApogeeSQ212_PAR(&SQ212, "12345678-abcd-1234-ef00-1234567890ab");
+    new ApogeeSQ212_PAR(&sq212, "12345678-abcd-1234-ef00-1234567890ab");
 Variable* sq212voltage =
-    new ApogeeSQ212_Voltage(&SQ212, "12345678-abcd-1234-ef00-1234567890ab");
+    new ApogeeSQ212_Voltage(&sq212, "12345678-abcd-1234-ef00-1234567890ab");
+
+// create a custom analog reader based on the TI ADS1115 (optional)
+float         sq212Multiplier = 1.0f;      // factor for a voltage divider
+adsGain_t     sq212AdsGain    = GAIN_ONE;  // gain of the ADS1115
+float         sq212adsSupply  = 3.3f;      // supply voltage of the ADS1115
+const uint8_t sq212i2c_addr   = 0x48;      // The I2C address of the ADS1115 ADC
+TIADS1x15Base sq212ADS(sq212Multiplier, sq212AdsGain, sq212adsSupply,
+                       sq212i2c_addr);
+
+// Create an Apogee SQ212 sensor object with the custom TIADS1x15Base
+ApogeeSQ212 sq212_c(sq212Power, sq212ADSChannel, sq212Readings, &sq212ADS);
 /** End [apogee_sq212] */
 #endif
 
@@ -1436,11 +1460,12 @@ Variable* clarivueError = new CampbellClariVUE10_ErrorCode(
 // ==========================================================================
 /** Start [campbell_obs3] */
 #include <sensors/CampbellOBS3.h>
+#include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  OBS3Power          = sensorPowerPin;  // Power pin
-const uint8_t OBS3NumberReadings = 10;
-const uint8_t OBS3ADSi2c_addr    = 0x48;  // The I2C address of the ADS1115 ADC
+const int8_t  OBS3Power       = sensorPowerPin;  // Power pin
+const uint8_t OBS3NReadings   = 10;
+const uint8_t OBS3AdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
 
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 
@@ -1451,7 +1476,7 @@ const float OBSLow_C = 0.000E+00;  // "C" value [*low* range]
 
 // Create a Campbell OBS3+ *low* range sensor object
 CampbellOBS3 osb3low(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B, OBSLow_C,
-                     OBS3ADSi2c_addr, OBS3NumberReadings);
+                     OBS3NReadings);
 
 // Create turbidity and voltage variable pointers for the low range  of the OBS3
 Variable* obs3TurbLow = new CampbellOBS3_Turbidity(
@@ -1469,13 +1494,31 @@ const float OBSHigh_C = 0.000E+00;  // "C" value [*high* range]
 
 // Create a Campbell OBS3+ *high* range sensor object
 CampbellOBS3 osb3high(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
-                      OBSHigh_C, OBS3ADSi2c_addr, OBS3NumberReadings);
+                      OBSHigh_C, OBS3NReadings);
 
 // Create turbidity and voltage variable pointers for the high range of the OBS3
 Variable* obs3TurbHigh = new CampbellOBS3_Turbidity(
     &osb3high, "12345678-abcd-1234-ef00-1234567890ab", "TurbHigh");
 Variable* obs3VoltHigh = new CampbellOBS3_Voltage(
     &osb3high, "12345678-abcd-1234-ef00-1234567890ab", "TurbHighV");
+
+// create a custom analog reader based on the TI ADS1115 (optional)
+float         OBS3Multiplier       = 1.0f;      // factor for a voltage divider
+adsGain_t     OBS3AdsGain          = GAIN_ONE;  // gain of the ADS1115
+float         OBS3AdsSupplyVoltage = 3.3f;      // supply voltage of the ADS1115
+const uint8_t OBS3AdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
+TIADS1x15Base OBSADS(OBS3Multiplier, OBS3AdsGain, OBS3AdsSupplyVoltage,
+                     OBS3AdsI2C_addr);
+
+// Create a Campbell OBS3+ *low* range sensor object with the custom
+// TIADS1x15Base
+CampbellOBS3 osb3low_c(OBS3Power, OBSLowADSChannel, OBSLow_A, OBSLow_B,
+                       OBSLow_C, OBS3NReadings, &OBSADS);
+
+// Create a Campbell OBS3+ *high* range sensor object with the custom
+// TIADS1x15Base
+CampbellOBS3 osb3high_c(OBS3Power, OBSHighADSChannel, OBSHigh_A, OBSHigh_B,
+                        OBSHigh_C, OBS3NReadings, &OBSADS);
 /** End [campbell_obs3] */
 #endif
 
@@ -1517,13 +1560,13 @@ Variable* rainvueRainRateMax = new CampbellRainVUE10_RainRateMax(
 #include <sensors/DecagonCTD.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const char*   CTDSDI12address   = "1";  // The SDI-12 Address of the CTD
-const uint8_t CTDNumberReadings = 6;    // The number of readings to average
-const int8_t  CTDPower          = sensorPowerPin;  // Power pin
-const int8_t  CTDData           = sdi12DataPin;    // The SDI-12 data pin
+const char*   CTDSDI12address = "1";  // The SDI-12 Address of the CTD
+const uint8_t CTDNReadings    = 6;    // The number of readings to average
+const int8_t  CTDPower        = sensorPowerPin;  // Power pin
+const int8_t  CTDData         = sdi12DataPin;    // The SDI-12 data pin
 
 // Create a Decagon CTD sensor object
-DecagonCTD ctd(*CTDSDI12address, CTDPower, CTDData, CTDNumberReadings);
+DecagonCTD ctd(*CTDSDI12address, CTDPower, CTDData, CTDNReadings);
 
 // Create conductivity, temperature, and depth variable pointers for the CTD
 Variable* ctdCond = new DecagonCTD_Cond(&ctd,
@@ -1544,13 +1587,13 @@ Variable* ctdDepth =
 #include <sensors/DecagonES2.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const char*   ES2SDI12address   = "3";  // The SDI-12 Address of the ES2
-const int8_t  ES2Power          = sensorPowerPin;  // Power pin
-const int8_t  ES2Data           = sdi12DataPin;    // The SDI-12 data pin
-const uint8_t ES2NumberReadings = 5;
+const char*   ES2SDI12address = "3";  // The SDI-12 Address of the ES2
+const int8_t  ES2Power        = sensorPowerPin;  // Power pin
+const int8_t  ES2Data         = sdi12DataPin;    // The SDI-12 data pin
+const uint8_t ES2NReadings    = 5;
 
 // Create a Decagon ES2 sensor object
-DecagonES2 es2(*ES2SDI12address, ES2Power, ES2Data, ES2NumberReadings);
+DecagonES2 es2(*ES2SDI12address, ES2Power, ES2Data, ES2NReadings);
 
 // Create specific conductance and temperature variable pointers for the ES2
 Variable* es2Cond = new DecagonES2_Cond(&es2,
@@ -1567,6 +1610,7 @@ Variable* es2Temp = new DecagonES2_Temp(&es2,
 // ==========================================================================
 /** Start [everlight_alspt19] */
 #include <sensors/EverlightALSPT19.h>
+#include <sensors/ProcessorAnalog.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t alsPower = sensorPowerPin;  // Power pin
@@ -1577,14 +1621,15 @@ const int8_t alsData = A4;  // The ALS PT-19 data pin
 #endif
 const int8_t  alsSupply     = 3.3;  // The ALS PT-19 supply power voltage
 const int8_t  alsResistance = 10;   // The ALS PT-19 loading resistance (in kΩ)
-const uint8_t alsNumberReadings = 10;
+const uint8_t alsNReadings  = 10;
 
 // Create a Everlight ALS-PT19 sensor object
 EverlightALSPT19 alsPt19(alsPower, alsData, alsSupply, alsResistance,
-                         alsNumberReadings);
+                         alsNReadings);
 
-// For an EnviroDIY Mayfly, you can use the abbreviated version
-// EverlightALSPT19 alsPt19(alsNumberReadings);
+// For a board with ALS parameters set in KnownProcessors.h (ie, an EnviroDIY
+// Mayfly or Stonefly), you can simply do:
+// EverlightALSPT19 alsPt19_mf(alsNReadings);
 
 // Create voltage, current, and illuminance variable pointers for the ALS-PT19
 Variable* alsPt19Volt = new EverlightALSPT19_Voltage(
@@ -1592,7 +1637,17 @@ Variable* alsPt19Volt = new EverlightALSPT19_Voltage(
 Variable* alsPt19Current = new EverlightALSPT19_Current(
     &alsPt19, "12345678-abcd-1234-ef00-1234567890ab");
 Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
-    &alsPt19, "12345678-abcd-1234-ef00-1234567890ab");
+    &alsPt19, "b7cf9961-246a-4443-b57f-0526fecfea8f");
+
+// create a custom analog reader based on the Processor ADC (optional)
+float               alsMultiplier = 1.0f;  // factor for a voltage divider
+float               alsAdsSupply = 3.3f;  // supply voltage of the Processor ADC
+ProcessorAnalogBase alsADS(alsMultiplier, alsAdsSupply);
+
+// Create an Everlight ALS-PT19 sensor object with the custom
+// ProcessorAnalogBase
+EverlightALSPT19 alsPt19_c(alsPower, alsData, alsSupply, alsResistance,
+                           alsNReadings, &alsADS);
 /** End [everlight_alspt19] */
 #endif
 
@@ -1605,19 +1660,32 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 #include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t ADSPower   = sensorPowerPin;  // Power pin
-const int8_t ADSChannel = 2;               // The ADS channel of interest
-const float  voltageMultiplier =
-    1.0f;  // Voltage multiplier for an external voltage divider
-// use 1.0f for direct connection
-// use (R_top + R_bottom) / R_bottom for voltage divider
-const adsGain_t adsPGAGain = GAIN_ONE;  // The internal gain setting for the ADS
-const uint8_t evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
-const uint8_t VoltReadsToAvg = 1;     // Only read one sample
+const int8_t evADSPower = sensorPowerPin;  // Power pin
+const int8_t evADSChannel1 =
+    2;  // The first ADS channel (or only for single-ended readings)
+const int8_t evADSChannel2 =
+    3;  // The second ADS channel (for differential readings).  Pass -1 for
+        // single-ended readings.
+const uint8_t evReadsToAvg = 1;  // Only read one sample
 
-// Create a TI ADS1x15 sensor object
-TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, adsPGAGain,
-                  evADSi2c_addr, VoltReadsToAvg);
+// Create a single-ended External Voltage sensor object with the default
+// TIADS1x15Base
+TIADS1x15 ads1x15(evADSPower, evADSChannel1);
+// Create a differential External Voltage sensor object with the default
+// TIADS1x15Base
+TIADS1x15 ads1x15_d(evADSPower, evADSChannel1, evADSChannel2);
+
+// create a custom ADS instance (optional)
+float         evVoltageMultiplier = 1.0f;      // factor for a voltage divider
+adsGain_t     evAdsGain           = GAIN_ONE;  // gain of the ADS1115
+float         evAdsSupplyVoltage  = 3.3f;      // supply voltage of the ADS1115
+const uint8_t evAdsI2C_addr       = 0x48;  // The I2C address of the ADS1115 ADC
+TIADS1x15Base evADS(evVoltageMultiplier, evAdsGain, evAdsSupplyVoltage,
+                    evAdsI2C_addr);
+
+// Create a single ended External Voltage sensor object with the custom
+// TIADS1x15Base
+TIADS1x15 ads1x15_c(evADSPower, evADSChannel1, -1, evReadsToAvg, &evADS);
 
 // Create a voltage variable pointer
 Variable* ads1x15Volt =
@@ -1634,20 +1702,29 @@ Variable* ads1x15Volt =
 #include <sensors/ProcessorAnalog.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t processorAnalogPowerPin = sensorPowerPin;  // Power pin
-const int8_t processorAnalogDataPin  = A0;  // Analog input pin (processor ADC)
-const float  processorAnalogMultiplier =
-    5.58;                        //  Gain setting if using a voltage divider
-const uint8_t eaReadsToAvg = 1;  // Only read one sample
+const int8_t  processorAnalogPowerPin = sensorPowerPin;  // Power pin
+const int8_t  processorAnalogDataPin  = A0;  // Analog input pin (processor ADC)
+const uint8_t processorAnalogNReadings = 1;  // Only read one sample
 
-// Create an Processor Analog sensor object
-ProcessorAnalog extAnalog(processorAnalogPowerPin, processorAnalogDataPin,
-                          processorAnalogMultiplier, OPERATING_VOLTAGE,
-                          eaReadsToAvg);
+// Create a Processor Analog sensor object with the default ProcessorAnalogBase
+ProcessorAnalog processorAnalog(processorAnalogPowerPin, processorAnalogDataPin,
+                                processorAnalogNReadings);
+
+// create a custom analog reader based on the Processor ADC (optional)
+float processorAnalogMultiplier = 1.0f;  // factor for a voltage divider
+float processorAnalogSupply     = 3.3f;  // supply voltage of the Processor ADC
+ProcessorAnalogBase processorAnalogBaseCustom(processorAnalogMultiplier,
+                                              processorAnalogSupply);
+
+// Create a Processor Analog sensor object with the custom ProcessorAnalogBase
+ProcessorAnalog processorAnalog_c(processorAnalogPowerPin,
+                                  processorAnalogDataPin,
+                                  processorAnalogNReadings,
+                                  &processorAnalogBaseCustom);
 
 // Create a voltage variable pointer
-Variable* extAnalogVolts = new ProcessorAnalog_Voltage(
-    &extAnalog, "12345678-abcd-1234-ef00-1234567890ab");
+Variable* processorAnalogVolts = new ProcessorAnalog_Voltage(
+    &processorAnalog, "12345678-abcd-1234-ef00-1234567890ab");
 /** End [processor_analog] */
 #endif
 
@@ -1719,16 +1796,16 @@ Variable* hydrocamByteError = new GeoluxHydroCam_ByteError(
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 byte gplp8ModbusAddress = 0x19;  // The modbus address of the gplp8
 // Raw Request >>> {0x19, 0x03, 0x00, 0xC8, 0x00, 0x01, 0x06, 0x2C}
-const int8_t  gplp8AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  gplp8SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  gplp8EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t gplp8NumberReadings = 1;
+const int8_t  gplp8AdapterPower = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  gplp8SensorPower  = relayPowerPin;   // Sensor power pin
+const int8_t  gplp8EnablePin    = -1;              // Adapter RE/DE pin
+const uint8_t gplp8NReadings    = 1;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a GroPoint Profile GPLP-8 sensor object
 GroPointGPLP8 gplp8(gplp8ModbusAddress, modbusSerial, gplp8AdapterPower,
-                    gplp8SensorPower, gplp8EnablePin, gplp8NumberReadings);
+                    gplp8SensorPower, gplp8EnablePin, gplp8NReadings);
 
 // Create moisture variable pointers for each segment of the GPLP-8
 Variable* gplp8Moist1 = new GroPointGPLP8_Moist(
@@ -1787,13 +1864,13 @@ Variable* gplp8Temp13 = new GroPointGPLP8_Temp(
 #include <sensors/InSituRDO.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const char*   RDOSDI12address   = "5";  // The SDI-12 Address of the RDO PRO-X
-const int8_t  RDOPower          = sensorPowerPin;  // Power pin
-const int8_t  RDOData           = sdi12DataPin;    // The SDI-12 data pin
-const uint8_t RDONumberReadings = 3;
+const char*   rdoSDI12address = "5";  // The SDI-12 Address of the RDO PRO-X
+const int8_t  rdoPower        = sensorPowerPin;  // Power pin
+const int8_t  rdoData         = sdi12DataPin;    // The SDI-12 data pin
+const uint8_t rdoNReadings    = 3;
 
 // Create an In-Situ RDO PRO-X dissolved oxygen sensor object
-InSituRDO insituRDO(*RDOSDI12address, RDOPower, RDOData, RDONumberReadings);
+InSituRDO insituRDO(*rdoSDI12address, rdoPower, rdoData, rdoNReadings);
 
 // Create dissolved oxygen percent, dissolved oxygen concentration, temperature,
 // and oxygen partial pressure variable pointers for the RDO PRO-X
@@ -1817,16 +1894,16 @@ Variable* rdoO2pp =
 #include <sensors/InSituTrollSdi12a.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const char* TROLLSDI12address =
+const char* trollSDI12address =
     "1";  // The SDI-12 Address of the Aqua/Level TROLL
-const int8_t TROLLPower =
+const int8_t trollPower =
     sensorPowerPin;  // Pin to switch power on and off (-1 if unconnected)
-const int8_t  TROLLData           = sdi12DataPin;  // The SDI-12 data pin
-const uint8_t TROLLNumberReadings = 2;  // The number of readings to average
+const int8_t  trollData      = sdi12DataPin;  // The SDI-12 data pin
+const uint8_t trollNReadings = 2;  // The number of readings to average
 
 // Create an In-Situ TROLL sensor object
-InSituTrollSdi12a insituTROLL(*TROLLSDI12address, TROLLPower, TROLLData,
-                              TROLLNumberReadings);
+InSituTrollSdi12a insituTROLL(*trollSDI12address, trollPower, trollData,
+                              trollNReadings);
 
 // Create pressure, temperature, and depth variable pointers for the TROLL
 Variable* trollPressure = new InSituTrollSdi12a_Pressure(
@@ -1857,13 +1934,12 @@ byte acculevelModbusAddress  = 0x01;  // The modbus address of KellerAcculevel
 const int8_t  acculevelPower = relayPowerPin;   // Acculevel Sensor power pin
 const int8_t  alAdapterPower = sensorPowerPin;  // RS485 adapter power pin
 const int8_t  al485EnablePin = -1;              // Adapter RE/DE pin
-const uint8_t acculevelNumberReadings = 5;
+const uint8_t acculevelNReadings = 5;
 // The manufacturer recommends taking and averaging a few readings
 
 // Create a Keller Acculevel sensor object
 KellerAcculevel acculevel(acculevelModbusAddress, modbusSerial, alAdapterPower,
-                          acculevelPower, al485EnablePin,
-                          acculevelNumberReadings);
+                          acculevelPower, al485EnablePin, acculevelNReadings);
 
 // Create pressure, temperature, and height variable pointers for the Acculevel
 Variable* acculevPress = new KellerAcculevel_Pressure(
@@ -1894,13 +1970,12 @@ byte nanolevelModbusAddress  = 0x01;  // The modbus address of KellerNanolevel
 const int8_t  nlAdapterPower = sensorPowerPin;  // RS485 adapter power pin
 const int8_t  nanolevelPower = relayPowerPin;   // Sensor power pin
 const int8_t  nl485EnablePin = -1;              // Adapter RE/DE pin
-const uint8_t nanolevelNumberReadings = 5;
+const uint8_t nanolevelNReadings = 5;
 // The manufacturer recommends taking and averaging a few readings
 
 // Create a Keller Nanolevel sensor object
 KellerNanolevel nanolevel(nanolevelModbusAddress, modbusSerial, nlAdapterPower,
-                          nanolevelPower, nl485EnablePin,
-                          nanolevelNumberReadings);
+                          nanolevelPower, nl485EnablePin, nanolevelNReadings);
 
 // Create pressure, temperature, and height variable pointers for the Nanolevel
 Variable* nanolevPress = new KellerNanolevel_Pressure(
@@ -1930,12 +2005,12 @@ Variable* nanolevHeight = new KellerNanolevel_Height(
 const int8_t SonarPower    = sensorPowerPin;  // Excite (power) pin
 const int8_t Sonar1Trigger = -1;              // Trigger pin
 // Trigger should be a *unique* negative number if unconnected
-const int16_t Sonar1MaxRange       = 9999;  // Maximum range of sonar
-const uint8_t sonar1NumberReadings = 3;     // The number of readings to average
+const int16_t Sonar1MaxRange  = 9999;  // Maximum range of sonar
+const uint8_t sonar1NReadings = 3;     // The number of readings to average
 
 // Create a MaxBotix Sonar sensor object
 MaxBotixSonar sonar1(sonarSerial, SonarPower, Sonar1Trigger, Sonar1MaxRange,
-                     sonar1NumberReadings);
+                     sonar1NReadings);
 
 // Create an ultrasonic range variable pointer
 Variable* sonar1Range =
@@ -1957,12 +2032,12 @@ Variable* sonar1Range =
 DeviceAddress OneWireAddress1 = {0x28, 0xFF, 0xBD, 0xBA,
                                  0x81, 0x16, 0x03, 0x0C};
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t OneWirePower       = sensorPowerPin;  // Power pin
-const int8_t OneWireBus         = A0;              // OneWire Bus Pin
-const int8_t ds18NumberReadings = 3;
+const int8_t OneWirePower  = sensorPowerPin;  // Power pin
+const int8_t OneWireBus    = A0;              // OneWire Bus Pin
+const int8_t ds18NReadings = 3;
 
 // Create a Maxim DS18 sensor objects (use this form for a known address)
-MaximDS18 ds18(OneWireAddress1, OneWirePower, OneWireBus, ds18NumberReadings);
+MaximDS18 ds18(OneWireAddress1, OneWirePower, OneWireBus, ds18NReadings);
 
 // Create a Maxim DS18 sensor object (use this form for a single sensor on bus
 // with an unknown address)
@@ -2039,13 +2114,13 @@ Variable* fivetmTemp =
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const char*   hydros21SDI12address = "1";  // The SDI-12 Address of the Hydros21
-const uint8_t hydros21NumberReadings = 6;  // The number of readings to average
-const int8_t  hydros21Power          = sensorPowerPin;  // Power pin
-const int8_t  hydros21Data           = sdi12DataPin;    // The SDI-12 data pin
+const uint8_t hydros21NReadings    = 6;    // The number of readings to average
+const int8_t  hydros21Power        = sensorPowerPin;  // Power pin
+const int8_t  hydros21Data         = sdi12DataPin;    // The SDI-12 data pin
 
 // Create a Decagon Hydros21 sensor object
 MeterHydros21 hydros21(*hydros21SDI12address, hydros21Power, hydros21Data,
-                       hydros21NumberReadings);
+                       hydros21NReadings);
 
 // Create conductivity, temperature, and depth variable pointers for the
 // Hydros21
@@ -2070,11 +2145,11 @@ Variable* hydros21Depth =
 const char*   teros11SDI12address = "4";  // The SDI-12 Address of the Teros 11
 const int8_t  terosPower          = sensorPowerPin;  // Power pin
 const int8_t  terosData           = sdi12DataPin;    // The SDI-12 data pin
-const uint8_t teros11NumberReadings = 3;  // The number of readings to average
+const uint8_t teros11NReadings    = 3;  // The number of readings to average
 
 // Create a METER TEROS 11 sensor object
 MeterTeros11 teros11(*teros11SDI12address, terosPower, terosData,
-                     teros11NumberReadings);
+                     teros11NReadings);
 
 // Create the matric potential, volumetric water content, and temperature
 // variable pointers for the Teros 11
@@ -2236,11 +2311,13 @@ Variable* inaPower = new TIINA219_Power(&ina219,
 // ==========================================================================
 /** Start [turner_cyclops] */
 #include <sensors/TurnerCyclops.h>
+#include <sensors/TIADS1x15.h>
+#include <sensors/ProcessorAnalog.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  cyclopsPower          = sensorPowerPin;  // Power pin
-const uint8_t cyclopsNumberReadings = 10;
-const uint8_t cyclopsADSi2c_addr = 0x48;  // The I2C address of the ADS1115 ADC
+const int8_t  cyclopsPower       = sensorPowerPin;  // Power pin
+const uint8_t cyclopsNReadings   = 10;
+const uint8_t cyclopsAdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
 const int8_t  cyclopsADSChannel  = 0;     // ADS channel
 
 // Cyclops calibration information
@@ -2253,8 +2330,7 @@ const float cyclopsBlankVolt =
 
 // Create a Turner Cyclops sensor object
 TurnerCyclops cyclops(cyclopsPower, cyclopsADSChannel, cyclopsStdConc,
-                      cyclopsStdVolt, cyclopsBlankVolt, cyclopsADSi2c_addr,
-                      cyclopsNumberReadings);
+                      cyclopsStdVolt, cyclopsBlankVolt, cyclopsNReadings);
 
 // Create the voltage variable pointer - used for any type of Cyclops
 Variable* cyclopsVoltage =
@@ -2288,6 +2364,29 @@ Variable* cyclopsTryptophan = new TurnerCyclops_Tryptophan(
     &cyclops, "12345678-abcd-1234-ef00-1234567890ab");
 Variable* cyclopsRedChloro = new TurnerCyclops_RedChlorophyll(
     &cyclops, "12345678-abcd-1234-ef00-1234567890ab");
+
+// create a custom analog reader based on the TI ADS1115 (optional)
+float         cyclopsMultiplier       = 1.0f;  // factor for a voltage divider
+adsGain_t     cyclopsAdsGain          = GAIN_ONE;  // gain of the ADS1115
+float         cyclopsAdsSupplyVoltage = 3.3f;  // supply voltage of the ADS1115
+const uint8_t cyclopsAdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
+TIADS1x15Base cyclopsADS(cyclopsMultiplier, cyclopsAdsGain,
+                         cyclopsAdsSupplyVoltage, cyclopsAdsI2C_addr);
+
+// Create a Turner Cyclops sensor object with the custom ADS instance
+TurnerCyclops cyclops_c(cyclopsPower, cyclopsADSChannel, cyclopsStdConc,
+                        cyclopsStdVolt, cyclopsBlankVolt, cyclopsNReadings,
+                        &cyclopsADS);
+
+// create a custom analog reader based on the Processor ADC (optional)
+float cyclopsMultiplier2 = 1.0f;  // factor for a voltage divider
+float cyclopsSupply2     = 3.3f;  // supply voltage of the Processor ADC
+ProcessorAnalogBase cyclopsADS2(cyclopsMultiplier2, cyclopsSupply2);
+
+// Create a Turner Cyclops sensor object with the custom ADS instance
+TurnerCyclops cyclops_c2(cyclopsPower, cyclopsADSChannel, cyclopsStdConc,
+                         cyclopsStdVolt, cyclopsBlankVolt, cyclopsNReadings,
+                         &cyclopsADS2);
 /** End [turner_cyclops] */
 #endif
 
@@ -2298,39 +2397,48 @@ Variable* cyclopsRedChloro = new TurnerCyclops_RedChlorophyll(
 // ==========================================================================
 /** Start [turner_turbidity_plus] */
 #include <sensors/TurnerTurbidityPlus.h>
+#include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t     turbidityPlusPower = sensorPowerPin;  // Power pin
-const int8_t     turbidityPlusWiper = relayPowerPin;   // Wiper pin
-ttp_adsDiffMux_t turbidityPlusDiffMux =
-    DIFF_MUX_2_3;  // Differential voltage config
-const uint8_t turbidityPlusNumberReadings = 10;
-const uint8_t turbidityPlusADSi2c_addr =
-    0x48;                                 // The I2C address of the ADS1115 ADC
-adsGain_t turbidityPlusGain  = GAIN_ONE;  // The gain of the ADS
-float tpVoltageDividerFactor = 1;  // The factor for a voltage divider, if any
+const int8_t  ttPlusPower    = sensorPowerPin;  // Power pin
+const int8_t  ttPlusWiper    = relayPowerPin;   // Wiper pin
+const int8_t  ttPlusChannel1 = 2;               // First differential channel
+const int8_t  ttPlusChannel2 = 3;               // Second differential channel
+const uint8_t ttPlusReadings = 10;
 
 // Turbidity Plus calibration information
-const float turbidityPlusStdConc = 1.000;  // Concentration of the standard used
-                                           // for a 1-point sensor calibration.
-const float turbidityPlusStdVolt =
+const float ttPlusStdConc = 1.000;  // Concentration of the standard used
+                                    // for a 1-point sensor calibration.
+const float ttPlusStdVolt =
     1.000;  // The voltage (in volts) measured for the conc_std.
-const float turbidityPlusBlankVolt =
+const float ttPlusBlankVolt =
     0.000;  // The voltage (in volts) measured for a blank.
 
 // Create a Turner Turbidity Plus sensor object
-TurnerTurbidityPlus turbidityPlus(turbidityPlusPower, turbidityPlusWiper,
-                                  turbidityPlusDiffMux, turbidityPlusStdConc,
-                                  turbidityPlusStdVolt, turbidityPlusBlankVolt,
-                                  turbidityPlusADSi2c_addr, turbidityPlusGain,
-                                  turbidityPlusNumberReadings,
-                                  tpVoltageDividerFactor);
+const uint8_t       ttPlusReadings = 10;
+TurnerTurbidityPlus turbidityPlus(ttPlusPower, ttPlusWiper, ttPlusChannel1,
+                                  ttPlusChannel2, ttPlusStdConc, ttPlusStdVolt,
+                                  ttPlusBlankVolt, ttPlusReadings);
 
 // Create the variable pointers
 Variable* turbidityPlusVoltage = new TurnerTurbidityPlus_Voltage(
     &turbidityPlus, "12345678-abcd-1234-ef00-1234567890ab");
 Variable* turbidityPlusTurbidity = new TurnerTurbidityPlus_Turbidity(
     &turbidityPlus, "12345678-abcd-1234-ef00-1234567890ab");
+
+// create a custom analog reader based on the TI ADS1115 (optional)
+float         ttPlusMultiplier = 1.0f;      // factor for a voltage divider
+adsGain_t     ttPlusAdsGain    = GAIN_ONE;  // gain of the ADS1115
+float         ttPlusAdsSupply  = 3.3f;      // supply voltage of the ADS1115
+const uint8_t ttPlusI2C_addr   = 0x48;  // The I2C address of the ADS1115 ADC
+TIADS1x15Base ttPlusADS(ttPlusMultiplier, ttPlusAdsGain, ttPlusAdsSupply,
+                        ttPlusI2C_addr);
+
+// Create a Turner Turbidity Plus sensor object with the custom TIADS1x15Base
+TurnerTurbidityPlus turbidityPlus_c(ttPlusPower, ttPlusWiper, ttPlusChannel1,
+                                    ttPlusChannel2, ttPlusStdConc,
+                                    ttPlusStdVolt, ttPlusBlankVolt,
+                                    ttPlusReadings, &ttPlusADS);
 /** End [turner_turbidity_plus] */
 #endif
 
@@ -2341,16 +2449,18 @@ Variable* turbidityPlusTurbidity = new TurnerTurbidityPlus_Turbidity(
 // ==========================================================================
 /** Start [analog_elec_conductivity] */
 #include <sensors/AnalogElecConductivity.h>
+#include <sensors/ProcessorAnalog.h>
 
-const int8_t ECpwrPin   = A4;  // Power pin (-1 if continuously powered)
-const int8_t ECdataPin1 = A0;  // Data pin (must be an analog pin, ie A#)
+const int8_t  analogECPower = A4;     // Power pin (-1 if continuously powered)
+const int8_t  analogECData  = A0;     // Data pin (must be an analog pin, ie A#)
+const uint8_t analogECNReadings = 1;  // The number of readings to average
 
 // Create an Analog Electrical Conductivity sensor object
-AnalogElecConductivity analogEC_phy(ECpwrPin, ECdataPin1);
+AnalogElecConductivity analogEC(analogECPower, analogECData);
 
 // Create a conductivity variable pointer for the analog sensor
 Variable* analogEc_cond = new AnalogElecConductivity_EC(
-    &analogEC_phy, "12345678-abcd-1234-ef00-1234567890ab");
+    &analogEC, "12345678-abcd-1234-ef00-1234567890ab");
 
 // Create a calculated variable for the temperature compensated conductivity
 // (that is, the specific conductance).  For this example, we will use the
@@ -2393,6 +2503,17 @@ Variable* analogEc_spcond = new Variable(
     calculateAnalogSpCond, analogSpCondResolution, analogSpCondName,
     analogSpCondUnit, analogSpCondCode, analogSpCondUUID);
 /** End [analog_elec_conductivity] */
+
+// create a custom analog reader based on the Processor ADC (optional)
+float analogECMultiplier = 1.0f;  // factor for a voltage divider
+float analogECSupply     = 3.3f;  // supply voltage of the Processor ADC
+ProcessorAnalogBase analogECADS(analogECMultiplier, analogECSupply);
+
+// Create a Turner analogEC sensor object with the custom ADS instance
+AnalogElecConductivity analogEC_c(analogECPower, analogECData,
+                                  ANALOGELECCONDUCTIVITY_RSERIES_OHMS,
+                                  ANALOGELECCONDUCTIVITY_KONST,
+                                  analogECNReadings, &analogECADS);
 #endif
 
 
@@ -2443,17 +2564,17 @@ Variable* VegaPulsError =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y504ModbusAddress  = 0x04;  // The modbus address of the Y504
-const int8_t  y504AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y504SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y504EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y504NumberReadings = 5;
+byte          y504ModbusAddress = 0x04;  // The modbus address of the Y504
+const int8_t  y504AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y504SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y504EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y504NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Yosemitech Y504 dissolved oxygen sensor object
 YosemitechY504 y504(y504ModbusAddress, modbusSerial, y504AdapterPower,
-                    y504SensorPower, y504EnablePin, y504NumberReadings);
+                    y504SensorPower, y504EnablePin, y504NReadings);
 
 // Create the dissolved oxygen percent, dissolved oxygen concentration, and
 // temperature variable pointers for the Y504
@@ -2481,17 +2602,17 @@ Variable* y504Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y510ModbusAddress  = 0x0B;  // The modbus address of the Y510
-const int8_t  y510AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y510SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y510EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y510NumberReadings = 5;
+byte          y510ModbusAddress = 0x0B;  // The modbus address of the Y510
+const int8_t  y510AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y510SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y510EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y510NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y510-B Turbidity sensor object
 YosemitechY510 y510(y510ModbusAddress, modbusSerial, y510AdapterPower,
-                    y510SensorPower, y510EnablePin, y510NumberReadings);
+                    y510SensorPower, y510EnablePin, y510NReadings);
 
 // Create turbidity and temperature variable pointers for the Y510
 Variable* y510Turb =
@@ -2516,17 +2637,17 @@ Variable* y510Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y511ModbusAddress  = 0x1A;  // The modbus address of the Y511
-const int8_t  y511AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y511SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y511EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y511NumberReadings = 5;
+byte          y511ModbusAddress = 0x1A;  // The modbus address of the Y511
+const int8_t  y511AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y511SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y511EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y511NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y511-A Turbidity sensor object
 YosemitechY511 y511(y511ModbusAddress, modbusSerial, y511AdapterPower,
-                    y511SensorPower, y511EnablePin, y511NumberReadings);
+                    y511SensorPower, y511EnablePin, y511NReadings);
 
 // Create turbidity and temperature variable pointers for the Y511
 Variable* y511Turb =
@@ -2551,17 +2672,17 @@ Variable* y511Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y513ModbusAddress  = 0x13;  // The modbus address of the Y513
-const int8_t  y513AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y513SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y513EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y513NumberReadings = 5;
+byte          y513ModbusAddress = 0x13;  // The modbus address of the Y513
+const int8_t  y513AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y513SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y513EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y513NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y513 Blue Green Algae (BGA) sensor object
 YosemitechY513 y513(y513ModbusAddress, modbusSerial, y513AdapterPower,
-                    y513SensorPower, y513EnablePin, y513NumberReadings);
+                    y513SensorPower, y513EnablePin, y513NReadings);
 
 // Create Blue Green Algae (BGA) concentration and temperature variable
 // pointers for the Y513
@@ -2586,17 +2707,17 @@ Variable* y513Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y514ModbusAddress  = 0x14;  // The modbus address of the Y514
-const int8_t  y514AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y514SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y514EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y514NumberReadings = 5;
+byte          y514ModbusAddress = 0x14;  // The modbus address of the Y514
+const int8_t  y514AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y514SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y514EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y514NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y514 chlorophyll sensor object
 YosemitechY514 y514(y514ModbusAddress, modbusSerial, y514AdapterPower,
-                    y514SensorPower, y514EnablePin, y514NumberReadings);
+                    y514SensorPower, y514EnablePin, y514NReadings);
 
 // Create chlorophyll concentration and temperature variable pointers for the
 // Y514
@@ -2622,17 +2743,17 @@ Variable* y514Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y520ModbusAddress  = 0x20;  // The modbus address of the Y520
-const int8_t  y520AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y520SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y520EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y520NumberReadings = 5;
+byte          y520ModbusAddress = 0x20;  // The modbus address of the Y520
+const int8_t  y520AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y520SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y520EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y520NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y520 conductivity sensor object
 YosemitechY520 y520(y520ModbusAddress, modbusSerial, y520AdapterPower,
-                    y520SensorPower, y520EnablePin, y520NumberReadings);
+                    y520SensorPower, y520EnablePin, y520NReadings);
 
 // Create specific conductance and temperature variable pointers for the Y520
 Variable* y520Cond =
@@ -2657,16 +2778,16 @@ Variable* y520Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y532ModbusAddress  = 0x32;  // The modbus address of the Y532
-const int8_t  y532AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y532SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y532EnablePin      = 4;               // Adapter RE/DE pin
-const uint8_t y532NumberReadings = 1;
+byte          y532ModbusAddress = 0x32;  // The modbus address of the Y532
+const int8_t  y532AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y532SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y532EnablePin     = 4;               // Adapter RE/DE pin
+const uint8_t y532NReadings     = 1;
 // The manufacturer actually doesn't mention averaging for this one
 
 // Create a Yosemitech Y532 pH sensor object
 YosemitechY532 y532(y532ModbusAddress, modbusSerial, y532AdapterPower,
-                    y532SensorPower, y532EnablePin, y532NumberReadings);
+                    y532SensorPower, y532EnablePin, y532NReadings);
 
 // Create pH, electrical potential, and temperature variable pointers for the
 // Y532
@@ -2694,16 +2815,16 @@ Variable* y532Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y533ModbusAddress  = 0x32;  // The modbus address of the Y533
-const int8_t  y533AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y533SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y533EnablePin      = 4;               // Adapter RE/DE pin
-const uint8_t y533NumberReadings = 1;
+byte          y533ModbusAddress = 0x32;  // The modbus address of the Y533
+const int8_t  y533AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y533SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y533EnablePin     = 4;               // Adapter RE/DE pin
+const uint8_t y533NReadings     = 1;
 // The manufacturer actually doesn't mention averaging for this one
 
 // Create a Yosemitech Y533 ORP sensor object
 YosemitechY533 y533(y533ModbusAddress, modbusSerial, y533AdapterPower,
-                    y533SensorPower, y533EnablePin, y533NumberReadings);
+                    y533SensorPower, y533EnablePin, y533NReadings);
 
 // Create ORP and temperature variable pointers for the Y533
 Variable* y533ORP =
@@ -2728,17 +2849,17 @@ Variable* y533Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y551ModbusAddress  = 0x50;  // The modbus address of the Y551
-const int8_t  y551AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y551SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y551EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y551NumberReadings = 5;
+byte          y551ModbusAddress = 0x50;  // The modbus address of the Y551
+const int8_t  y551AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y551SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y551EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y551NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y551 chemical oxygen demand sensor object
 YosemitechY551 y551(y551ModbusAddress, modbusSerial, y551AdapterPower,
-                    y551SensorPower, y551EnablePin, y551NumberReadings);
+                    y551SensorPower, y551EnablePin, y551NReadings);
 
 // Create COD, turbidity, and temperature variable pointers for the Y551
 Variable* y551COD =
@@ -2768,16 +2889,16 @@ Variable* y551Temp =
 byte y560ModbusAddress =
     0x60;  // The modbus address of the Y560.
            // NOTE: Hexidecimal 0x60 = 96 decimal used by Yosemitech SmartPC
-const int8_t  y560AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y560SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y560EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y560NumberReadings = 3;
+const int8_t  y560AdapterPower = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y560SensorPower  = relayPowerPin;   // Sensor power pin
+const int8_t  y560EnablePin    = -1;              // Adapter RE/DE pin
+const uint8_t y560NReadings    = 3;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y560 Ammonium Probe object
 YosemitechY560 y560(y560ModbusAddress, modbusSerial, y560AdapterPower,
-                    y560SensorPower, y560EnablePin, y560NumberReadings);
+                    y560SensorPower, y560EnablePin, y560NReadings);
 
 // Create COD, turbidity, and temperature variable pointers for the Y560
 Variable* y560NH4_N =
@@ -2804,17 +2925,17 @@ Variable* y560Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y700ModbusAddress  = 0x70;  // The modbus address of the Y700
-const int8_t  y700AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y700SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y700EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y700NumberReadings = 5;
+byte          y700ModbusAddress = 0x70;  // The modbus address of the Y700
+const int8_t  y700AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y700SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y700EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y700NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Y700 pressure sensor object
 YosemitechY700 y700(y700ModbusAddress, modbusSerial, y700AdapterPower,
-                    y700SensorPower, y700EnablePin, y700NumberReadings);
+                    y700SensorPower, y700EnablePin, y700NReadings);
 
 // Create pressure and temperature variable pointers for the Y700
 Variable* y700Pres =
@@ -2840,17 +2961,17 @@ Variable* y700Temp =
 // for Additional Serial Ports" section
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-byte          y4000ModbusAddress  = 0x05;  // The modbus address of the Y4000
-const int8_t  y4000AdapterPower   = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  y4000SensorPower    = relayPowerPin;   // Sensor power pin
-const int8_t  y4000EnablePin      = -1;              // Adapter RE/DE pin
-const uint8_t y4000NumberReadings = 5;
+byte          y4000ModbusAddress = 0x05;  // The modbus address of the Y4000
+const int8_t  y4000AdapterPower  = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  y4000SensorPower   = relayPowerPin;   // Sensor power pin
+const int8_t  y4000EnablePin     = -1;              // Adapter RE/DE pin
+const uint8_t y4000NReadings     = 5;
 // The manufacturer recommends averaging 10 readings, but we take 5 to minimize
 // power consumption
 
 // Create a Yosemitech Y4000 multi-parameter sensor object
 YosemitechY4000 y4000(y4000ModbusAddress, modbusSerial, y4000AdapterPower,
-                      y4000SensorPower, y4000EnablePin, y4000NumberReadings);
+                      y4000SensorPower, y4000EnablePin, y4000NReadings);
 
 // Create all of the variable pointers for the Y4000
 Variable* y4000DO =
@@ -3115,7 +3236,7 @@ Variable* variableList[] = {
     ads1x15Volt,
 #endif
 #if defined(BUILD_SENSOR_PROCESSOR_ANALOG)
-    extAnalogVolts,
+    processorAnalogVolts,
 #endif
 #if defined(BUILD_SENSOR_FREESCALE_MPL115A2)
     mplTemp,
@@ -4120,10 +4241,12 @@ void loop() {
 /** End [complex_loop] */
 
 
-// cspell: ignore EDBG XBCT XBLTEB XBWF SVZM BatterymV Atlasp oversample
-// cspell: ignore asco2voltage atlasGrav Hayashi emas PMID temperatureCoef
-// cspell: ignore ClariVUESDI12address RainVUESDI12address Turb CTDSDI
-// cspell: ignore RDOSDI TROLLSDI acculev nanolev TMSDI ELEC fivetm tallyi
-// cspell: ignore kmph TIINA Chloro Fluoroscein PTSA BTEX ECpwrPin anlg spcond
-// cspell: ignore Relia NEOPIXEL RESTAPI autobauding xbeec
-// cspell: ignore CFUN UMNOPROF URAT PHEC GAIN_TWOTHIRDS
+// cspell: words EDBG XBCT XBLTEB XBWF SVZM BatterymV Atlasp oversample
+// cspell: words asco2voltage atlasGrav Hayashi emas PMID temperatureCoef
+// cspell: words ClariVUESDI12address RainVUESDI12address Turb CTDSDI
+// cspell: words RDOSDI TROLLSDI acculev nanolev TMSDI ELEC fivetm tallyi
+// cspell: words kmph TIINA Chloro Fluoroscein PTSA BTEX analogECPower anlg
+// cspell: words spcond Relia NEOPIXEL RESTAPI autobauding xbeec CFUN UMNOPROF
+// cspell: words URAT PHEC GAIN_TWOTHIRDS anbPHEC OBSADS CTDNReadings rdoDOmgL
+// cspell: words ANALOGELECCONDUCTIVITY_RSERIES_OHMS analogECADS
+// cspell: words ANALOGELECCONDUCTIVITY_KONST

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1607,12 +1607,12 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t  ADSPower       = sensorPowerPin;  // Power pin
 const int8_t  ADSChannel     = 2;               // The ADS channel of interest
-const float   dividerGain    = 10;  //  Gain setting if using a voltage divider
-const uint8_t evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
-const uint8_t VoltReadsToAvg = 1;     // Only read one sample
+const float   voltageMultiplier = 10;  //  Voltage multiplier if using a voltage divider
+const uint8_t evADSi2c_addr     = 0x48;  // The I2C address of the ADS1115 ADC
+const uint8_t VoltReadsToAvg    = 1;     // Only read one sample
 
 // Create a TI ADS1x15 sensor object
-TIADS1x15 ads1x15(ADSPower, ADSChannel, dividerGain, evADSi2c_addr,
+TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, evADSi2c_addr,
                   VoltReadsToAvg);
 
 // Create a voltage variable pointer

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1608,8 +1608,9 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 const int8_t ADSPower   = sensorPowerPin;  // Power pin
 const int8_t ADSChannel = 2;               // The ADS channel of interest
 const float  voltageMultiplier =
-    10.0f;  // Voltage multiplier: 1.0f for direct connection, (R_top + R_bottom) / R_bottom for voltage divider
-            // Default 10.0f assumes specific divider; change to 1.0f for direct ADS connection
+    1.0f;  // Voltage multiplier for an external voltage divider
+// use 1.0f for direct connection
+// use (R_top + R_bottom) / R_bottom for voltage divider
 const adsGain_t adsGain = GAIN_ONE;     // The internal gain setting for the ADS
 const uint8_t   evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
 const uint8_t   VoltReadsToAvg = 1;     // Only read one sample

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1001,8 +1001,8 @@ Variable* ds3231Temp =
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t      AlphasenseCO2Power = sensorPowerPin;  // Power pin
-aco2_adsDiffMux_t AlphasenseDiffMux =
-    DIFF_MUX_2_3;  // Differential voltage config
+tiads1x15_adsDiffMux_t AlphasenseDiffMux =
+    tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3;  // Differential voltage config
 const uint8_t AlphasenseCO2ADSi2c_addr =
     0x48;  // The I2C address of the ADS1115 ADC
 
@@ -2301,7 +2301,7 @@ Variable* cyclopsRedChloro = new TurnerCyclops_RedChlorophyll(
 const int8_t     turbidityPlusPower = sensorPowerPin;  // Power pin
 const int8_t     turbidityPlusWiper = relayPowerPin;   // Wiper pin
 ttp_adsDiffMux_t turbidityPlusDiffMux =
-    DIFF_MUX_2_3;  // Differential voltage config
+    tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3;  // Differential voltage config
 const uint8_t turbidityPlusNumberReadings = 10;
 const uint8_t turbidityPlusADSi2c_addr =
     0x48;                                 // The I2C address of the ADS1115 ADC

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1605,15 +1605,17 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 #include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  ADSPower       = sensorPowerPin;  // Power pin
-const int8_t  ADSChannel     = 2;               // The ADS channel of interest
-const float   voltageMultiplier = 10;  //  Voltage multiplier if using a voltage divider
-const uint8_t evADSi2c_addr     = 0x48;  // The I2C address of the ADS1115 ADC
-const uint8_t VoltReadsToAvg    = 1;     // Only read one sample
+const int8_t ADSPower   = sensorPowerPin;  // Power pin
+const int8_t ADSChannel = 2;               // The ADS channel of interest
+const float  voltageMultiplier =
+    10;  //  Voltage multiplier if using a voltage divider
+const adsGain_t adsGain = GAIN_ONE;     // The internal gain setting for the ADS
+const uint8_t   evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
+const uint8_t   VoltReadsToAvg = 1;     // Only read one sample
 
 // Create a TI ADS1x15 sensor object
-TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, evADSi2c_addr,
-                  VoltReadsToAvg);
+TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, adsGain,
+                  evADSi2c_addr, VoltReadsToAvg);
 
 // Create a voltage variable pointer
 Variable* ads1x15Volt =

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1608,7 +1608,8 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 const int8_t ADSPower   = sensorPowerPin;  // Power pin
 const int8_t ADSChannel = 2;               // The ADS channel of interest
 const float  voltageMultiplier =
-    10.0f;  //  Voltage multiplier if using a voltage divider
+    10.0f;  // Voltage multiplier: 1.0f for direct connection, (R_top + R_bottom) / R_bottom for voltage divider
+            // Default 10.0f assumes specific divider; change to 1.0f for direct ADS connection
 const adsGain_t adsGain = GAIN_ONE;     // The internal gain setting for the ADS
 const uint8_t   evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
 const uint8_t   VoltReadsToAvg = 1;     // Only read one sample

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1004,7 +1004,7 @@ Variable* ds3231Temp =
 const int8_t  asCO2Power    = sensorPowerPin;  // Power pin
 const int8_t  asCO2Channel1 = 2;               // First differential channel
 const int8_t  asCO2Channel2 = 3;               // Second differential channel
-const uint8_t asCO2Meas     = 1;               // Second differential channel
+const uint8_t asCO2Meas     = 1;               // Number of readings to average
 
 // Create an Alphasense CO2 sensor object
 AlphasenseCO2 alphasenseCO2(asCO2Power, asCO2Channel1, asCO2Channel2,
@@ -1137,7 +1137,7 @@ Variable* dhtHI   = new AOSongDHT_HI(&dht,
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t  sq212Power      = sensorPowerPin;  // Power pin
 const int8_t  sq212ADSChannel = 3;  // The ADS channel for the SQ212
-const uint8_t sq212Readings   = 1;  // The ADS channel for the SQ212
+const uint8_t sq212Readings   = 1;  // The number of readings to average
 
 // Create an Apogee SQ212 sensor object with the default voltage reader
 ApogeeSQ212 sq212(sq212Power, sq212ADSChannel);
@@ -2506,7 +2506,7 @@ float analogECMultiplier = 1.0f;  // factor for a voltage divider
 float analogECSupply     = 3.3f;  // supply voltage of the Processor ADC
 ProcessorAnalogBase analogECADS(analogECMultiplier, analogECSupply);
 
-// Create a Turner analogEC sensor object with the custom ADS instance
+// Create an AnalogElecConductivity sensor object with the custom ADS instance
 AnalogElecConductivity analogEC_c(analogECPower, analogECData,
                                   ANALOGELECCONDUCTIVITY_RSERIES_OHMS,
                                   ANALOGELECCONDUCTIVITY_KONST,

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1048,13 +1048,13 @@ AlphasenseCO2 alphasenseCO2_c(asCO2Power, asCO2Channel1, asCO2Channel2,
 byte anbModbusAddress =
     0x55;  // The modbus address of ANB pH Sensor (0x55 is the default)
 const int8_t  anbPower       = sensorPowerPin;  // ANB pH Sensor power pin
-const int8_t  alAdapterPower = sensorPowerPin;  // RS485 adapter power pin
-const int8_t  al485EnablePin = -1;              // Adapter RE/DE pin
+const int8_t  anbAdapterPower = sensorPowerPin;  // RS485 adapter power pin
+const int8_t  anb485EnablePin = -1;              // Adapter RE/DE pin
 const uint8_t anbNReadings   = 1;
 
 // Create an ANB pH sensor object
 ANBpH anbPH(anbModbusAddress, modbusSerial, anbPower, loggingInterval,
-            alAdapterPower, al485EnablePin, anbNReadings);
+            anbAdapterPower, anb485EnablePin, anbNReadings);
 
 // Create all of the variable pointers for the ANB pH sensor
 Variable* anbPHValue = new ANBpH_pH(&anbPH,
@@ -1465,7 +1465,6 @@ Variable* clarivueError = new CampbellClariVUE10_ErrorCode(
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t  OBS3Power       = sensorPowerPin;  // Power pin
 const uint8_t OBS3NReadings   = 10;
-const uint8_t OBS3AdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
 
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 
@@ -2317,7 +2316,6 @@ Variable* inaPower = new TIINA219_Power(&ina219,
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 const int8_t  cyclopsPower       = sensorPowerPin;  // Power pin
 const uint8_t cyclopsNReadings   = 10;
-const uint8_t cyclopsAdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
 const int8_t  cyclopsADSChannel  = 0;     // ADS channel
 
 // Cyclops calibration information
@@ -2415,7 +2413,6 @@ const float ttPlusBlankVolt =
     0.000;  // The voltage (in volts) measured for a blank.
 
 // Create a Turner Turbidity Plus sensor object
-const uint8_t       ttPlusReadings = 10;
 TurnerTurbidityPlus turbidityPlus(ttPlusPower, ttPlusWiper, ttPlusChannel1,
                                   ttPlusChannel2, ttPlusStdConc, ttPlusStdVolt,
                                   ttPlusBlankVolt, ttPlusReadings);

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1608,7 +1608,7 @@ Variable* alsPt19Lux = new EverlightALSPT19_Illuminance(
 const int8_t ADSPower   = sensorPowerPin;  // Power pin
 const int8_t ADSChannel = 2;               // The ADS channel of interest
 const float  voltageMultiplier =
-    10;  //  Voltage multiplier if using a voltage divider
+    10.0f;  //  Voltage multiplier if using a voltage divider
 const adsGain_t adsGain = GAIN_ONE;     // The internal gain setting for the ADS
 const uint8_t   evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
 const uint8_t   VoltReadsToAvg = 1;     // Only read one sample

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1611,12 +1611,14 @@ const float  voltageMultiplier =
     1.0f;  // Voltage multiplier for an external voltage divider
 // use 1.0f for direct connection
 // use (R_top + R_bottom) / R_bottom for voltage divider
-const adsGain_t adsGain = GAIN_ONE;     // The internal gain setting for the ADS
-const uint8_t   evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
-const uint8_t   VoltReadsToAvg = 1;     // Only read one sample
+const adsGain_t adsPGAGain = GAIN_ONE;  // The internal gain setting for the ADS
+// GAIN_ONE  => +/-4.096V range; use GAIN_TWOTHIRDS (+/-6.144V) for inputs
+// > 4.096V GAIN_TWO  => +/-2.048V, GAIN_FOUR => +/-1.024V, etc.
+const uint8_t evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
+const uint8_t VoltReadsToAvg = 1;     // Only read one sample
 
 // Create a TI ADS1x15 sensor object
-TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, adsGain,
+TIADS1x15 ads1x15(ADSPower, ADSChannel, voltageMultiplier, adsPGAGain,
                   evADSi2c_addr, VoltReadsToAvg);
 
 // Create a voltage variable pointer
@@ -4126,4 +4128,4 @@ void loop() {
 // cspell: ignore RDOSDI TROLLSDI acculev nanolev TMSDI ELEC fivetm tallyi
 // cspell: ignore kmph TIINA Chloro Fluoroscein PTSA BTEX ECpwrPin anlg spcond
 // cspell: ignore Relia NEOPIXEL RESTAPI autobauding xbeec
-// cspell: ignore CFUN UMNOPROF URAT PHEC
+// cspell: ignore CFUN UMNOPROF URAT PHEC GAIN_TWOTHIRDS

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1612,8 +1612,6 @@ const float  voltageMultiplier =
 // use 1.0f for direct connection
 // use (R_top + R_bottom) / R_bottom for voltage divider
 const adsGain_t adsPGAGain = GAIN_ONE;  // The internal gain setting for the ADS
-// GAIN_ONE  => +/-4.096V range; use GAIN_TWOTHIRDS (+/-6.144V) for inputs
-// > 4.096V GAIN_TWO  => +/-2.048V, GAIN_FOUR => +/-1.024V, etc.
 const uint8_t evADSi2c_addr  = 0x48;  // The I2C address of the ADS1115 ADC
 const uint8_t VoltReadsToAvg = 1;     // Only read one sample
 

--- a/examples/menu_a_la_carte/menu_a_la_carte.ino
+++ b/examples/menu_a_la_carte/menu_a_la_carte.ino
@@ -1021,8 +1021,8 @@ float         AsCO2Multiplier = 1.0f;      // factor for a voltage divider
 adsGain_t     AsCO2AdsGain    = GAIN_ONE;  // gain of the ADS1115
 float         AsCO2adsSupply  = 3.3f;      // supply voltage of the ADS1115
 const uint8_t AsCO2i2c_addr   = 0x48;      // The I2C address of the ADS1115 ADC
-TIADS1x15Base AsCO2ADS(AsCO2Multiplier, AsCO2AdsGain, AsCO2adsSupply,
-                       AsCO2i2c_addr);
+TIADS1x15Base AsCO2ADS(AsCO2Multiplier, AsCO2AdsGain, AsCO2i2c_addr,
+                       AsCO2adsSupply);
 
 // Create an Alphasense CO2 sensor object with the custom TIADS1x15Base
 AlphasenseCO2 alphasenseCO2_c(asCO2Power, asCO2Channel1, asCO2Channel2,
@@ -1047,10 +1047,10 @@ AlphasenseCO2 alphasenseCO2_c(asCO2Power, asCO2Channel1, asCO2Channel2,
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
 byte anbModbusAddress =
     0x55;  // The modbus address of ANB pH Sensor (0x55 is the default)
-const int8_t  anbPower       = sensorPowerPin;  // ANB pH Sensor power pin
+const int8_t  anbPower        = sensorPowerPin;  // ANB pH Sensor power pin
 const int8_t  anbAdapterPower = sensorPowerPin;  // RS485 adapter power pin
 const int8_t  anb485EnablePin = -1;              // Adapter RE/DE pin
-const uint8_t anbNReadings   = 1;
+const uint8_t anbNReadings    = 1;               // Number of readings
 
 // Create an ANB pH sensor object
 ANBpH anbPH(anbModbusAddress, modbusSerial, anbPower, loggingInterval,
@@ -1153,8 +1153,8 @@ float         sq212Multiplier = 1.0f;      // factor for a voltage divider
 adsGain_t     sq212AdsGain    = GAIN_ONE;  // gain of the ADS1115
 float         sq212adsSupply  = 3.3f;      // supply voltage of the ADS1115
 const uint8_t sq212i2c_addr   = 0x48;      // The I2C address of the ADS1115 ADC
-TIADS1x15Base sq212ADS(sq212Multiplier, sq212AdsGain, sq212adsSupply,
-                       sq212i2c_addr);
+TIADS1x15Base sq212ADS(sq212Multiplier, sq212AdsGain, sq212i2c_addr,
+                       sq212adsSupply);
 
 // Create an Apogee SQ212 sensor object with the custom TIADS1x15Base
 ApogeeSQ212 sq212_c(sq212Power, sq212ADSChannel, sq212Readings, &sq212ADS);
@@ -1463,8 +1463,8 @@ Variable* clarivueError = new CampbellClariVUE10_ErrorCode(
 #include <sensors/TIADS1x15.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  OBS3Power       = sensorPowerPin;  // Power pin
-const uint8_t OBS3NReadings   = 10;
+const int8_t  OBS3Power     = sensorPowerPin;  // Power pin
+const uint8_t OBS3NReadings = 10;
 
 const int8_t OBSLowADSChannel = 0;  // ADS channel for *low* range output
 
@@ -1506,8 +1506,8 @@ float         OBS3Multiplier       = 1.0f;      // factor for a voltage divider
 adsGain_t     OBS3AdsGain          = GAIN_ONE;  // gain of the ADS1115
 float         OBS3AdsSupplyVoltage = 3.3f;      // supply voltage of the ADS1115
 const uint8_t OBS3AdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
-TIADS1x15Base OBSADS(OBS3Multiplier, OBS3AdsGain, OBS3AdsSupplyVoltage,
-                     OBS3AdsI2C_addr);
+TIADS1x15Base OBSADS(OBS3Multiplier, OBS3AdsGain, OBS3AdsI2C_addr,
+                     OBS3AdsSupplyVoltage);
 
 // Create a Campbell OBS3+ *low* range sensor object with the custom
 // TIADS1x15Base
@@ -1679,8 +1679,8 @@ float         evVoltageMultiplier = 1.0f;      // factor for a voltage divider
 adsGain_t     evAdsGain           = GAIN_ONE;  // gain of the ADS1115
 float         evAdsSupplyVoltage  = 3.3f;      // supply voltage of the ADS1115
 const uint8_t evAdsI2C_addr       = 0x48;  // The I2C address of the ADS1115 ADC
-TIADS1x15Base evADS(evVoltageMultiplier, evAdsGain, evAdsSupplyVoltage,
-                    evAdsI2C_addr);
+TIADS1x15Base evADS(evVoltageMultiplier, evAdsGain, evAdsI2C_addr,
+                    evAdsSupplyVoltage);
 
 // Create a single ended External Voltage sensor object with the custom
 // TIADS1x15Base
@@ -2314,9 +2314,9 @@ Variable* inaPower = new TIINA219_Power(&ina219,
 #include <sensors/ProcessorAnalog.h>
 
 // NOTE: Use -1 for any pins that don't apply or aren't being used.
-const int8_t  cyclopsPower       = sensorPowerPin;  // Power pin
-const uint8_t cyclopsNReadings   = 10;
-const int8_t  cyclopsADSChannel  = 0;     // ADS channel
+const int8_t  cyclopsPower      = sensorPowerPin;  // Power pin
+const uint8_t cyclopsNReadings  = 10;
+const int8_t  cyclopsADSChannel = 0;  // ADS channel
 
 // Cyclops calibration information
 const float cyclopsStdConc = 1.000;  // Concentration of the standard used
@@ -2368,8 +2368,8 @@ float         cyclopsMultiplier       = 1.0f;  // factor for a voltage divider
 adsGain_t     cyclopsAdsGain          = GAIN_ONE;  // gain of the ADS1115
 float         cyclopsAdsSupplyVoltage = 3.3f;  // supply voltage of the ADS1115
 const uint8_t cyclopsAdsI2C_addr = 0x48;  // The I2C address of the ADS1115 ADC
-TIADS1x15Base cyclopsADS(cyclopsMultiplier, cyclopsAdsGain,
-                         cyclopsAdsSupplyVoltage, cyclopsAdsI2C_addr);
+TIADS1x15Base cyclopsADS(cyclopsMultiplier, cyclopsAdsGain, cyclopsAdsI2C_addr,
+                         cyclopsAdsSupplyVoltage);
 
 // Create a Turner Cyclops sensor object with the custom ADS instance
 TurnerCyclops cyclops_c(cyclopsPower, cyclopsADSChannel, cyclopsStdConc,
@@ -2428,8 +2428,8 @@ float         ttPlusMultiplier = 1.0f;      // factor for a voltage divider
 adsGain_t     ttPlusAdsGain    = GAIN_ONE;  // gain of the ADS1115
 float         ttPlusAdsSupply  = 3.3f;      // supply voltage of the ADS1115
 const uint8_t ttPlusI2C_addr   = 0x48;  // The I2C address of the ADS1115 ADC
-TIADS1x15Base ttPlusADS(ttPlusMultiplier, ttPlusAdsGain, ttPlusAdsSupply,
-                        ttPlusI2C_addr);
+TIADS1x15Base ttPlusADS(ttPlusMultiplier, ttPlusAdsGain, ttPlusI2C_addr,
+                        ttPlusAdsSupply);
 
 // Create a Turner Turbidity Plus sensor object with the custom TIADS1x15Base
 TurnerTurbidityPlus turbidityPlus_c(ttPlusPower, ttPlusWiper, ttPlusChannel1,

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -192,7 +192,7 @@
  *
  * This is not a hardware limit but a validation ceiling that exceeds the
  * largest channel index found on any supported Arduino platform (e.g. Mega:
- * A0–A15). Override with -D MS_PROCESSOR_ANALOG_MAX_CHANNEL=<n> if needed.
+ * A0–A15). Override with -D MS_PROCESSOR_ANALOG_MAX_CHANNEL=x if needed.
  */
 #define MS_PROCESSOR_ANALOG_MAX_CHANNEL 100
 #endif  // MS_PROCESSOR_ANALOG_MAX_CHANNEL

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -186,6 +186,9 @@
 /// @brief The maximum possible range of the ADC - the resolution shifted up one
 /// bit.
 #define PROCESSOR_ADC_RANGE (1 << MS_PROCESSOR_ADC_RESOLUTION)
+/// @brief The maximum analog channel number supported by the processor ADC.
+/// This conservative limit accommodates various Arduino platforms (Uno, Mega, etc.)
+#define PROCESSOR_ANALOG_MAX_CHANNEL 100
 
 #if !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
 #if defined(ARDUINO_ARCH_AVR) || defined(DOXYGEN)

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -43,6 +43,21 @@
 // This is for sensors that use the external ADC for analog voltage
 // measurements.
 // #define MS_USE_ADS1015
+
+#if !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
+/**
+ * @brief The default I²C address of the ADS1115 or ADS1015 external ADC.
+ *
+ * Valid addresses depend on the ADDR pin connection:
+ * - `0x48` – ADDR to GND (default)
+ * - `0x49` – ADDR to VDD
+ * - `0x4A` – ADDR to SDA
+ * - `0x4B` – ADDR to SCL
+ *
+ * Override with a build flag: `-DMS_DEFAULT_ADS1X15_ADDRESS=0x49`
+ */
+#define MS_DEFAULT_ADS1X15_ADDRESS 0x48
+#endif  // !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 //==============================================================
 
 //==============================================================
@@ -229,21 +244,6 @@
 #error The processor ADC reference type must be defined!
 #endif  // MS_PROCESSOR_ADC_REFERENCE_MODE
 #endif  // !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
-
-#if !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
-/**
- * @brief The default I²C address of the ADS1115 or ADS1015 external ADC.
- *
- * Valid addresses depend on the ADDR pin connection:
- * - `0x48` – ADDR to GND (default)
- * - `0x49` – ADDR to VDD
- * - `0x4A` – ADDR to SDA
- * - `0x4B` – ADDR to SCL
- *
- * Override with a build flag: `-DMS_DEFAULT_ADS1X15_ADDRESS=0x49`
- */
-#define MS_DEFAULT_ADS1X15_ADDRESS 0x48
-#endif  // !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 //==============================================================
 
 

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -228,13 +228,12 @@
 #if !defined(MS_PROCESSOR_ADC_REFERENCE_MODE)
 #error The processor ADC reference type must be defined!
 #endif  // MS_PROCESSOR_ADC_REFERENCE_MODE
-#endif  // ARDUINO_ARCH_SAMD
+#endif  // !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
 
-
-#ifndef MS_DEFAULT_ADS1X15_ADDRESS || defined(DOXYGEN)
+#if !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 /// @brief The assumed address of the ADS1115 or ADS1015, 1001 000 (ADDR = GND)
 #define MS_DEFAULT_ADS1X15_ADDRESS 0x48
-#endif
+#endif  // MS_DEFAULT_ADS1X15_ADDRESS
 //==============================================================
 
 

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -157,7 +157,7 @@
  */
 #if defined(__AVR__) || defined(ARDUINO_ARCH_AVR)
 #define MS_PROCESSOR_ADC_RESOLUTION 10
-#else
+#elif defined(ARDUINO_ARCH_SAMD)
 #define MS_PROCESSOR_ADC_RESOLUTION 12
 #endif
 #if !defined(MS_PROCESSOR_ADC_RESOLUTION)
@@ -233,7 +233,7 @@
 #if !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 /// @brief The assumed address of the ADS1115 or ADS1015, 1001 000 (ADDR = GND)
 #define MS_DEFAULT_ADS1X15_ADDRESS 0x48
-#endif  // MS_DEFAULT_ADS1X15_ADDRESS
+#endif  // !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 //==============================================================
 
 

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -166,7 +166,8 @@
  * higher than what your processor actually supports. This does **not** apply to
  * the TI ADS1115 or ADS1015 external ADS.
  *
- * The default for AVR boards is 10 and for other boards is 12.
+ * The default for AVR boards is 10 and for SAMD boards is 12.  The library
+ * currently only supports AVR and SAMD platforms.
  *
  * Future note: The ESP32 has a 12 bit ADC and the ESP8266 has a 10 bit ADC.
  */

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -57,7 +57,7 @@
  * Override with a build flag: `-DMS_DEFAULT_ADS1X15_ADDRESS=0x49`
  */
 #define MS_DEFAULT_ADS1X15_ADDRESS 0x48
-#endif  // !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
+#endif
 //==============================================================
 
 //==============================================================
@@ -186,16 +186,16 @@
 /// @brief The maximum possible range of the ADC - the resolution shifted up one
 /// bit.
 #define PROCESSOR_ADC_RANGE (1 << MS_PROCESSOR_ADC_RESOLUTION)
-#ifndef PROCESSOR_ANALOG_MAX_CHANNEL
+#ifndef MS_PROCESSOR_ANALOG_MAX_CHANNEL
 /**
  * @brief Upper bound used to sanity-check analog channel numbers at runtime.
  *
  * This is not a hardware limit but a validation ceiling that exceeds the
  * largest channel index found on any supported Arduino platform (e.g. Mega:
- * A0–A15). Override with -D PROCESSOR_ANALOG_MAX_CHANNEL=<n> if needed.
+ * A0–A15). Override with -D MS_PROCESSOR_ANALOG_MAX_CHANNEL=<n> if needed.
  */
-#define PROCESSOR_ANALOG_MAX_CHANNEL 100
-#endif  // PROCESSOR_ANALOG_MAX_CHANNEL
+#define MS_PROCESSOR_ANALOG_MAX_CHANNEL 100
+#endif  // MS_PROCESSOR_ANALOG_MAX_CHANNEL
 #if !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
 #if defined(ARDUINO_ARCH_AVR) || defined(DOXYGEN)
 /**
@@ -252,7 +252,7 @@
 #if !defined(MS_PROCESSOR_ADC_REFERENCE_MODE)
 #error The processor ADC reference type must be defined!
 #endif  // MS_PROCESSOR_ADC_REFERENCE_MODE
-#endif  // !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
+#endif
 //==============================================================
 
 

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -140,6 +140,9 @@
 // GroPoint Profile GPLP-8 has 8 Moisture and 13 Temperature values
 #endif
 
+//==============================================================
+// Analog voltage configuration
+//==============================================================
 #ifndef MS_PROCESSOR_ADC_RESOLUTION
 /**
  * @brief Select or adjust the processor analog resolution.
@@ -226,6 +229,12 @@
 #error The processor ADC reference type must be defined!
 #endif  // MS_PROCESSOR_ADC_REFERENCE_MODE
 #endif  // ARDUINO_ARCH_SAMD
+
+
+#ifndef MS_DEFAULT_ADS1X15_ADDRESS || defined(DOXYGEN)
+/// @brief The assumed address of the ADS1115 or ADS1015, 1001 000 (ADDR = GND)
+#define MS_DEFAULT_ADS1X15_ADDRESS 0x48
+#endif
 //==============================================================
 
 

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -231,7 +231,17 @@
 #endif  // !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
 
 #if !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
-/// @brief The assumed address of the ADS1115 or ADS1015, 1001 000 (ADDR = GND)
+/**
+ * @brief The default I²C address of the ADS1115 or ADS1015 external ADC.
+ *
+ * Valid addresses depend on the ADDR pin connection:
+ * - `0x48` – ADDR to GND (default)
+ * - `0x49` – ADDR to VDD
+ * - `0x4A` – ADDR to SDA
+ * - `0x4B` – ADDR to SCL
+ *
+ * Override with a build flag: `-DMS_DEFAULT_ADS1X15_ADDRESS=0x49`
+ */
 #define MS_DEFAULT_ADS1X15_ADDRESS 0x48
 #endif  // !defined(MS_DEFAULT_ADS1X15_ADDRESS) || defined(DOXYGEN)
 //==============================================================

--- a/src/ModSensorConfig.h
+++ b/src/ModSensorConfig.h
@@ -186,10 +186,16 @@
 /// @brief The maximum possible range of the ADC - the resolution shifted up one
 /// bit.
 #define PROCESSOR_ADC_RANGE (1 << MS_PROCESSOR_ADC_RESOLUTION)
-/// @brief The maximum analog channel number supported by the processor ADC.
-/// This conservative limit accommodates various Arduino platforms (Uno, Mega, etc.)
+#ifndef PROCESSOR_ANALOG_MAX_CHANNEL
+/**
+ * @brief Upper bound used to sanity-check analog channel numbers at runtime.
+ *
+ * This is not a hardware limit but a validation ceiling that exceeds the
+ * largest channel index found on any supported Arduino platform (e.g. Mega:
+ * A0–A15). Override with -D PROCESSOR_ANALOG_MAX_CHANNEL=<n> if needed.
+ */
 #define PROCESSOR_ANALOG_MAX_CHANNEL 100
-
+#endif  // PROCESSOR_ANALOG_MAX_CHANNEL
 #if !defined(MS_PROCESSOR_ADC_REFERENCE_MODE) || defined(DOXYGEN)
 #if defined(ARDUINO_ARCH_AVR) || defined(DOXYGEN)
 /**

--- a/src/SensorBase.h
+++ b/src/SensorBase.h
@@ -716,7 +716,7 @@ class Sensor {
      * calculated within the library for the sensor.  The @ref _incCalcValues
      * are *included* in this total.
      */
-    const uint8_t _numReturnedValues;
+    uint8_t _numReturnedValues;
     /**
      * @brief The number of included calculated variables from the sensor, if
      * any.

--- a/src/SensorBase.h
+++ b/src/SensorBase.h
@@ -716,7 +716,7 @@ class Sensor {
      * calculated within the library for the sensor.  The @ref _incCalcValues
      * are *included* in this total.
      */
-    uint8_t _numReturnedValues;
+    const uint8_t _numReturnedValues;
     /**
      * @brief The number of included calculated variables from the sensor, if
      * any.
@@ -726,7 +726,7 @@ class Sensor {
      * from any calculated variables that are created on-the-fly and depend on
      * multiple other sensors.
      */
-    uint8_t _incCalcValues;
+    const uint8_t _incCalcValues;
     /**
      * @brief The number of measurements from the sensor to average.
      *

--- a/src/VariableBase.h
+++ b/src/VariableBase.h
@@ -20,6 +20,9 @@
 // Include the debugging config
 #include "ModSensorDebugConfig.h"
 
+// Include math library for log10f function
+#include <math.h>
+
 // Define the print label[s] for the debugger
 #ifdef MS_VARIABLEBASE_DEBUG
 #define MS_DEBUGGING_STD "VariableBase"
@@ -403,6 +406,36 @@ class Variable {
      * @brief Internal note as to whether the value is calculated.
      */
     bool isCalculated = false;
+
+    /**
+     * @brief Convert measurement resolution to appropriate decimal places
+     *
+     * This static utility function converts any measurement resolution value to
+     * the appropriate number of decimal places for variable resolution
+     * settings. Works with any float resolution value (voltage, temperature,
+     * pressure, etc.).
+     *
+     * @param resolution The measurement resolution (e.g., volts per LSB,
+     * degrees per count, etc.)
+     * @return The number of decimal places needed to represent the resolution
+     */
+    static inline uint8_t floatResolutionToDecimalPlaces(float resolution) {
+        if (resolution <= 0.0f) {
+            return 4;  // Default to 4 decimal places for invalid input
+        }
+
+        // Calculate the number of decimal places needed to represent the
+        // resolution We want at least one significant digit beyond the
+        // resolution
+        float log10Resolution = log10f(resolution);
+        int   decimalPlaces   = static_cast<int>(-log10Resolution) + 1;
+
+        // Clamp to reasonable bounds (0-6 decimal places)
+        if (decimalPlaces < 0) decimalPlaces = 0;
+        if (decimalPlaces > 6) decimalPlaces = 6;
+
+        return static_cast<uint8_t>(decimalPlaces);
+    }
 
  protected:
     /**

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -12,32 +12,33 @@
 
 
 #include "AlphasenseCO2.h"
-#include "TIADS1x15.h"
+#include <Adafruit_ADS1X15.h>
 
 
-// The constructor - need the power pin and the differential mux configuration
-AlphasenseCO2::AlphasenseCO2(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux,
+// The constructor - need the power pin and the data pin
+AlphasenseCO2::AlphasenseCO2(int8_t powerPin, aco2_adsDiffMux_t adsDiffMux,
                              uint8_t i2cAddress, uint8_t measurementsToAverage)
-    : TIADS1x15(powerPin, adsDiffMux, ALPHASENSE_CO2_VOLTAGE_MULTIPLIER,
-                GAIN_ONE, i2cAddress, measurementsToAverage) {
-    // Override timing settings for Alphasense CO2-specific requirements
-    _warmUpTime_ms        = ALPHASENSE_CO2_WARM_UP_TIME_MS;
-    _stabilizationTime_ms = ALPHASENSE_CO2_STABILIZATION_TIME_MS;
-    _measurementTime_ms   = ALPHASENSE_CO2_MEASUREMENT_TIME_MS;
-    // Override variable counts from parent class defaults
-    _numReturnedValues = ALPHASENSE_CO2_NUM_VARIABLES;
-    _incCalcValues     = ALPHASENSE_CO2_INC_CALC_VARIABLES;
-    // Set the sensor name
-    _sensorName = "AlphasenseCO2";
-}
+    : Sensor("AlphasenseCO2", ALPHASENSE_CO2_NUM_VARIABLES,
+             ALPHASENSE_CO2_WARM_UP_TIME_MS,
+             ALPHASENSE_CO2_STABILIZATION_TIME_MS,
+             ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, -1,
+             measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
+      _adsDiffMux(adsDiffMux),
+      _i2cAddress(i2cAddress) {}
+
 // Destructor
 AlphasenseCO2::~AlphasenseCO2() {}
 
 
 String AlphasenseCO2::getSensorLocation(void) {
-    // Use TIADS1x15's location with Alphasense CO2-specific identifier
-    String sensorLocation = TIADS1x15::getSensorLocation();
-    sensorLocation += F("_AlphasenseCO2");
+#ifndef MS_USE_ADS1015
+    String sensorLocation = F("ADS1115_0x");
+#else
+    String sensorLocation = F("ADS1015_0x");
+#endif
+    sensorLocation += String(_i2cAddress, HEX);
+    sensorLocation += F("_adsDiffMux");
+    sensorLocation += String(_adsDiffMux);
     return sensorLocation;
 }
 
@@ -48,22 +49,82 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999;
-    float co2Current  = -9999;
-    float calibResult = -9999;
+    bool    success     = false;
+    int16_t adcCounts   = -9999;
+    float   adcVoltage  = -9999;
+    float   co2Current  = -9999;
+    float   calibResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Use the TIADS1x15 differential voltage reading function
-    // The voltage multiplier and gain settings are handled by the parent class
-    if (readVoltageDifferential(adcVoltage)) {
-        MS_DBG(F("  Differential voltage:"), String(adcVoltage, 3), F("V"));
-        // Convert voltage to current (mA) - using series sense resistor
+// Create an auxiliary ADD object
+// We create and set up the ADC object here so that each sensor using the ADC
+// may set the gain appropriately without effecting others.
+#ifndef MS_USE_ADS1015
+    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
+#else
+    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
+#endif
+    // ADS Library default settings:
+    //  - TI ADS1115 (16 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 128 samples per second (8ms conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+    //  - TI ADS1015 (12 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 1600 samples per second (625µs conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+
+    // Bump the gain up to 1x = +/- 4.096V range
+    // Sensor return range is 0-2.5V, but the next gain option is 2x which
+    // only allows up to 2.048V
+    ads.setGain(GAIN_ONE);
+    // Begin ADC, returns true if anything was detected at the address
+    if (!ads.begin(_i2cAddress)) {
+        MS_DBG(F("  ADC initialization failed at 0x"),
+               String(_i2cAddress, HEX));
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    // Read Analog to Digital Converter (ADC)
+    // Taking this reading includes the 8ms conversion delay.
+    // Measure the voltage differential across the two voltage pins
+    switch (_adsDiffMux) {
+        case DIFF_MUX_0_1: {
+            adcCounts = ads.readADC_Differential_0_1();
+            break;
+        }
+        case DIFF_MUX_0_3: {
+            adcCounts = ads.readADC_Differential_0_3();
+            break;
+        }
+        case DIFF_MUX_1_3: {
+            adcCounts = ads.readADC_Differential_1_3();
+            break;
+        }
+        case DIFF_MUX_2_3: {
+            adcCounts = ads.readADC_Differential_2_3();
+            break;
+        }
+        default: {
+            MS_DBG(F("  Invalid differential mux configuration"));
+            return bumpMeasurementAttemptCount(false);
+        }
+    }
+    // Convert ADC counts value to voltage (V)
+    adcVoltage = ads.computeVolts(adcCounts);
+    MS_DBG(F("  ads.readADC_Differential("), _adsDiffMux, F("):"), adcCounts,
+           '=', String(adcVoltage, 3));
+
+    // @todo Verify the voltage range for the CO2 sensor
+    // Here we are using the range of the ADS when it is powered at 3.3V
+    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+        // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in
+        // series
         co2Current = (adcVoltage / ALPHASENSE_CO2_SENSE_RESISTOR_OHM) * 1000;
-        MS_DBG(F("  co2Current:"),
-               co2Current);  // Convert current to ppm (using a formula
-                             // recommended by the sensor
+        MS_DBG(F("  co2Current:"), co2Current);
+
+        // Convert current to ppm (using a formula recommended by the sensor
         // manufacturer)
         calibResult = ALPHASENSE_CO2_MFG_SCALE * co2Current -
             ALPHASENSE_CO2_MFG_OFFSET;
@@ -72,8 +133,6 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
                                       adcVoltage);
         success = true;
-    } else {
-        MS_DBG(F("  Failed to read differential voltage"));
     }
 
     // Return success value when finished

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -55,9 +55,9 @@ String AlphasenseCO2::getSensorLocation(void) {
 
 
 bool AlphasenseCO2::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -68,7 +68,7 @@ bool AlphasenseCO2::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 
@@ -104,7 +104,7 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in
         // series
         float co2Current = (adcVoltage / ALPHASENSE_CO2_SENSE_RESISTOR_OHM) *
-            1000;
+            1000.0f;
         MS_DBG(F("  co2Current:"), co2Current);
 
         // Convert current to ppm (using a formula recommended by the sensor

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -27,13 +27,11 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
              measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
 
       _analogReferenceChannel(analogReferenceChannel),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 AlphasenseCO2::~AlphasenseCO2() {

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -54,6 +54,25 @@ String AlphasenseCO2::getSensorLocation(void) {
 }
 
 
+bool AlphasenseCO2::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool AlphasenseCO2::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -28,9 +28,10 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
 
       _analogReferenceChannel(analogReferenceChannel),
       // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader == nullptr
-                               ? new TIADS1x15Base()
-                               : analogVoltageReader),
+      _analogVoltageReader(
+          analogVoltageReader == nullptr
+              ? new TIADS1x15Base(ALPHASENSE_CO2_VOLTAGE_MULTIPLIER)
+              : analogVoltageReader),
       _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -26,11 +26,15 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
              ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, analogChannel,
              measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
 
-      _analogReferenceChannel(analogReferenceChannel),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new TIADS1x15Base()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _analogReferenceChannel(analogReferenceChannel) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 AlphasenseCO2::~AlphasenseCO2() {

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -29,8 +29,12 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
       _analogReferenceChannel(analogReferenceChannel) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
+        _analogVoltageReader = new TIADS1x15Base();
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -37,7 +37,6 @@ AlphasenseCO2::~AlphasenseCO2() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -82,7 +82,7 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
 
         // Convert current to ppm (using a formula recommended by the sensor
         // manufacturer)
-        float calibResult = ALPHASENSE_CO2_MFG_SCALE * co2Current -
+        float calibResult = (ALPHASENSE_CO2_MFG_SCALE * co2Current) -
             ALPHASENSE_CO2_MFG_OFFSET;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM,

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -26,13 +26,12 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
              ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, analogChannel,
              measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
 
-      _analogReferenceChannel(analogReferenceChannel) {
+      _analogReferenceChannel(analogReferenceChannel),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -64,13 +64,12 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Read differential voltage using the AnalogVoltageBase interface
-    success = _analogVoltageReader->readVoltageDifferential(
+    bool success = _analogVoltageReader->readVoltageDifferential(
         _dataPin, _analogReferenceChannel, adcVoltage);
 
     if (success) {

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -49,7 +49,7 @@ String AlphasenseCO2::getSensorLocation(void) {
         return _analogVoltageReader->getAnalogLocation(_dataPin,
                                                        _analogReferenceChannel);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -12,33 +12,32 @@
 
 
 #include "AlphasenseCO2.h"
-#include <Adafruit_ADS1X15.h>
+#include "TIADS1x15.h"
 
 
-// The constructor - need the power pin and the data pin
-AlphasenseCO2::AlphasenseCO2(int8_t powerPin, aco2_adsDiffMux_t adsDiffMux,
+// The constructor - need the power pin and the differential mux configuration
+AlphasenseCO2::AlphasenseCO2(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux,
                              uint8_t i2cAddress, uint8_t measurementsToAverage)
-    : Sensor("AlphasenseCO2", ALPHASENSE_CO2_NUM_VARIABLES,
-             ALPHASENSE_CO2_WARM_UP_TIME_MS,
-             ALPHASENSE_CO2_STABILIZATION_TIME_MS,
-             ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, -1,
-             measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
-      _adsDiffMux(adsDiffMux),
-      _i2cAddress(i2cAddress) {}
-
+    : TIADS1x15(powerPin, adsDiffMux, 1.0, GAIN_ONE, i2cAddress,
+                measurementsToAverage) {
+    // Override timing settings for Alphasense CO2-specific requirements
+    _warmUpTime_ms        = ALPHASENSE_CO2_WARM_UP_TIME_MS;
+    _stabilizationTime_ms = ALPHASENSE_CO2_STABILIZATION_TIME_MS;
+    _measurementTime_ms   = ALPHASENSE_CO2_MEASUREMENT_TIME_MS;
+    // Set the number of variables returned
+    _numReturnedValues = ALPHASENSE_CO2_NUM_VARIABLES;
+    _incCalcValues     = ALPHASENSE_CO2_INC_CALC_VARIABLES;
+    // Set the sensor name
+    _sensorName = "AlphasenseCO2";
+}
 // Destructor
 AlphasenseCO2::~AlphasenseCO2() {}
 
 
 String AlphasenseCO2::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_adsDiffMux");
-    sensorLocation += String(_adsDiffMux);
+    // Use TIADS1x15's location with Alphasense CO2-specific identifier
+    String sensorLocation = TIADS1x15::getSensorLocation();
+    sensorLocation += F("_AlphasenseCO2");
     return sensorLocation;
 }
 
@@ -49,79 +48,21 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   co2Current  = -9999;
-    float   calibResult = -9999;
+    bool  success     = false;
+    float adcVoltage  = -9999;
+    float co2Current  = -9999;
+    float calibResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-// Create an auxiliary ADC object
-// We create and set up the ADC object here so that each sensor using the ADC
-// may set the gain appropriately without effecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-
-    // Bump the gain up to 1x = +/- 4.096V range
-    // Sensor return range is 0-2.5V, but the next gain option is 2x which
-    // only allows up to 2.048V
-    ads.setGain(GAIN_ONE);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
-        return bumpMeasurementAttemptCount(false);
-    }
-
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the voltage differential across the two voltage pins
-    switch (_adsDiffMux) {
-        case DIFF_MUX_0_1: {
-            adcCounts = ads.readADC_Differential_0_1();
-            break;
-        }
-        case DIFF_MUX_0_3: {
-            adcCounts = ads.readADC_Differential_0_3();
-            break;
-        }
-        case DIFF_MUX_1_3: {
-            adcCounts = ads.readADC_Differential_1_3();
-            break;
-        }
-        case DIFF_MUX_2_3: {
-            adcCounts = ads.readADC_Differential_2_3();
-            break;
-        }
-        default: {
-            MS_DBG(F("  Invalid differential mux configuration"));
-            return bumpMeasurementAttemptCount(false);
-        }
-    }
-    // Convert ADC counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_Differential("), _adsDiffMux, F("):"), adcCounts,
-           '=', String(adcVoltage, 3));
-
-    // @todo Verify the voltage range for the CO2 sensor
-    // Here we are using the range of the ADS when it is powered at 3.3V
-    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+    // Use the TIADS1x15 differential voltage reading function
+    // The voltage multiplier and gain settings are handled by the parent class
+    if (readVoltageDifferential(adcVoltage)) {
+        MS_DBG(F("  Differential voltage:"), String(adcVoltage, 3), F("V"));
         // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in
         // series
         co2Current = (adcVoltage / 250) * 1000;
+        MS_DBG(F("  co2Current:"), calibResult);
         // Convert current to ppm (using a formula recommended by the sensor
         // manufacturer)
         calibResult = 312.5 * co2Current - 1250;
@@ -130,6 +71,8 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
                                       adcVoltage);
         success = true;
+    } else {
+        MS_DBG(F("  Failed to read differential voltage"));
     }
 
     // Return success value when finished

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -78,10 +78,8 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999;
-    float co2Current  = -9999;
-    float calibResult = -9999;
+    bool  success    = false;
+    float adcVoltage = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
@@ -92,17 +90,18 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
     if (success) {
         // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in
         // series
-        co2Current = (adcVoltage / ALPHASENSE_CO2_SENSE_RESISTOR_OHM) * 1000;
+        float co2Current = (adcVoltage / ALPHASENSE_CO2_SENSE_RESISTOR_OHM) *
+            1000;
         MS_DBG(F("  co2Current:"), co2Current);
 
         // Convert current to ppm (using a formula recommended by the sensor
         // manufacturer)
-        calibResult = ALPHASENSE_CO2_MFG_SCALE * co2Current -
+        float calibResult = ALPHASENSE_CO2_MFG_SCALE * co2Current -
             ALPHASENSE_CO2_MFG_OFFSET;
         MS_DBG(F("  calibResult:"), calibResult);
-        verifyAndAddMeasurementResult(ALPHASENSE_CO2_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
                                       adcVoltage);
+        verifyAndAddMeasurementResult(ALPHASENSE_CO2_VAR_NUM, calibResult);
     } else {
         MS_DBG(F("  Failed to read differential voltage from analog reader"));
     }

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -26,16 +26,11 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
              ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, analogChannel,
              measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
 
-      _analogReferenceChannel(analogReferenceChannel) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _analogReferenceChannel(analogReferenceChannel),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new TIADS1x15Base()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 AlphasenseCO2::~AlphasenseCO2() {

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -29,12 +29,8 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
       _analogReferenceChannel(analogReferenceChannel) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = new TIADS1x15Base();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -48,20 +48,13 @@ AlphasenseCO2::~AlphasenseCO2() {
 
 
 String AlphasenseCO2::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_Diff_");
+    sensorLocation += String(_dataPin);
+    sensorLocation += F("_");
+    sensorLocation += String(_analogReferenceChannel);
+    return sensorLocation;
 }
 
 
@@ -83,7 +76,10 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read differential voltage using the AnalogVoltageBase interface
+    // Read the differential voltage using the AnalogVoltageBase interface
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageDifferential(
         _dataPin, _analogReferenceChannel, adcVoltage);
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -66,6 +66,12 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
                F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
+    // validate the resistor value
+    if (ALPHASENSE_CO2_SENSE_RESISTOR_OHM <= 0) {
+        MS_DBG(F("  Error: Invalid sense resistor value"),
+               ALPHASENSE_CO2_SENSE_RESISTOR_OHM);
+        return bumpMeasurementAttemptCount(false);
+    }
 
     float adcVoltage = -9999;
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -12,34 +12,51 @@
 
 
 #include "AlphasenseCO2.h"
-#include <Adafruit_ADS1X15.h>
+#include "TIADS1x15.h"
 
 
 // The constructor - need the power pin and the data pin
-AlphasenseCO2::AlphasenseCO2(int8_t powerPin, aco2_adsDiffMux_t adsDiffMux,
-                             uint8_t i2cAddress, uint8_t measurementsToAverage)
+AlphasenseCO2::AlphasenseCO2(int8_t powerPin, int8_t analogChannel,
+                             int8_t             analogReferenceChannel,
+                             uint8_t            measurementsToAverage,
+                             AnalogVoltageBase* analogVoltageReader)
     : Sensor("AlphasenseCO2", ALPHASENSE_CO2_NUM_VARIABLES,
              ALPHASENSE_CO2_WARM_UP_TIME_MS,
              ALPHASENSE_CO2_STABILIZATION_TIME_MS,
-             ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, -1,
+             ALPHASENSE_CO2_MEASUREMENT_TIME_MS, powerPin, analogChannel,
              measurementsToAverage, ALPHASENSE_CO2_INC_CALC_VARIABLES),
-      _adsDiffMux(adsDiffMux),
-      _i2cAddress(i2cAddress) {}
+
+      _analogReferenceChannel(analogReferenceChannel) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
-AlphasenseCO2::~AlphasenseCO2() {}
+AlphasenseCO2::~AlphasenseCO2() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
 
 
 String AlphasenseCO2::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_adsDiffMux");
-    sensorLocation += String(_adsDiffMux);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Diff_") +
+            String(_dataPin) + F("_") + String(_analogReferenceChannel);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
+        sensorLocation += String(_dataPin) + F("_") +
+            String(_analogReferenceChannel);
+        return sensorLocation;
+    }
 }
 
 
@@ -49,76 +66,25 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   co2Current  = -9999;
-    float   calibResult = -9999;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-// Create an auxiliary ADD object
-// We create and set up the ADC object here so that each sensor using the ADC
-// may set the gain appropriately without effecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-
-    // Bump the gain up to 1x = +/- 4.096V range
-    // Sensor return range is 0-2.5V, but the next gain option is 2x which
-    // only allows up to 2.048V
-    ads.setGain(GAIN_ONE);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the voltage differential across the two voltage pins
-    switch (_adsDiffMux) {
-        case DIFF_MUX_0_1: {
-            adcCounts = ads.readADC_Differential_0_1();
-            break;
-        }
-        case DIFF_MUX_0_3: {
-            adcCounts = ads.readADC_Differential_0_3();
-            break;
-        }
-        case DIFF_MUX_1_3: {
-            adcCounts = ads.readADC_Differential_1_3();
-            break;
-        }
-        case DIFF_MUX_2_3: {
-            adcCounts = ads.readADC_Differential_2_3();
-            break;
-        }
-        default: {
-            MS_DBG(F("  Invalid differential mux configuration"));
-            return bumpMeasurementAttemptCount(false);
-        }
-    }
-    // Convert ADC counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_Differential("), _adsDiffMux, F("):"), adcCounts,
-           '=', String(adcVoltage, 3));
+    bool  success     = false;
+    float adcVoltage  = -9999;
+    float co2Current  = -9999;
+    float calibResult = -9999;
 
-    // @todo Verify the voltage range for the CO2 sensor
-    // Here we are using the range of the ADS when it is powered at 3.3V
-    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+    // Read differential voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageDifferential(
+        _dataPin, _analogReferenceChannel, adcVoltage);
+
+    if (success) {
         // Convert voltage to current (mA) - assuming a 250 Ohm resistor is in
         // series
         co2Current = (adcVoltage / ALPHASENSE_CO2_SENSE_RESISTOR_OHM) * 1000;
@@ -132,7 +98,8 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(ALPHASENSE_CO2_VOLTAGE_VAR_NUM,
                                       adcVoltage);
-        success = true;
+    } else {
+        MS_DBG(F("  Failed to read differential voltage from analog reader"));
     }
 
     // Return success value when finished

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -49,12 +49,17 @@ AlphasenseCO2::~AlphasenseCO2() {
 
 String AlphasenseCO2::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Diff_") +
-            String(_dataPin) + F("_") + String(_analogReferenceChannel);
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
     } else {
         String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin) + F("_") +
-            String(_analogReferenceChannel);
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
         return sensorLocation;
     }
 }

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -43,18 +43,10 @@ AlphasenseCO2::~AlphasenseCO2() {
 
 String AlphasenseCO2::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
+        return _analogVoltageReader->getAnalogLocation(_dataPin,
+                                                       _analogReferenceChannel);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -43,13 +43,20 @@ AlphasenseCO2::~AlphasenseCO2() {
 
 
 String AlphasenseCO2::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_Diff_");
-    sensorLocation += String(_dataPin);
-    sensorLocation += F("_");
-    sensorLocation += String(_analogReferenceChannel);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
+    }
 }
 
 
@@ -71,10 +78,7 @@ bool AlphasenseCO2::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read the differential voltage using the AnalogVoltageBase interface
-    // NOTE: All implementations of the AnalogVoltageBase class validate both
-    // the input channel and the resulting voltage, so we can trust that a
-    // successful read will give us a valid voltage value to work with.
+    // Read differential voltage using the AnalogVoltageBase interface
     success = _analogVoltageReader->readVoltageDifferential(
         _dataPin, _analogReferenceChannel, adcVoltage);
 

--- a/src/sensors/AlphasenseCO2.cpp
+++ b/src/sensors/AlphasenseCO2.cpp
@@ -24,7 +24,7 @@ AlphasenseCO2::AlphasenseCO2(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux,
     _warmUpTime_ms        = ALPHASENSE_CO2_WARM_UP_TIME_MS;
     _stabilizationTime_ms = ALPHASENSE_CO2_STABILIZATION_TIME_MS;
     _measurementTime_ms   = ALPHASENSE_CO2_MEASUREMENT_TIME_MS;
-    // Set the number of variables returned
+    // Override variable counts from parent class defaults
     _numReturnedValues = ALPHASENSE_CO2_NUM_VARIABLES;
     _incCalcValues     = ALPHASENSE_CO2_INC_CALC_VARIABLES;
     // Set the sensor name

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -91,7 +91,8 @@
 
 // Include other in-library and external dependencies
 #include "VariableBase.h"
-#include "SensorBase.h"
+#include "TIADS1x15.h"
+#include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_alphasense_co2 */
 /**@{*/
@@ -124,17 +125,6 @@
  */
 #define ALPHASENSE_CO2_CALIBRATION_FACTOR 1
 #endif
-/**
- * @brief Enum for the pins used for differential voltages.
- */
-typedef enum : uint16_t {
-    DIFF_MUX_0_1,  ///< differential across pins 0 and 1
-    DIFF_MUX_0_3,  ///< differential across pins 0 and 3
-    DIFF_MUX_1_3,  ///< differential across pins 1 and 3
-    DIFF_MUX_2_3   ///< differential across pins 2 and 3
-} aco2_adsDiffMux_t;
-/// @brief The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
 /**@}*/
 
 /**
@@ -247,7 +237,7 @@ typedef enum : uint16_t {
  *
  * @ingroup sensor_alphasense_co2
  */
-class AlphasenseCO2 : public Sensor {
+class AlphasenseCO2 : public TIADS1x15 {
  public:
     /**
      * @brief Construct a new Alphasense IRC-A1 CO2 object - need the power pin
@@ -263,7 +253,7 @@ class AlphasenseCO2 : public Sensor {
      * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
      * - The ADS1115 requires 2.0-5.5V but is assumed to be powered at 3.3V
      * @param adsDiffMux Which two pins _on the TI ADS1115_ that will measure
-     * differential voltage. See #aco2_adsDiffMux_t.
+     * differential voltage. See tiads1x15_adsDiffMux_t.
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
@@ -273,7 +263,7 @@ class AlphasenseCO2 : public Sensor {
      * its power controlled by the same pin as the Alphasense CO2 sensor.  This
      * library does not support any other configuration.
      */
-    AlphasenseCO2(int8_t powerPin, aco2_adsDiffMux_t adsDiffMux = DIFF_MUX_2_3,
+    AlphasenseCO2(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux = tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3,
                   uint8_t i2cAddress            = ADS1115_ADDRESS,
                   uint8_t measurementsToAverage = 7);
     /**
@@ -292,15 +282,7 @@ class AlphasenseCO2 : public Sensor {
     bool addSingleMeasurementResult(void) override;
 
  private:
-    /**
-     * @brief Which two pins _on the TI ADS1115_ that will measure differential
-     * voltage from the Turbidity Plus. See #aco2_adsDiffMux_t
-     */
-    aco2_adsDiffMux_t _adsDiffMux;
-    /**
-     * @brief Internal reference to the I2C address of the TI-ADS1x15
-     */
-    uint8_t _i2cAddress;
+    // All differential mux and I2C address functionality is now handled by the parent TIADS1x15 class
 };
 
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -94,7 +94,9 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
+
+// Forward declaration
+class AnalogVoltageBase;
 
 /** @ingroup sensor_alphasense_co2 */
 /**@{*/

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -283,7 +283,7 @@ class AlphasenseCO2 : public Sensor {
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
      * internally create and own an analog voltage reader.  For backward
-     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
      *

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -270,12 +270,12 @@ class AlphasenseCO2 : public Sensor {
      * Alphasense CO2 sensor.  Use -1 if it is continuously powered.
      * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
      * @param analogChannel The primary analog channel for differential
-     * measurement. Negative or invalid channel numbers or parings between the
+     * measurement. Negative or invalid channel numbers or pairings between the
      * analogChannel and analogReferenceChannel are not clamped and will cause
      * the reading to fail and emit a warning.
      * @param analogReferenceChannel The secondary (reference) analog channel
      * for differential measurement. Negative or invalid channel numbers or
-     * parings between the analogChannel and analogReferenceChannel are not
+     * pairings between the analogChannel and analogReferenceChannel are not
      * clamped and will cause the reading to fail and emit a warning.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -97,8 +97,7 @@
 
 // Include other in-library and external dependencies
 #include "VariableBase.h"
-#include "TIADS1x15.h"
-#include <Adafruit_ADS1X15.h>
+#include "SensorBase.h"
 
 /** @ingroup sensor_alphasense_co2 */
 /**@{*/
@@ -148,6 +147,16 @@
 #define ALPHASENSE_CO2_VOLTAGE_MULTIPLIER 1.0
 #endif
 /**@}*/
+
+/**
+ * @brief Enum for the pins used for differential voltages.
+ */
+typedef enum : uint16_t {
+    DIFF_MUX_0_1,  ///< differential across pins 0 and 1
+    DIFF_MUX_0_3,  ///< differential across pins 0 and 3
+    DIFF_MUX_1_3,  ///< differential across pins 1 and 3
+    DIFF_MUX_2_3   ///< differential across pins 2 and 3
+} aco2_adsDiffMux_t;
 
 /**
  * @anchor sensor_alphasense_co2_timing
@@ -259,7 +268,7 @@
  *
  * @ingroup sensor_alphasense_co2
  */
-class AlphasenseCO2 : public TIADS1x15 {
+class AlphasenseCO2 : public Sensor {
  public:
     /**
      * @brief Construct a new Alphasense IRC-A1 CO2 object - need the power pin
@@ -275,7 +284,7 @@ class AlphasenseCO2 : public TIADS1x15 {
      * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
      * - The ADS1115 requires 2.0-5.5V but is assumed to be powered at 3.3V
      * @param adsDiffMux Which two pins _on the TI ADS1115_ that will measure
-     * differential voltage. See tiads1x15_adsDiffMux_t.
+     * differential voltage. See #aco2_adsDiffMux_t.
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
@@ -285,8 +294,8 @@ class AlphasenseCO2 : public TIADS1x15 {
      * its power controlled by the same pin as the Alphasense CO2 sensor.  This
      * library does not support any other configuration.
      */
-    AlphasenseCO2(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux = tiads1x15_adsDiffMux_t::TIADS1X15_DIFF_MUX_2_3,
-                  uint8_t i2cAddress            = ADS1115_ADDRESS,
+    AlphasenseCO2(int8_t powerPin, aco2_adsDiffMux_t adsDiffMux = DIFF_MUX_2_3,
+                  uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
                   uint8_t measurementsToAverage = 7);
     /**
      * @brief Destroy the AlphasenseCO2 object - no action needed
@@ -304,7 +313,15 @@ class AlphasenseCO2 : public TIADS1x15 {
     bool addSingleMeasurementResult(void) override;
 
  private:
-    // All differential mux and I2C address functionality is now handled by the parent TIADS1x15 class
+    /**
+     * @brief Which two pins _on the TI ADS1115_ that will measure differential
+     * voltage from the Turbidity Plus. See #aco2_adsDiffMux_t
+     */
+    aco2_adsDiffMux_t _adsDiffMux;
+    /**
+     * @brief Internal reference to the I2C address of the TI-ADS1x15
+     */
+    uint8_t _i2cAddress;
 };
 
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -124,25 +124,25 @@
 /**
  * @brief Sense resistor value in ohms for current conversion
  */
-#define ALPHASENSE_CO2_SENSE_RESISTOR_OHM 250.0
+#define ALPHASENSE_CO2_SENSE_RESISTOR_OHM 250.0f
 #endif
 #if !defined(ALPHASENSE_CO2_MFG_SCALE) || defined(DOXYGEN)
 /**
  * @brief Manufacturer scale factor for CO2 conversion (ppm/mA)
  */
-#define ALPHASENSE_CO2_MFG_SCALE 312.5
+#define ALPHASENSE_CO2_MFG_SCALE 312.5f
 #endif
 #if !defined(ALPHASENSE_CO2_MFG_OFFSET) || defined(DOXYGEN)
 /**
  * @brief Manufacturer offset for CO2 conversion (ppm)
  */
-#define ALPHASENSE_CO2_MFG_OFFSET 1250.0
+#define ALPHASENSE_CO2_MFG_OFFSET 1250.0f
 #endif
 #if !defined(ALPHASENSE_CO2_VOLTAGE_MULTIPLIER) || defined(DOXYGEN)
 /**
  * @brief Voltage multiplier for direct voltage reading
  */
-#define ALPHASENSE_CO2_VOLTAGE_MULTIPLIER 1.0
+#define ALPHASENSE_CO2_VOLTAGE_MULTIPLIER 1.0f
 #endif
 /**@}*/
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -323,10 +323,10 @@ class AlphasenseCO2 : public Sensor {
      */
     int8_t _analogReferenceChannel;
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -269,10 +269,6 @@ class AlphasenseCO2 : public Sensor {
      * default values for voltage readings, but a pointer to a custom
      * AnalogVoltageBase object can be passed in if desired.
      *
-     * @note ModularSensors only supports connecting the ADS1x15 to the primary
-     * hardware I2C instance defined in the Arduino core. Connecting the ADS to
-     * a secondary hardware or software I2C instance is *not* supported!
-     *
      * @param powerPin The pin on the mcu controlling power to the
      * Alphasense CO2 sensor.  Use -1 if it is continuously powered.
      * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
@@ -284,8 +280,9 @@ class AlphasenseCO2 : public Sensor {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 7.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new TIADS1x15Base
-     * object.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a TIADS1x15Base instance.
+     *
      * @note  The ADS is expected to be either continuously powered or have
      * its power controlled by the same pin as the Alphasense CO2 sensor.  This
      * library does not support any other configuration.
@@ -305,6 +302,15 @@ class AlphasenseCO2 : public Sensor {
      * @brief Destroy the AlphasenseCO2 object
      */
     ~AlphasenseCO2();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    AlphasenseCO2(const AlphasenseCO2&)            = delete;
+    AlphasenseCO2& operator=(const AlphasenseCO2&) = delete;
+
+    // Delete move constructor and move assignment operator
+    AlphasenseCO2(AlphasenseCO2&&)            = delete;
+    AlphasenseCO2& operator=(AlphasenseCO2&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -15,8 +15,6 @@
  * Carbon Dioxide (CO2) sensor. This library will almost certainly also work
  * with the Alphasense IRC-AT CO2 sensor (which uses a thermopile detector),
  * although the warmup and stabilization times might be different.
- *
- * This depends on the Adafruit ADS1X15 v2.x library.
  */
 /* clang-format off */
 /**
@@ -119,8 +117,7 @@
 /**
  * @anchor sensor_alphasense_co2_config
  * @name Configuration Defines
- * Defines to set the calibration of the Alphasense CO2 sensor and the address
- * of the ADD.
+ * Defines to set the calibration of the Alphasense CO2 sensor.
  */
 /**@{*/
 #if !defined(ALPHASENSE_CO2_SENSE_RESISTOR_OHM) || defined(DOXYGEN)
@@ -281,11 +278,9 @@ class AlphasenseCO2 : public Sensor {
      * default value of 7.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.
-     *
-     * @note  The ADS is expected to be either continuously powered or have
-     * its power controlled by the same pin as the Alphasense CO2 sensor.  This
-     * library does not support any other configuration.
+     * internally create and own a TIADS1x15Base instance.  If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      *
      * @warning In library versions 0.37.0 and earlier, a different constructor
      * was used that required an enum object instead of two different analog

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -314,6 +314,8 @@ class AlphasenseCO2 : public Sensor {
 
     String getSensorLocation(void) override;
 
+    bool setup(void) override;
+
     bool addSingleMeasurementResult(void) override;
 
  private:

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -322,11 +322,11 @@ class AlphasenseCO2 : public Sensor {
      * @brief The second (reference) pin for differential voltage measurements.
      */
     int8_t _analogReferenceChannel;
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -262,9 +262,9 @@ class AlphasenseCO2 : public Sensor {
      * @brief Construct a new Alphasense IRC-A1 CO2 object - need the power pin
      * and the analog data and reference channels.
      *
-     * By default, this constructor will use a new TIADS1x15Base object with all
-     * default values for voltage readings, but a pointer to a custom
-     * AnalogVoltageBase object can be passed in if desired.
+     * By default, this constructor will internally create a default
+     * AnalogVoltageBase implementation for voltage readings, but a pointer to
+     * a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @param powerPin The pin on the mcu controlling power to the
      * Alphasense CO2 sensor.  Use -1 if it is continuously powered.

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -55,8 +55,14 @@
  * @section sensor_alphasense_co2_flags Build flags
  * - ```-D MS_USE_ADS1015```
  *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
- * - ```-D ALPHASENSE_CO2_CALIBRATION_FACTOR=x```
- *      - Changes the calibration factor from 1 to x
+ * - ```-D ALPHASENSE_CO2_SENSE_RESISTOR_OHM=x```
+ *      - Changes the sense resistor value from 250.0 ohms to x ohms
+ * - ```-D ALPHASENSE_CO2_MFG_SCALE=x```
+ *      - Changes the manufacturer scale factor from 312.5 ppm/mA to x ppm/mA
+ * - ```-D ALPHASENSE_CO2_MFG_OFFSET=x```
+ *      - Changes the manufacturer offset from 1250.0 ppm to x ppm
+ * - ```-D ALPHASENSE_CO2_VOLTAGE_MULTIPLIER=x```
+ *      - Changes the voltage multiplier from 1.0 to x
  *
  * @section sensor_alphasense_co2_ctor Sensor Constructor
  * {{ @ref AlphasenseCO2::AlphasenseCO2 }}
@@ -111,19 +117,35 @@
 /**@}*/
 
 /**
- * @anchor sensor__alphasense_co2_config
+ * @anchor sensor_alphasense_co2_config
  * @name Configuration Defines
  * Defines to set the calibration of the Alphasense CO2 sensor and the address
  * of the ADD.
  */
 /**@{*/
-#if !defined(ALPHASENSE_CO2_CALIBRATION_FACTOR) || defined(DOXYGEN)
+#if !defined(ALPHASENSE_CO2_SENSE_RESISTOR_OHM) || defined(DOXYGEN)
 /**
- * @brief The calibration factor between output in volts and CO2
- * (microeinsteinPerSquareMeterPerSecond) 1 µmol mˉ² sˉ¹ per mV (reciprocal of
- * sensitivity)
+ * @brief Sense resistor value in ohms for current conversion
  */
-#define ALPHASENSE_CO2_CALIBRATION_FACTOR 1
+#define ALPHASENSE_CO2_SENSE_RESISTOR_OHM 250.0
+#endif
+#if !defined(ALPHASENSE_CO2_MFG_SCALE) || defined(DOXYGEN)
+/**
+ * @brief Manufacturer scale factor for CO2 conversion (ppm/mA)
+ */
+#define ALPHASENSE_CO2_MFG_SCALE 312.5
+#endif
+#if !defined(ALPHASENSE_CO2_MFG_OFFSET) || defined(DOXYGEN)
+/**
+ * @brief Manufacturer offset for CO2 conversion (ppm)
+ */
+#define ALPHASENSE_CO2_MFG_OFFSET 1250.0
+#endif
+#if !defined(ALPHASENSE_CO2_VOLTAGE_MULTIPLIER) || defined(DOXYGEN)
+/**
+ * @brief Voltage multiplier for direct voltage reading
+ */
+#define ALPHASENSE_CO2_VOLTAGE_MULTIPLIER 1.0
 #endif
 /**@}*/
 

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -51,8 +51,6 @@
  * [Datasheet](https://www.alphasense.com/wp-content/uploads/2018/04/IRC-A1.pdf)
  *
  * @section sensor_alphasense_co2_flags Build flags
- * - ```-D MS_USE_ADS1015```
- *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
  * - ```-D ALPHASENSE_CO2_SENSE_RESISTOR_OHM=x```
  *      - Changes the sense resistor value from 250.0 ohms to x ohms
  * - ```-D ALPHASENSE_CO2_MFG_SCALE=x```
@@ -104,7 +102,7 @@
 /**
  * @anchor sensor_alphasense_co2_var_counts
  * @name Sensor Variable Counts
- * The number of variables that can be returned by the Apogee SQ-212
+ * The number of variables that can be returned by the Alphasense CO2 sensor
  */
 /**@{*/
 /// @brief Sensor::_numReturnedValues; the Alphasense CO2 sensor can report 2

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -282,9 +282,10 @@ class AlphasenseCO2 : public Sensor {
      * default value of 7.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.  If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      *
      * @warning In library versions 0.37.0 and earlier, a different constructor
      * was used that required an enum object instead of two different analog
@@ -320,7 +321,7 @@ class AlphasenseCO2 : public Sensor {
     /**
      * @brief The second (reference) pin for differential voltage measurements.
      */
-    int8_t _analogReferenceChannel;
+    int8_t _analogReferenceChannel = -1;
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -270,9 +270,13 @@ class AlphasenseCO2 : public Sensor {
      * Alphasense CO2 sensor.  Use -1 if it is continuously powered.
      * - The Alphasense CO2 sensor requires 2-5 V DC; current draw 20-60 mA
      * @param analogChannel The primary analog channel for differential
-     * measurement
+     * measurement. Negative or invalid channel numbers or parings between the
+     * analogChannel and analogReferenceChannel are not clamped and will cause
+     * the reading to fail and emit a warning.
      * @param analogReferenceChannel The secondary (reference) analog channel
-     * for differential measurement
+     * for differential measurement. Negative or invalid channel numbers or
+     * parings between the analogChannel and analogReferenceChannel are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 7.

--- a/src/sensors/AlphasenseCO2.h
+++ b/src/sensors/AlphasenseCO2.h
@@ -320,6 +320,8 @@ class AlphasenseCO2 : public Sensor {
 
     /**
      * @brief The second (reference) pin for differential voltage measurements.
+     *
+     * @note The primary pin is stored as Sensor::_dataPin.
      */
     int8_t _analogReferenceChannel = -1;
     /// @brief Pointer to analog voltage reader

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -24,14 +24,11 @@ AnalogElecConductivity::AnalogElecConductivity(
              measurementsToAverage, ANALOGELECCONDUCTIVITY_INC_CALC_VARIABLES),
       _Rseries_ohms(Rseries_ohms),
       _sensorEC_Konst(sensorEC_Konst),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader =
-            createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new ProcessorAnalogBase()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 AnalogElecConductivity::~AnalogElecConductivity() {
@@ -56,9 +53,9 @@ String AnalogElecConductivity::getSensorLocation(void) {
 
 
 bool AnalogElecConductivity::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -69,7 +66,7 @@ bool AnalogElecConductivity::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -23,13 +23,13 @@ AnalogElecConductivity::AnalogElecConductivity(
              ANALOGELECCONDUCTIVITY_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, ANALOGELECCONDUCTIVITY_INC_CALC_VARIABLES),
       _Rseries_ohms(Rseries_ohms),
-      _sensorEC_Konst(sensorEC_Konst) {
+      _sensorEC_Konst(sensorEC_Konst),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
+        _analogVoltageReader =
+            createProcessorAnalogBase(_ownsAnalogVoltageReader);
     }
 }
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -64,9 +64,10 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Check if we have a valid load resistor
-    if (_sensorEC_Konst <= 0) {
-        MS_DBG(getSensorNameAndLocation(), F("Invalid cell constant"));
+    // Check if we have a resistance and cell constant
+    if (_Rseries_ohms <= 0 || _sensorEC_Konst <= 0) {
+        MS_DBG(getSensorNameAndLocation(),
+               F(" has an invalid cell constant or resistor value!"));
         return bumpMeasurementAttemptCount(false);
     }
 
@@ -95,12 +96,12 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
             adcRatio = ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO;
         }
 
-        float Rwater_ohms = _Rseries_ohms * adcRatio / (1.0 - adcRatio);
+        float Rwater_ohms = _Rseries_ohms * adcRatio / (1.0f - adcRatio);
         MS_DBG(F("  Resistance:"), Rwater_ohms, F("ohms"));
 
         // Convert to EC
         float EC_uScm = -9999.0f;  // units are uS per cm
-        if (Rwater_ohms > 0) {
+        if (Rwater_ohms > 0.0f) {
             EC_uScm = 1000000.0f / (Rwater_ohms * _sensorEC_Konst);
             MS_DBG(F("Water EC (uS/cm)"), EC_uScm);
             verifyAndAddMeasurementResult(ANALOGELECCONDUCTIVITY_EC_VAR_NUM,

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -55,6 +55,25 @@ String AnalogElecConductivity::getSensorLocation(void) {
 }
 
 
+bool AnalogElecConductivity::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool AnalogElecConductivity::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -34,7 +34,6 @@ AnalogElecConductivity::~AnalogElecConductivity() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 
@@ -90,7 +89,9 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
 
         if (adcRatio >= 1.0) {
             // Prevent division issues when voltage reaches supply voltage
-            adcRatio = 0.999;
+            MS_DBG(F("  ADC ratio clamped from"), adcRatio, F("to"),
+                   ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO);
+            adcRatio = ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO;
         }
 
         float Rwater_ohms = _Rseries_ohms * adcRatio / (1.0 - adcRatio);

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -11,67 +11,54 @@
  */
 
 #include "AnalogElecConductivity.h"
+#include "ProcessorAnalog.h"
 
 // For Mayfly version; the battery resistor depends on it
-AnalogElecConductivity::AnalogElecConductivity(int8_t powerPin, int8_t dataPin,
-                                               float   Rseries_ohms,
-                                               float   sensorEC_Konst,
-                                               uint8_t measurementsToAverage)
+AnalogElecConductivity::AnalogElecConductivity(
+    int8_t powerPin, int8_t dataPin, float Rseries_ohms, float sensorEC_Konst,
+    uint8_t measurementsToAverage, AnalogVoltageBase* analogVoltageReader)
     : Sensor("AnalogElecConductivity", ANALOGELECCONDUCTIVITY_NUM_VARIABLES,
              ANALOGELECCONDUCTIVITY_WARM_UP_TIME_MS,
              ANALOGELECCONDUCTIVITY_STABILIZATION_TIME_MS,
              ANALOGELECCONDUCTIVITY_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, ANALOGELECCONDUCTIVITY_INC_CALC_VARIABLES),
       _Rseries_ohms(Rseries_ohms),
-      _sensorEC_Konst(sensorEC_Konst) {}
+      _sensorEC_Konst(sensorEC_Konst) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new ProcessorAnalogBase();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
+
 // Destructor
-AnalogElecConductivity::~AnalogElecConductivity() {}
+AnalogElecConductivity::~AnalogElecConductivity() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
+
 
 String AnalogElecConductivity::getSensorLocation(void) {
-    String sensorLocation = F("anlgEc Proc Data/Pwr");
-    sensorLocation += String(_dataPin) + "/" + String(_powerPin);
-    return sensorLocation;
-}
-
-
-float AnalogElecConductivity::readEC() {
-    return readEC(_dataPin);
-}
-
-
-float AnalogElecConductivity::readEC(uint8_t analogPinNum) {
-    uint32_t sensorEC_adc;
-    float    Rwater_ohms;      // literal value of water
-    float    EC_uScm = -9999;  // units are uS per cm
-
-    // First measure the analog voltage.
-    // The return value from analogRead() is IN BITS NOT IN VOLTS!!
-    // Take a priming reading.
-    // First reading will be low - discard
-    analogRead(analogPinNum);
-    // Take the reading we'll keep
-    sensorEC_adc = analogRead(analogPinNum);
-    MS_DEEP_DBG("adc bits=", sensorEC_adc);
-
-    if (0 == sensorEC_adc) {
-        // Prevent underflow, can never be outside of PROCESSOR_ADC_RANGE
-        sensorEC_adc = 1;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_anlgEc_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_Pwr");
+        sensorLocation += String(_powerPin);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_anlgEc_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_Pwr");
+        sensorLocation += String(_powerPin);
+        return sensorLocation;
     }
-
-    // Estimate Resistance of Liquid
-
-    // see the header for an explanation of this calculation
-    Rwater_ohms = _Rseries_ohms /
-        ((static_cast<float>(PROCESSOR_ADC_RANGE) /
-          static_cast<float>(sensorEC_adc)) -
-         1);
-    MS_DEEP_DBG("ohms=", Rwater_ohms);
-
-    // Convert to EC
-    EC_uScm = 1000000 / (Rwater_ohms * _sensorEC_Konst);
-    MS_DEEP_DBG("cond=", EC_uScm);
-
-    return EC_uScm;
 }
 
 
@@ -81,18 +68,52 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    float sensorEC_uScm = -9999;
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    bool  success    = false;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    sensorEC_uScm = readEC(_dataPin);
-    MS_DBG(F("Water EC (uSm/cm)"), sensorEC_uScm);
+    // Read the analog voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                           adcVoltage);
 
-    // NOTE: We don't actually have any criteria for if the reading was any good
-    // or not, so we mark it as successful no matter what.
-    verifyAndAddMeasurementResult(ANALOGELECCONDUCTIVITY_EC_VAR_NUM,
-                                  sensorEC_uScm);
-    return bumpMeasurementAttemptCount(true);
+    if (success) {
+        // Estimate Resistance of Liquid
+        // see the header for an explanation of this calculation
+        // Convert voltage back to ADC equivalent for existing calculation
+        float supplyVoltage = _analogVoltageReader->getSupplyVoltage();
+        float adcRatio      = adcVoltage / supplyVoltage;
+
+        if (adcRatio >= 1.0) {
+            // Prevent division issues when voltage reaches supply voltage
+            adcRatio = 0.999;
+        }
+
+        float Rwater_ohms = _Rseries_ohms * adcRatio / (1.0 - adcRatio);
+        MS_DBG(F("  Resistance:"), Rwater_ohms, F("ohms"));
+
+        // Convert to EC
+        float EC_uScm = -9999.0f;  // units are uS per cm
+        if (Rwater_ohms > 0) {
+            EC_uScm = 1000000.0f / (Rwater_ohms * _sensorEC_Konst);
+            MS_DBG(F("Water EC (uSm/cm)"), EC_uScm);
+            verifyAndAddMeasurementResult(ANALOGELECCONDUCTIVITY_EC_VAR_NUM,
+                                          EC_uScm);
+        } else {
+            MS_DBG(F("  Invalid resistance; cannot calculate EC"));
+            success = false;
+        }
+    } else {
+        MS_DBG(F("  Failed to get valid voltage from analog reader"));
+    }
+    return bumpMeasurementAttemptCount(success);
 }
 
 // cSpell:ignore AnalogElecConductivity Rseries_ohms sensorEC_Konst Rwater_ohms

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -103,7 +103,7 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         float EC_uScm = -9999.0f;  // units are uS per cm
         if (Rwater_ohms > 0) {
             EC_uScm = 1000000.0f / (Rwater_ohms * _sensorEC_Konst);
-            MS_DBG(F("Water EC (uSm/cm)"), EC_uScm);
+            MS_DBG(F("Water EC (uS/cm)"), EC_uScm);
             verifyAndAddMeasurementResult(ANALOGELECCONDUCTIVITY_EC_VAR_NUM,
                                           EC_uScm);
         } else {

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -26,8 +26,12 @@ AnalogElecConductivity::AnalogElecConductivity(
       _sensorEC_Konst(sensorEC_Konst) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
+        _analogVoltageReader = new ProcessorAnalogBase();
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -69,6 +69,12 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
+    // Check if we have a valid load resistor
+    if (_sensorEC_Konst <= 0) {
+        MS_DBG(getSensorNameAndLocation(), F("Invalid cell constant"));
+        return bumpMeasurementAttemptCount(false);
+    }
+
     bool  success    = false;
     float adcVoltage = -9999.0f;
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -40,13 +40,20 @@ AnalogElecConductivity::~AnalogElecConductivity() {
 
 
 String AnalogElecConductivity::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_anlgEc_");
-    sensorLocation += String(_dataPin);
-    sensorLocation += F("_Pwr");
-    sensorLocation += String(_powerPin);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_anlgEc_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_Pwr");
+        sensorLocation += String(_powerPin);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_anlgEc_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_Pwr");
+        sensorLocation += String(_powerPin);
+        return sensorLocation;
+    }
 }
 
 
@@ -68,11 +75,7 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read the single-ended analog voltage using the AnalogVoltageBase
-    // interface.
-    // NOTE: All implementations of the AnalogVoltageBase class validate both
-    // the input channel and the resulting voltage, so we can trust that a
-    // successful read will give us a valid voltage value to work with.
+    // Read the analog voltage using the AnalogVoltageBase interface
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -45,20 +45,13 @@ AnalogElecConductivity::~AnalogElecConductivity() {
 
 
 String AnalogElecConductivity::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_anlgEc_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_Pwr");
-        sensorLocation += String(_powerPin);
-        return sensorLocation;
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_anlgEc_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_Pwr");
-        sensorLocation += String(_powerPin);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_anlgEc_");
+    sensorLocation += String(_dataPin);
+    sensorLocation += F("_Pwr");
+    sensorLocation += String(_powerPin);
+    return sensorLocation;
 }
 
 
@@ -80,7 +73,11 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read the analog voltage using the AnalogVoltageBase interface
+    // Read the single-ended analog voltage using the AnalogVoltageBase
+    // interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -80,6 +80,8 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         // Estimate Resistance of Liquid
         // see the header for an explanation of this calculation
         // Convert voltage back to ADC equivalent for existing calculation
+        // NOTE: The supplyVoltage is already clamped by the
+        // _analogVoltageReader
         float supplyVoltage = _analogVoltageReader->getSupplyVoltage();
         float adcRatio      = adcVoltage / supplyVoltage;
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -39,20 +39,15 @@ AnalogElecConductivity::~AnalogElecConductivity() {
 
 
 String AnalogElecConductivity::getSensorLocation(void) {
+    String sensorLocation;
     if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_anlgEc_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_Pwr");
-        sensorLocation += String(_powerPin);
-        return sensorLocation;
+        sensorLocation = _analogVoltageReader->getAnalogLocation(_dataPin);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_anlgEc_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_Pwr");
-        sensorLocation += String(_powerPin);
-        return sensorLocation;
+        sensorLocation = F("Unknown_AnalogVoltageReader");
     }
+    sensorLocation += F("_Pwr");
+    sensorLocation += String(_powerPin);
+    return sensorLocation;
 }
 
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -94,7 +94,7 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         }
         float adcRatio = adcVoltage / supplyVoltage;
 
-        if (adcRatio >= 1.0) {
+        if (adcRatio >= 1.0f) {
             // Prevent division issues when voltage reaches supply voltage
             MS_DBG(F("  ADC ratio clamped from"), adcRatio, F("to"),
                    ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO);

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -41,7 +41,7 @@ AnalogElecConductivity::~AnalogElecConductivity() {
 String AnalogElecConductivity::getSensorLocation(void) {
     String sensorLocation;
     if (_analogVoltageReader != nullptr) {
-        sensorLocation = _analogVoltageReader->getAnalogLocation(_dataPin);
+        sensorLocation = _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
         sensorLocation = F("Unknown_AnalogVoltageReader");
     }

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -23,16 +23,11 @@ AnalogElecConductivity::AnalogElecConductivity(
              ANALOGELECCONDUCTIVITY_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, ANALOGELECCONDUCTIVITY_INC_CALC_VARIABLES),
       _Rseries_ohms(Rseries_ohms),
-      _sensorEC_Konst(sensorEC_Konst) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _sensorEC_Konst(sensorEC_Konst),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new ProcessorAnalogBase()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 AnalogElecConductivity::~AnalogElecConductivity() {

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -82,8 +82,8 @@ bool AnalogElecConductivity::addSingleMeasurementResult(void) {
         // Estimate Resistance of Liquid
         // see the header for an explanation of this calculation
         // Convert voltage back to ADC equivalent for existing calculation
-        // NOTE: The supplyVoltage is already clamped by the
-        // _analogVoltageReader
+        // NOTE: The supplyVoltage is validated and clamped by the
+        // _analogVoltageReader and cannot be 0.
         float supplyVoltage = _analogVoltageReader->getSupplyVoltage();
         float adcRatio      = adcVoltage / supplyVoltage;
 

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -23,11 +23,15 @@ AnalogElecConductivity::AnalogElecConductivity(
              ANALOGELECCONDUCTIVITY_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, ANALOGELECCONDUCTIVITY_INC_CALC_VARIABLES),
       _Rseries_ohms(Rseries_ohms),
-      _sensorEC_Konst(sensorEC_Konst),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new ProcessorAnalogBase()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _sensorEC_Konst(sensorEC_Konst) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 AnalogElecConductivity::~AnalogElecConductivity() {

--- a/src/sensors/AnalogElecConductivity.cpp
+++ b/src/sensors/AnalogElecConductivity.cpp
@@ -26,12 +26,8 @@ AnalogElecConductivity::AnalogElecConductivity(
       _sensorEC_Konst(sensorEC_Konst) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = new ProcessorAnalogBase();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _analogVoltageReader     = new ProcessorAnalogBase();
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -342,10 +342,10 @@ class AnalogElecConductivity : public Sensor {
     /// @brief the cell constant for the circuit
     float _sensorEC_Konst = SENSOREC_KONST_DEF;
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 /**

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -284,6 +284,9 @@ class AnalogElecConductivity : public Sensor {
      * typical standard sized lamp-type plug.
      * @param measurementsToAverage The number of measurements to average;
      * optional with default value of 1.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage measurements; optional with a default of a new ProcessorAnalogBase
+     * object. The private member _analogVoltageReader will store this pointer.
      */
     AnalogElecConductivity(int8_t powerPin, int8_t dataPin,
                            float   Rseries_ohms          = RSERIES_OHMS_DEF,

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -316,9 +316,10 @@ class AnalogElecConductivity : public Sensor {
      * optional with default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a ProcessorAnalogBase instance. If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses the processor's internal ADC. If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     AnalogElecConductivity(
         int8_t powerPin, int8_t dataPin,

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -260,6 +260,9 @@
 #define ANALOGELECCONDUCTIVITY_EC_DEFAULT_CODE "anlgEc"
 /**@}*/
 
+// Forward declaration
+class AnalogVoltageBase;
+
 /**
  * @brief Class for the analog [Electrical Conductivity monitor](@ref
  * sensor_analog_cond)

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -300,7 +300,9 @@ class AnalogElecConductivity : public Sensor {
                            AnalogVoltageBase* analogVoltageReader = nullptr);
 
     /**
-     * @brief Destroy the AnalogElecConductivity object - no action needed.
+     * @brief Destroy the AnalogElecConductivity object.
+     *
+     * Deletes the internal analog voltage reader if this object owns it.
      */
     ~AnalogElecConductivity();
 

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -288,12 +288,22 @@ class AnalogElecConductivity : public Sensor {
     AnalogElecConductivity(int8_t powerPin, int8_t dataPin,
                            float   Rseries_ohms          = RSERIES_OHMS_DEF,
                            float   sensorEC_Konst        = SENSOREC_KONST_DEF,
-                           uint8_t measurementsToAverage = 1);
+                           uint8_t measurementsToAverage = 1,
+                           AnalogVoltageBase* analogVoltageReader = nullptr);
 
     /**
      * @brief Destroy the AnalogElecConductivity object - no action needed.
      */
     ~AnalogElecConductivity();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    AnalogElecConductivity(const AnalogElecConductivity&)            = delete;
+    AnalogElecConductivity& operator=(const AnalogElecConductivity&) = delete;
+
+    // Delete move constructor and move assignment operator
+    AnalogElecConductivity(AnalogElecConductivity&&)            = delete;
+    AnalogElecConductivity& operator=(AnalogElecConductivity&&) = delete;
 
     /**
      * @brief Report the sensor info.
@@ -318,21 +328,6 @@ class AnalogElecConductivity : public Sensor {
         _Rseries_ohms = sourceResistance_ohms;
     }
 
-    /**
-     * @brief reads the calculated EC from an analog pin using the analog pin
-     * number set in the constructor.
-     *
-     * @return The electrical conductance value
-     */
-    float readEC(void);
-    /**
-     * @brief reads the calculated EC from an analog pin.
-     *
-     * @param analogPinNum Analog port pin number
-     * @return The electrical conductance value
-     */
-    float readEC(uint8_t analogPinNum);
-
  private:
     /// @brief The resistance of the circuit resistor plus any series port
     /// resistance
@@ -340,6 +335,11 @@ class AnalogElecConductivity : public Sensor {
 
     /// @brief the cell constant for the circuit
     float _sensorEC_Konst = SENSOREC_KONST_DEF;
+    AnalogVoltageBase*
+         _analogVoltageReader;      ///< Pointer to analog voltage reader
+    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
+                                    ///< analog voltage reader and should delete
+                                    ///< it in the destructor
 };
 
 /**

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -199,7 +199,7 @@
  * @brief The default resistance (in ohms) of the measuring resistor.
  * This should not be less than 300 ohms when measuring EC in water.
  */
-#define ANALOGELECCONDUCTIVITY_RSERIES_OHMS 499
+#define ANALOGELECCONDUCTIVITY_RSERIES_OHMS 499.0f
 #endif  // ANALOGELECCONDUCTIVITY_RSERIES_OHMS
 
 #if !defined(ANALOGELECCONDUCTIVITY_KONST) || defined(DOXYGEN)
@@ -214,7 +214,7 @@
  * and fluid to get a better estimate for K.
  * Default to 1.0, and can be set at startup.
  */
-#define ANALOGELECCONDUCTIVITY_KONST 1.0
+#define ANALOGELECCONDUCTIVITY_KONST 1.0f
 #endif  // ANALOGELECCONDUCTIVITY_KONST
 
 #if !defined(ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO) || defined(DOXYGEN)
@@ -228,6 +228,12 @@
  */
 #define ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO 0.999f
 #endif  // ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO
+
+// Compile-time validation of ADC maximum ratio constraint
+static_assert(
+    ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO > 0.0f &&
+        ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO < 1.0f,
+    "ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO must be in the range (0.0, 1.0)");
 /**@}*/
 
 /**

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -308,10 +308,11 @@ class AnalogElecConductivity : public Sensor {
      * as analog pins generally are numbered with an "A" in front of the number
      * - ie, A1.
      * @param Rseries_ohms The resistance of the resistor series (R) in the
-     * line; optional with default value of 499.
+     * line; optional with default value of
+     * #ANALOGELECCONDUCTIVITY_RSERIES_OHMS (499).
      * @param sensorEC_Konst The cell constant for the sensing circuit; optional
-     * with default value of 2.88 - which is what has been measured for a
-     * typical standard sized lamp-type plug.
+     * with default value of #ANALOGELECCONDUCTIVITY_KONST (1.0f) - this should
+     * be calibrated for each specific sensing setup.
      * @param measurementsToAverage The number of measurements to average;
      * optional with default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -335,11 +335,11 @@ class AnalogElecConductivity : public Sensor {
 
     /// @brief the cell constant for the circuit
     float _sensorEC_Konst = SENSOREC_KONST_DEF;
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 /**

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -116,6 +116,15 @@
  * - `-D MS_PROCESSOR_ADC_REFERENCE_MODE=xxx`
  *      - used to set the processor ADC value reference mode
  *      - @see #MS_PROCESSOR_ADC_REFERENCE_MODE
+ * - `-D ANALOGELECCONDUCTIVITY_RSERIES_OHMS=###`
+ *      - used to set the default resistance of the measuring resistor in ohms
+ *      - @see #ANALOGELECCONDUCTIVITY_RSERIES_OHMS
+ * - `-D ANALOGELECCONDUCTIVITY_KONST=x.x`
+ *      - used to set the cell constant for EC measurements
+ *      - @see #ANALOGELECCONDUCTIVITY_KONST
+ * - `-D ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO=x.xxx`
+ *      - used to set the maximum ADC ratio to prevent division by zero
+ *      - @see #ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO
  *
  * @section sensor_analog_cond_ctor Sensor Constructor
  * {{ @ref AnalogElecConductivity::AnalogElecConductivity }}
@@ -185,15 +194,15 @@
  * conductivity sensor depending on the processor and ADC in use.
  */
 /**@{*/
-#if !defined(RSERIES_OHMS_DEF) || defined(DOXYGEN)
+#if !defined(ANALOGELECCONDUCTIVITY_RSERIES_OHMS) || defined(DOXYGEN)
 /**
  * @brief The default resistance (in ohms) of the measuring resistor.
  * This should not be less than 300 ohms when measuring EC in water.
  */
-#define RSERIES_OHMS_DEF 499
-#endif  // RSERIES_OHMS_DEF
+#define ANALOGELECCONDUCTIVITY_RSERIES_OHMS 499
+#endif  // ANALOGELECCONDUCTIVITY_RSERIES_OHMS
 
-#if !defined(SENSOREC_KONST_DEF) || defined(DOXYGEN)
+#if !defined(ANALOGELECCONDUCTIVITY_KONST) || defined(DOXYGEN)
 /**
  * @brief Cell Constant For EC Measurements.
  *
@@ -205,8 +214,20 @@
  * and fluid to get a better estimate for K.
  * Default to 1.0, and can be set at startup.
  */
-#define SENSOREC_KONST_DEF 1.0
-#endif  // SENSOREC_KONST_DEF
+#define ANALOGELECCONDUCTIVITY_KONST 1.0
+#endif  // ANALOGELECCONDUCTIVITY_KONST
+
+#if !defined(ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO) || defined(DOXYGEN)
+/**
+ * @brief Maximum ADC ratio to prevent division by zero in resistance
+ * calculation.
+ *
+ * This value clamps the ADC ratio when the measured voltage approaches the
+ * supply voltage, preventing division by zero in the water resistance
+ * calculation. Must be less than 1.0.
+ */
+#define ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO 0.999f
+#endif  // ANALOGELECCONDUCTIVITY_ADC_MAX_RATIO
 /**@}*/
 
 /**
@@ -293,11 +314,12 @@ class AnalogElecConductivity : public Sensor {
      * pointer is supplied, the caller retains ownership and must ensure its
      * lifetime exceeds that of this object.
      */
-    AnalogElecConductivity(int8_t powerPin, int8_t dataPin,
-                           float   Rseries_ohms          = RSERIES_OHMS_DEF,
-                           float   sensorEC_Konst        = SENSOREC_KONST_DEF,
-                           uint8_t measurementsToAverage = 1,
-                           AnalogVoltageBase* analogVoltageReader = nullptr);
+    AnalogElecConductivity(
+        int8_t powerPin, int8_t dataPin,
+        float              Rseries_ohms   = ANALOGELECCONDUCTIVITY_RSERIES_OHMS,
+        float              sensorEC_Konst = ANALOGELECCONDUCTIVITY_KONST,
+        uint8_t            measurementsToAverage = 1,
+        AnalogVoltageBase* analogVoltageReader   = nullptr);
 
     /**
      * @brief Destroy the AnalogElecConductivity object.
@@ -341,10 +363,10 @@ class AnalogElecConductivity : public Sensor {
  private:
     /// @brief The resistance of the circuit resistor plus any series port
     /// resistance
-    float _Rseries_ohms = RSERIES_OHMS_DEF;
+    float _Rseries_ohms = ANALOGELECCONDUCTIVITY_RSERIES_OHMS;
 
     /// @brief the cell constant for the circuit
-    float _sensorEC_Konst = SENSOREC_KONST_DEF;
+    float _sensorEC_Konst = ANALOGELECCONDUCTIVITY_KONST;
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -288,8 +288,10 @@ class AnalogElecConductivity : public Sensor {
      * @param measurementsToAverage The number of measurements to average;
      * optional with default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new ProcessorAnalogBase
-     * object. The private member _analogVoltageReader will store this pointer.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a ProcessorAnalogBase instance. If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      */
     AnalogElecConductivity(int8_t powerPin, int8_t dataPin,
                            float   Rseries_ohms          = RSERIES_OHMS_DEF,

--- a/src/sensors/AnalogElecConductivity.h
+++ b/src/sensors/AnalogElecConductivity.h
@@ -352,6 +352,8 @@ class AnalogElecConductivity : public Sensor {
      */
     String getSensorLocation(void) override;
 
+    bool setup(void) override;
+
     bool addSingleMeasurementResult(void) override;
 
     /**

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -82,7 +82,7 @@ class AnalogVoltageBase {
      */
     virtual void setVoltageMultiplier(float voltageMultiplier) {
         // If the input voltage multiplier is not positive, set it to 1.
-        if (voltageMultiplier <= 0.0f) {
+        if (!(voltageMultiplier > 0.0f)) {  // rejects NaN, -inf, and <= 0
             MS_DBG(F("Invalid voltage multiplier "), voltageMultiplier,
                    F(", clamping to 1.0"));
             _voltageMultiplier = 1.0f;
@@ -109,7 +109,7 @@ class AnalogVoltageBase {
      * clamped to OPERATING_VOLTAGE to maintain a valid reference.
      */
     virtual void setSupplyVoltage(float supplyVoltage) {
-        if (supplyVoltage <= 0.0f) {
+        if (!(supplyVoltage > 0.0f)) {  // rejects NaN, -inf, and <= 0
             MS_DBG(F("Invalid supply voltage "), supplyVoltage,
                    F(", clamping to "), OPERATING_VOLTAGE, F("V"));
             _supplyVoltage = OPERATING_VOLTAGE;
@@ -117,6 +117,7 @@ class AnalogVoltageBase {
             _supplyVoltage = supplyVoltage;
         }
     }
+
     /**
      * @brief Get the supply voltage for the analog system
      *
@@ -176,7 +177,7 @@ class AnalogVoltageBase {
      * differential measurements, or the sole channel for single-ended
      * measurements).
      * @param analogReferenceChannel The secondary (reference) analog channel
-     * for differential measurement. Use -1 for a single-ended analog sensor.
+     * for differential measurement. Set to -1 for a single-ended analog sensor.
      *
      * @return A string describing the analog sensor location
      */

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -40,19 +40,13 @@ class AnalogVoltageBase {
     /**
      * @brief Construct a new AnalogVoltageBase object
      *
-     * @param analogChannel The analog channel/pin for voltage readings
      * @param voltageMultiplier The voltage multiplier for any voltage dividers
      * @param supplyVoltage The supply/operating voltage for the analog system
-     * @param analogDifferentialChannel The second channel for differential
-     * measurements (-1 if not used)
      */
-    AnalogVoltageBase(int8_t analogChannel, float voltageMultiplier = 1.0,
-                      float  supplyVoltage             = OPERATING_VOLTAGE,
-                      int8_t analogDifferentialChannel = -1)
-        : _analogChannel(analogChannel),
-          _voltageMultiplier(voltageMultiplier),
-          _supplyVoltage(supplyVoltage),
-          _analogDifferentialChannel(analogDifferentialChannel) {}
+    AnalogVoltageBase(float voltageMultiplier = 1.0,
+                      float supplyVoltage     = OPERATING_VOLTAGE)
+        : _voltageMultiplier(voltageMultiplier),
+          _supplyVoltage(supplyVoltage) {}
 
     /**
      * @brief Destroy the AnalogVoltageBase object
@@ -96,25 +90,17 @@ class AnalogVoltageBase {
     }
 
     /**
-     * @brief Check if this instance is configured for differential measurements
-     *
-     * @return True if both analog channels are valid pins (>=0) for
-     * differential measurements
-     */
-    bool isDifferential(void) const {
-        return (_analogChannel >= 0 && _analogDifferentialChannel >= 0);
-    }
-
-    /**
      * @brief Read a single-ended voltage measurement
      *
      * This pure virtual function must be implemented by derived classes to
      * provide their specific method of reading analog voltages.
      *
+     * @param analogChannel The analog channel/pin for voltage readings
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful and within valid range
      */
-    virtual bool readVoltageSingleEnded(float& resultValue) = 0;
+    virtual bool readVoltageSingleEnded(int8_t analogChannel,
+                                        float& resultValue) = 0;
 
     /**
      * @brief Read a differential voltage measurement
@@ -125,10 +111,16 @@ class AnalogVoltageBase {
      * If the sensor does not support differential measurements, this function
      * should set the resultValue to -9999.0 and return false.
      *
+     * @param analogChannel The primary analog channel for differential
+     * measurement
+     * @param analogReferenceChannel The secondary (reference) analog channel
+     * for differential measurement
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful and within valid range
      */
-    virtual bool readVoltageDifferential(float& resultValue) = 0;
+    virtual bool readVoltageDifferential(int8_t analogChannel,
+                                         int8_t analogReferenceChannel,
+                                         float& resultValue) = 0;
 
     /**
      * @brief Get the sensor location string
@@ -141,14 +133,6 @@ class AnalogVoltageBase {
     virtual String getSensorLocation(void) = 0;
 
  protected:
-    /**
-     * @brief Internal reference to the analog channel/pin
-     *
-     * For TIADS1x15: ADS channel (0-3)
-     * For ProcessorAnalog: processor ADC pin number
-     */
-    int8_t _analogChannel;
-
     /**
      * @brief Internal reference to the voltage multiplier
      *
@@ -163,15 +147,6 @@ class AnalogVoltageBase {
      * For ProcessorAnalog: the processor operating voltage
      */
     float _supplyVoltage;
-
-    /**
-     * @brief Internal reference to the second analog channel for differential
-     * measurements
-     *
-     * For TIADS1x15: second ADS channel for differential readings (-1 if not
-     * used) For ProcessorAnalog: not used (-1)
-     */
-    int8_t _analogDifferentialChannel;
 };
 
 #endif  // SRC_SENSORS_ANALOGVOLTAGEBASE_H_

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -73,7 +73,7 @@ class AnalogVoltageBase {
      *
      * @return The current voltage multiplier
      */
-    float getVoltageMultiplier(void) {
+    float getVoltageMultiplier(void) const {
         return _voltageMultiplier;
     }
 
@@ -91,7 +91,7 @@ class AnalogVoltageBase {
      *
      * @return The current supply voltage in volts
      */
-    float getSupplyVoltage(void) {
+    float getSupplyVoltage(void) const {
         return _supplyVoltage;
     }
 

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -45,7 +45,7 @@
  * methods:
  * - readVoltageSingleEnded() for single-ended voltage measurements,
  * - readVoltageDifferential() for differential voltage measurements, and
- * - getSensorLocation() to provide sensor location identification.
+ * - getAnalogLocation() to provide sensor location identification.
  */
 class AnalogVoltageBase {
  public:

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -201,14 +201,6 @@ class AnalogVoltageBase {
 
  protected:
     /**
-     * @brief Convert voltage resolution to appropriate decimal places
-     *
-     * @param voltageResolution The voltage resolution in volts per LSB
-     * @return The number of decimal places needed to represent the resolution
-     */
-    uint8_t voltageResolutionToDecimalPlaces(float voltageResolution);
-
-    /**
      * @brief Stored voltage multiplier value
      *
      * Multiplier to apply for voltage divider calculations
@@ -223,24 +215,5 @@ class AnalogVoltageBase {
      */
     float _supplyVoltage;
 };
-
-// Inline implementation of voltageResolutionToDecimalPlaces
-inline uint8_t
-AnalogVoltageBase::voltageResolutionToDecimalPlaces(float voltageResolution) {
-    if (voltageResolution <= 0.0f) {
-        return 4;  // Default to 4 decimal places for invalid input
-    }
-
-    // Calculate the number of decimal places needed to represent the resolution
-    // We want at least one significant digit beyond the resolution
-    float log10Resolution = log10f(voltageResolution);
-    int   decimalPlaces   = static_cast<int>(-log10Resolution) + 1;
-
-    // Clamp to reasonable bounds (0-6 decimal places)
-    if (decimalPlaces < 0) decimalPlaces = 0;
-    if (decimalPlaces > 6) decimalPlaces = 6;
-
-    return static_cast<uint8_t>(decimalPlaces);
-}
 
 #endif  // SRC_SENSORS_ANALOGVOLTAGEBASE_H_

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -47,7 +47,11 @@ class AnalogVoltageBase {
      */
     AnalogVoltageBase(float voltageMultiplier = 1.0f,
                       float supplyVoltage     = OPERATING_VOLTAGE)
-        : _voltageMultiplier((voltageMultiplier > 0.0f) ? voltageMultiplier
+        :  // NOTE: These clamps are intentionally silent — Serial/MS_DBG is NOT
+           // safe to call during construction (the Serial object may not be
+           // initialized yet on Arduino targets). Use setSupplyVoltage() at
+           // runtime for logged clamping.
+          _voltageMultiplier((voltageMultiplier > 0.0f) ? voltageMultiplier
                                                         : 1.0f),
           _supplyVoltage((supplyVoltage > 0.0f) ? supplyVoltage
                                                 : OPERATING_VOLTAGE) {}

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -31,9 +31,11 @@
  *
  * This class provides a unified interface for analog voltage reading,
  * whether from external ADCs (like TI ADS1x15) or processor built-in ADCs.
- * Classes that inherit from this base must implement the
- * readVoltageSingleEnded method to provide their specific voltage reading
- * implementation.
+ * Classes that inherit from this base must implement three pure virtual
+ * methods:
+ * - readVoltageSingleEnded() for single-ended voltage measurements,
+ * - readVoltageDifferential() for differential voltage measurements, and
+ * - getSensorLocation() to provide sensor location identification.
  */
 class AnalogVoltageBase {
  public:
@@ -141,14 +143,14 @@ class AnalogVoltageBase {
 
  protected:
     /**
-     * @brief Internal reference to the voltage multiplier
+     * @brief Stored voltage multiplier value
      *
      * Multiplier to apply for voltage divider calculations
      */
     float _voltageMultiplier;
 
     /**
-     * @brief Internal reference to the supply voltage
+     * @brief Stored supply voltage value
      *
      * For TIADS1x15: the ADS supply voltage
      * For ProcessorAnalog: the processor operating voltage

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -64,7 +64,7 @@ class AnalogVoltageBase {
      *
      * @param voltageMultiplier The multiplier value for voltage scaling
      */
-    void setVoltageMultiplier(float voltageMultiplier) {
+    virtual void setVoltageMultiplier(float voltageMultiplier) {
         _voltageMultiplier = voltageMultiplier;
     }
 
@@ -119,17 +119,16 @@ class AnalogVoltageBase {
     /**
      * @brief Read a differential voltage measurement
      *
-     * This virtual function provides a default implementation for differential
-     * voltage readings. Derived classes can override this to provide their
-     * specific differential reading implementation.
+     * This pure virtual function must be implemented by derived classes to
+     * provide their specific method of reading differential voltages.
+     *
+     * If the sensor does not support differential measurements, this function
+     * should set the resultValue to -9999.0 and return false.
      *
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful and within valid range
      */
-    virtual bool readVoltageDifferential(float& resultValue) {
-        resultValue = -9999.0;
-        return false;
-    }
+    virtual bool readVoltageDifferential(float& resultValue) = 0;
 
     /**
      * @brief Get the sensor location string

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -57,9 +57,14 @@ class AnalogVoltageBase {
      * @brief Set the voltage multiplier for voltage divider calculations
      *
      * @param voltageMultiplier The multiplier value for voltage scaling
+     * 
+     * @note The multiplier must be positive (> 0). Values <= 0 will be 
+     * automatically clamped to 0.001 to prevent division-by-zero errors
+     * and maintain valid voltage calculations.
      */
     virtual void setVoltageMultiplier(float voltageMultiplier) {
-        _voltageMultiplier = voltageMultiplier;
+        // Clamp to minimum value to prevent division-by-zero and invalid readings
+        _voltageMultiplier = (voltageMultiplier > 0.0f) ? voltageMultiplier : 0.001f;
     }
 
     /**

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -84,7 +84,8 @@ class AnalogVoltageBase {
      * @param supplyVoltage The supply voltage in volts
      */
     virtual void setSupplyVoltage(float supplyVoltage) {
-        if (supplyVoltage > 0.0f) { _supplyVoltage = supplyVoltage; }
+        _supplyVoltage = (supplyVoltage > 0.0f) ? supplyVoltage
+                                                : OPERATING_VOLTAGE;
     }
     /**
      * @brief Get the supply voltage for the analog system

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -1,0 +1,178 @@
+/**
+ * @file AnalogVoltageBase.h
+ * @copyright Stroud Water Research Center
+ * Part of the EnviroDIY ModularSensors library for Arduino.
+ * This library is published under the BSD-3 license.
+ * @author Sara Geleskie Damiano <sdamiano@stroudcenter.org>
+ *
+ * @brief Contains the AnalogVoltageBase abstract class for providing a unified
+ * interface for analog voltage reading sensors.
+ *
+ * This abstract base class provides a common interface for sensors that can
+ * read single-ended analog voltages, either through external ADCs (like TI
+ * ADS1x15) or built-in processor ADCs.
+ */
+
+// Header Guards
+#ifndef SRC_SENSORS_ANALOGVOLTAGEBASE_H_
+#define SRC_SENSORS_ANALOGVOLTAGEBASE_H_
+
+// Include the library config before anything else
+#include "ModSensorConfig.h"
+
+// Include the debugging config
+#include "ModSensorDebugConfig.h"
+
+// Include the known processors for default values
+#include "KnownProcessors.h"
+
+/**
+ * @brief Abstract base class for analog voltage reading systems.
+ *
+ * This class provides a unified interface for analog voltage reading,
+ * whether from external ADCs (like TI ADS1x15) or processor built-in ADCs.
+ * Classes that inherit from this base must implement the
+ * readVoltageSingleEnded method to provide their specific voltage reading
+ * implementation.
+ */
+class AnalogVoltageBase {
+ public:
+    /**
+     * @brief Construct a new AnalogVoltageBase object
+     *
+     * @param analogChannel The analog channel/pin for voltage readings
+     * @param voltageMultiplier The voltage multiplier for any voltage dividers
+     * @param supplyVoltage The supply/operating voltage for the analog system
+     * @param analogDifferentialChannel The second channel for differential
+     * measurements (-1 if not used)
+     */
+    AnalogVoltageBase(int8_t analogChannel, float voltageMultiplier = 1.0,
+                      float  supplyVoltage             = OPERATING_VOLTAGE,
+                      int8_t analogDifferentialChannel = -1)
+        : _analogChannel(analogChannel),
+          _voltageMultiplier(voltageMultiplier),
+          _supplyVoltage(supplyVoltage),
+          _analogDifferentialChannel(analogDifferentialChannel) {}
+
+    /**
+     * @brief Destroy the AnalogVoltageBase object
+     */
+    virtual ~AnalogVoltageBase() = default;
+
+    /**
+     * @brief Set the voltage multiplier for voltage divider calculations
+     *
+     * @param voltageMultiplier The multiplier value for voltage scaling
+     */
+    void setVoltageMultiplier(float voltageMultiplier) {
+        _voltageMultiplier = voltageMultiplier;
+    }
+
+    /**
+     * @brief Get the voltage multiplier value
+     *
+     * @return The current voltage multiplier
+     */
+    float getVoltageMultiplier(void) {
+        return _voltageMultiplier;
+    }
+
+    /**
+     * @brief Set the supply voltage for the analog system
+     *
+     * @param supplyVoltage The supply voltage in volts
+     */
+    virtual void setSupplyVoltage(float supplyVoltage) {
+        _supplyVoltage = supplyVoltage;
+    }
+
+    /**
+     * @brief Get the supply voltage for the analog system
+     *
+     * @return The current supply voltage in volts
+     */
+    float getSupplyVoltage(void) {
+        return _supplyVoltage;
+    }
+
+    /**
+     * @brief Check if this instance is configured for differential measurements
+     *
+     * @return True if both analog channels are valid pins (>=0) for
+     * differential measurements
+     */
+    bool isDifferential(void) const {
+        return (_analogChannel >= 0 && _analogDifferentialChannel >= 0);
+    }
+
+    /**
+     * @brief Read a single-ended voltage measurement
+     *
+     * This pure virtual function must be implemented by derived classes to
+     * provide their specific method of reading analog voltages.
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful and within valid range
+     */
+    virtual bool readVoltageSingleEnded(float& resultValue) = 0;
+
+    /**
+     * @brief Read a differential voltage measurement
+     *
+     * This virtual function provides a default implementation for differential
+     * voltage readings. Derived classes can override this to provide their
+     * specific differential reading implementation.
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful and within valid range
+     */
+    virtual bool readVoltageDifferential(float& resultValue) {
+        resultValue = -9999.0;
+        return false;
+    }
+
+    /**
+     * @brief Get the sensor location string
+     *
+     * This pure virtual function must be implemented by derived classes to
+     * provide their specific sensor location identification string.
+     *
+     * @return A string describing the sensor location
+     */
+    virtual String getSensorLocation(void) = 0;
+
+ protected:
+    /**
+     * @brief Internal reference to the analog channel/pin
+     *
+     * For TIADS1x15: ADS channel (0-3)
+     * For ProcessorAnalog: processor ADC pin number
+     */
+    int8_t _analogChannel;
+
+    /**
+     * @brief Internal reference to the voltage multiplier
+     *
+     * Multiplier to apply for voltage divider calculations
+     */
+    float _voltageMultiplier;
+
+    /**
+     * @brief Internal reference to the supply voltage
+     *
+     * For TIADS1x15: the ADS supply voltage
+     * For ProcessorAnalog: the processor operating voltage
+     */
+    float _supplyVoltage;
+
+    /**
+     * @brief Internal reference to the second analog channel for differential
+     * measurements
+     *
+     * For TIADS1x15: second ADS channel for differential readings (-1 if not
+     * used) For ProcessorAnalog: not used (-1)
+     */
+    int8_t _analogDifferentialChannel;
+};
+
+#endif  // SRC_SENSORS_ANALOGVOLTAGEBASE_H_

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -43,9 +43,10 @@ class AnalogVoltageBase {
      * @param voltageMultiplier The voltage multiplier for any voltage dividers
      * @param supplyVoltage The supply/operating voltage for the analog system
      */
-    AnalogVoltageBase(float voltageMultiplier = 1.0,
+    AnalogVoltageBase(float voltageMultiplier = 1.0f,
                       float supplyVoltage     = OPERATING_VOLTAGE)
-        : _voltageMultiplier(voltageMultiplier),
+        : _voltageMultiplier((voltageMultiplier > 0.0f) ? voltageMultiplier
+                                                        : 1.0f),
           _supplyVoltage(supplyVoltage) {}
 
     /**
@@ -57,14 +58,15 @@ class AnalogVoltageBase {
      * @brief Set the voltage multiplier for voltage divider calculations
      *
      * @param voltageMultiplier The multiplier value for voltage scaling
-     * 
-     * @note The multiplier must be positive (> 0). Values <= 0 will be 
-     * automatically clamped to 0.001 to prevent division-by-zero errors
-     * and maintain valid voltage calculations.
+     *
+     * @note The multiplier must be positive (> 0). Values <= 0 will be
+     * set to 1 to prevent division-by-zero errors and maintain valid voltage
+     * calculations.
      */
     virtual void setVoltageMultiplier(float voltageMultiplier) {
-        // Clamp to minimum value to prevent division-by-zero and invalid readings
-        _voltageMultiplier = (voltageMultiplier > 0.0f) ? voltageMultiplier : 0.001f;
+        // If the input voltage multiplier is not positive, set it to 1.
+        _voltageMultiplier = (voltageMultiplier > 0.0f) ? voltageMultiplier
+                                                        : 1.0f;
     }
 
     /**
@@ -82,9 +84,8 @@ class AnalogVoltageBase {
      * @param supplyVoltage The supply voltage in volts
      */
     virtual void setSupplyVoltage(float supplyVoltage) {
-        _supplyVoltage = supplyVoltage;
+        if (supplyVoltage > 0.0f) { _supplyVoltage = supplyVoltage; }
     }
-
     /**
      * @brief Get the supply voltage for the analog system
      *

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -104,6 +104,9 @@ class AnalogVoltageBase {
      * @brief Set the supply voltage for the analog system
      *
      * @param supplyVoltage The supply voltage in volts
+     *
+     * @note The supply voltage must be positive (> 0). Values <= 0 will be
+     * clamped to OPERATING_VOLTAGE to maintain a valid reference.
      */
     virtual void setSupplyVoltage(float supplyVoltage) {
         if (supplyVoltage <= 0.0f) {
@@ -148,12 +151,12 @@ class AnalogVoltageBase {
      * should set the resultValue to -9999.0 and return false.
      *
      * @param analogChannel The primary analog channel for differential
-     * measurement. Negative or invalid channel numbers or parings between the
+     * measurement. Negative or invalid channel numbers or pairings between the
      * analogChannel and analogReferenceChannel are not clamped and will cause
      * the reading to fail and emit a warning.
      * @param analogReferenceChannel The secondary (reference) analog channel
      * for differential measurement. Negative or invalid channel numbers or
-     * parings between the analogChannel and analogReferenceChannel are not
+     * pairings between the analogChannel and analogReferenceChannel are not
      * clamped and will cause the reading to fail and emit a warning.
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful and within valid range

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -176,7 +176,7 @@ class AnalogVoltageBase {
      * differential measurements, or the sole channel for single-ended
      * measurements).
      * @param analogReferenceChannel The secondary (reference) analog channel
-     * for differential measurement. Optional with a default of -1.
+     * for differential measurement. Use -1 for a single-ended analog sensor.
      *
      * @return A string describing the analog sensor location
      */

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -44,11 +44,13 @@
  *
  * This class provides a unified interface for analog voltage reading,
  * whether from external ADCs (like TI ADS1x15) or processor built-in ADCs.
- * Classes that inherit from this base must implement three pure virtual
+ * Classes that inherit from this base must implement five pure virtual
  * methods:
+ * - begin() for hardware initialization,
  * - readVoltageSingleEnded() for single-ended voltage measurements,
- * - readVoltageDifferential() for differential voltage measurements, and
- * - getAnalogLocation() to provide sensor location identification.
+ * - readVoltageDifferential() for differential voltage measurements,
+ * - getAnalogLocation() to provide sensor location identification, and
+ * - calculateAnalogResolutionVolts() to compute voltage resolution.
  */
 class AnalogVoltageBase {
  public:

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -75,6 +75,19 @@ class AnalogVoltageBase {
     virtual ~AnalogVoltageBase() = default;
 
     /**
+     * @brief Initialize the analog voltage reading system
+     *
+     * This pure virtual function must be implemented by derived classes to
+     * perform any initialization that cannot be safely done in the constructor.
+     * This includes hardware setup that depends on other systems being
+     * initialized, Serial communication being available, or operations that
+     * might need to communicate with external devices.
+     *
+     * @return True if the initialization was successful, false otherwise
+     */
+    virtual bool begin(void) = 0;
+
+    /**
      * @brief Set the voltage multiplier for voltage divider calculations
      *
      * @param voltageMultiplier The multiplier value for voltage scaling

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -166,14 +166,21 @@ class AnalogVoltageBase {
                                          float& resultValue) = 0;
 
     /**
-     * @brief Get the sensor location string
+     * @brief Construct a String describing the analog sensor location from the
+     * input channels.
      *
      * This pure virtual function must be implemented by derived classes to
      * provide their specific sensor location identification string.
      *
-     * @return A string describing the sensor location
+     * @param analogChannel The primary analog channel for differential
+     * measurement.
+     * @param analogReferenceChannel The secondary (reference) analog channel
+     * for differential measurement. Optional with a default of -1.
+     *
+     * @return A string describing the analog sensor location
      */
-    virtual String getSensorLocation(void) = 0;
+    virtual String getAnalogLocation(int8_t analogChannel,
+                                     int8_t analogReferenceChannel = -1) = 0;
 
  protected:
     /**

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -172,15 +172,16 @@ class AnalogVoltageBase {
      * This pure virtual function must be implemented by derived classes to
      * provide their specific sensor location identification string.
      *
-     * @param analogChannel The primary analog channel for differential
-     * measurement.
+     * @param analogChannel The primary analog channel (primary channel for
+     * differential measurements, or the sole channel for single-ended
+     * measurements).
      * @param analogReferenceChannel The secondary (reference) analog channel
      * for differential measurement. Optional with a default of -1.
      *
      * @return A string describing the analog sensor location
      */
     virtual String getAnalogLocation(int8_t analogChannel,
-                                     int8_t analogReferenceChannel = -1) = 0;
+                                     int8_t analogReferenceChannel) = 0;
 
  protected:
     /**

--- a/src/sensors/AnalogVoltageBase.h
+++ b/src/sensors/AnalogVoltageBase.h
@@ -49,7 +49,8 @@ class AnalogVoltageBase {
                       float supplyVoltage     = OPERATING_VOLTAGE)
         : _voltageMultiplier((voltageMultiplier > 0.0f) ? voltageMultiplier
                                                         : 1.0f),
-          _supplyVoltage(supplyVoltage) {}
+          _supplyVoltage((supplyVoltage > 0.0f) ? supplyVoltage
+                                                : OPERATING_VOLTAGE) {}
 
     /**
      * @brief Destroy the AnalogVoltageBase object

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -13,38 +13,58 @@
 
 
 #include "ApogeeSQ212.h"
-#include <Adafruit_ADS1X15.h>
+#include "TIADS1x15.h"
 
 
 // The constructor - need the power pin and the data pin
-ApogeeSQ212::ApogeeSQ212(int8_t powerPin, uint8_t adsChannel,
-                         uint8_t i2cAddress, uint8_t measurementsToAverage)
+ApogeeSQ212::ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
+                         uint8_t            measurementsToAverage,
+                         AnalogVoltageBase* analogVoltageReader)
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,
              SQ212_STABILIZATION_TIME_MS, SQ212_MEASUREMENT_TIME_MS, powerPin,
-             -1, measurementsToAverage, SQ212_INC_CALC_VARIABLES),
-      _adsChannel(adsChannel),
-      _i2cAddress(i2cAddress) {}
+             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
-ApogeeSQ212::~ApogeeSQ212() {}
+ApogeeSQ212::~ApogeeSQ212() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
 
 
 String ApogeeSQ212::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_adsChannel);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
+            String(_dataPin);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 
 bool ApogeeSQ212::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
 
@@ -55,53 +75,23 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-// Create an auxiliary ADC object
-// We create and set up the ADC object here so that each sensor using
-// the ADC may set the gain appropriately without effecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+    // Read voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                           adcVoltage);
 
-    // Bump the gain up to 1x = +/- 4.096V range
-    // Sensor return range is 0-2.5V, but the next gain option is 2x which only
-    // allows up to 2.048V
-    ads.setGain(GAIN_ONE);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
-        return bumpMeasurementAttemptCount(false);
-    }
-
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the ADC raw count
-    adcCounts = ads.readADC_SingleEnded(_adsChannel);
-    // Convert ADC raw counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"), adcCounts,
-           '=', adcVoltage);
-
-    // @todo Verify the voltage range for the SQ-212 sensor
-    // Here we are using the range of the ADS when it is powered at 3.3V
-    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
-        // Apogee SQ-212 Calibration Factor = 1.0 μmol m-2 s-1 per mV
+    if (success) {
+        // Apply the calibration factor.
+        // The Apogee SQ-212 is factory calibrated with a calibration factor
+        // of 1.0 μmol m-2 s-1 per mV.  If the user wants to use a custom value,
+        // it must be set as a preprocessor definition when compiling the
+        // library, e.g. by adding -DSQ212_CALIBRATION_FACTOR=0.95 to the
+        // compiler flags.
         calibResult = 1000 * adcVoltage * SQ212_CALIBRATION_FACTOR;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(SQ212_PAR_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(SQ212_VOLTAGE_VAR_NUM, adcVoltage);
-        success = true;
+    } else {
+        MS_DBG(F("  Failed to get valid voltage from analog reader"));
     }
 
     // Return success value when finished

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -22,13 +22,12 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                          AnalogVoltageBase* analogVoltageReader)
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,
              SQ212_STABILIZATION_TIME_MS, SQ212_MEASUREMENT_TIME_MS, powerPin,
-             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES) {
+             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -45,8 +45,10 @@ ApogeeSQ212::~ApogeeSQ212() {
 
 String ApogeeSQ212::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
-            String(_dataPin);
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
     } else {
         String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
         sensorLocation += String(_dataPin);

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -22,16 +22,11 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                          AnalogVoltageBase* analogVoltageReader)
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,
              SQ212_STABILIZATION_TIME_MS, SQ212_MEASUREMENT_TIME_MS, powerPin,
-             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new TIADS1x15Base()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 ApogeeSQ212::~ApogeeSQ212() {

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -59,7 +59,6 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -69,8 +68,8 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
     // NOTE: All implementations of the AnalogVoltageBase class validate both
     // the input channel and the resulting voltage, so we can trust that a
     // successful read will give us a valid voltage value to work with.
-    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
-                                                           adcVoltage);
+    bool success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                adcVoltage);
 
     if (success) {
         // Apply the calibration factor.

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -22,11 +22,15 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                          AnalogVoltageBase* analogVoltageReader)
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,
              SQ212_STABILIZATION_TIME_MS, SQ212_MEASUREMENT_TIME_MS, powerPin,
-             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new TIADS1x15Base()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+             analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 ApogeeSQ212::~ApogeeSQ212() {

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -44,7 +44,7 @@ String ApogeeSQ212::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
         return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -39,7 +39,7 @@ ApogeeSQ212::~ApogeeSQ212() {
 
 String ApogeeSQ212::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getAnalogLocation(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
         return String("Unknown_AnalogVoltageReader");
     }

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -39,14 +39,9 @@ ApogeeSQ212::~ApogeeSQ212() {
 
 String ApogeeSQ212::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return _analogVoltageReader->getAnalogLocation(_dataPin);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -39,11 +39,16 @@ ApogeeSQ212::~ApogeeSQ212() {
 
 
 String ApogeeSQ212::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_dataPin);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -26,11 +26,7 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new TIADS1x15Base();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -49,6 +49,25 @@ String ApogeeSQ212::getSensorLocation(void) {
 }
 
 
+bool ApogeeSQ212::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool ApogeeSQ212::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -70,7 +70,11 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read voltage using the AnalogVoltageBase interface
+    // Read the single-ended analog voltage using the AnalogVoltageBase
+    // interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -17,7 +17,7 @@
 
 
 // The constructor - need the power pin and the data pin
-ApogeeSQ212::ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
+ApogeeSQ212::ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                          uint8_t            measurementsToAverage,
                          AnalogVoltageBase* analogVoltageReader)
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -26,7 +26,11 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -23,13 +23,11 @@ ApogeeSQ212::ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
     : Sensor("ApogeeSQ212", SQ212_NUM_VARIABLES, SQ212_WARM_UP_TIME_MS,
              SQ212_STABILIZATION_TIME_MS, SQ212_MEASUREMENT_TIME_MS, powerPin,
              analogChannel, measurementsToAverage, SQ212_INC_CALC_VARIABLES),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 ApogeeSQ212::~ApogeeSQ212() {
@@ -50,9 +48,9 @@ String ApogeeSQ212::getSensorLocation(void) {
 
 
 bool ApogeeSQ212::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -63,7 +61,7 @@ bool ApogeeSQ212::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -68,10 +68,8 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   calibResult = -9999;
+    bool  success    = false;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
@@ -86,7 +84,7 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
         // it must be set as a preprocessor definition when compiling the
         // library, e.g. by adding -DSQ212_CALIBRATION_FACTOR=0.95 to the
         // compiler flags.
-        calibResult = 1000 * adcVoltage * SQ212_CALIBRATION_FACTOR;
+        float calibResult = 1000 * adcVoltage * SQ212_CALIBRATION_FACTOR;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(SQ212_PAR_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(SQ212_VOLTAGE_VAR_NUM, adcVoltage);

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -33,7 +33,6 @@ ApogeeSQ212::~ApogeeSQ212() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 
@@ -85,7 +84,7 @@ bool ApogeeSQ212::addSingleMeasurementResult(void) {
         // it must be set as a preprocessor definition when compiling the
         // library, e.g. by adding -DSQ212_CALIBRATION_FACTOR=0.95 to the
         // compiler flags.
-        float calibResult = 1000 * adcVoltage * SQ212_CALIBRATION_FACTOR;
+        float calibResult = 1000.0f * adcVoltage * SQ212_CALIBRATION_FACTOR;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(SQ212_PAR_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(SQ212_VOLTAGE_VAR_NUM, adcVoltage);

--- a/src/sensors/ApogeeSQ212.cpp
+++ b/src/sensors/ApogeeSQ212.cpp
@@ -44,16 +44,11 @@ ApogeeSQ212::~ApogeeSQ212() {
 
 
 String ApogeeSQ212::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_Channel");
+    sensorLocation += String(_dataPin);
+    return sensorLocation;
 }
 
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -54,8 +54,6 @@
  * SQ-212-215 Manual.pdf)
  *
  * @section sensor_sq212_flags Build flags
- * - ```-D MS_USE_ADS1015```
- *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
  * - ```-D SQ212_CALIBRATION_FACTOR=x```
  *      - Changes the calibration factor from 1 to x
  *

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -242,9 +242,9 @@ class ApogeeSQ212 : public Sensor {
      * @brief Construct a new Apogee SQ-212 object - need the power pin and the
      * analog data channel.
      *
-     * By default, this constructor will use a new TIADS1x15Base object with all
-     * default values for voltage readings, but a pointer to a custom
-     * AnalogVoltageBase object can be passed in if desired.
+     * By default, this constructor will internally create a default
+     * AnalogVoltageBase implementation for voltage readings, but a pointer to
+     * a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @param powerPin The pin on the mcu controlling power to the Apogee
      * SQ-212.  Use -1 if it is continuously powered.

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -95,6 +95,7 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
+#include "AnalogVoltageBase.h"
 
 /** @ingroup sensor_sq212 */
 /**@{*/
@@ -241,7 +242,9 @@ class ApogeeSQ212 : public Sensor {
  public:
     /**
      * @brief Construct a new Apogee SQ-212 object - need the power pin and the
-     * data channel on the ADS1x15.
+     * analog data channel.  By default, this constructor will use a new
+     * TIADS1x15Base object with all default values for voltage readings, but a
+     * pointer to a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core. Connecting the ADS to
@@ -250,45 +253,39 @@ class ApogeeSQ212 : public Sensor {
      * @param powerPin The pin on the mcu controlling power to the Apogee
      * SQ-212.  Use -1 if it is continuously powered.
      * - The SQ-212 requires 3.3 to 24 V DC; current draw 10 µA
-     * - The ADS1115 requires 2.0-5.5V but is assumed to be powered at 3.3V
-     * @param adsChannel The analog data channel the Apogee SQ-212 is connected
-     * to _on the TI ADS1115_ (0-3).
-     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
-     * = GND)
+     * @param analogChannel The analog data channel or processor pin that the
+     * OBS3 is connected to.  The significance of the channel number depends on
+     * the specific AnalogVoltageBase implementation used for voltage readings.
+     * For example, with the TI ADS1x15, this would be the ADC channel (0-3)
+     * that the sensor is connected to.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage measurements; optional with a default of a new TIADS1x15Base
+     * object.
      * @note  The ADS is expected to be either continuously powered or have
      * its power controlled by the same pin as the SQ-212.  This library does
      * not support any other configuration.
      */
-    ApogeeSQ212(int8_t powerPin, uint8_t adsChannel,
-                uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
-                uint8_t measurementsToAverage = 1);
+    ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
+                uint8_t            measurementsToAverage = 1,
+                AnalogVoltageBase* analogVoltageReader   = nullptr);
     /**
-     * @brief Destroy the ApogeeSQ212 object - no action needed
+     * @brief Destroy the ApogeeSQ212 object
      */
     ~ApogeeSQ212();
 
-    /**
-     * @brief Report the I1C address of the ADS and the channel that the SQ-212
-     * is attached to.
-     *
-     * @return Text describing how the sensor is attached to the mcu.
-     */
     String getSensorLocation(void) override;
 
     bool addSingleMeasurementResult(void) override;
 
  private:
-    /**
-     * @brief Internal reference to the ADS channel number of the Apogee SQ-212
-     */
-    uint8_t _adsChannel;
-    /**
-     * @brief Internal reference to the I2C address of the TI-ADS1x15
-     */
-    uint8_t _i2cAddress;
+    AnalogVoltageBase*
+         _analogVoltageReader;      ///< Pointer to analog voltage reader
+    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
+                                    ///< analog voltage reader and should delete
+                                    ///< it in the destructor
 };
 
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -265,6 +265,14 @@ class ApogeeSQ212 : public Sensor {
      * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
+     *
+     * @warning In library versions 0.37.0 and earlier, a different constructor
+     * was used that the I2C address of the ADS1x15 was an optional input
+     * parameter which came *before* the optional input parameter for the number
+     * of measurements to average.  The input parameter for the I2C address has
+     * been *removed* and the input for the number of measurements to average
+     * has been moved up in the order!  Please update your code to prevent a
+     * compiler error or a silent reading error.
      */
     ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                 uint8_t            measurementsToAverage = 1,

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -260,9 +260,10 @@ class ApogeeSQ212 : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * allocate a TIADS1x15Base object automatically (owned and deleted by this
-     * instance).  If a non-null pointer is supplied, the caller retains
-     * ownership and must ensure its lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                 uint8_t            measurementsToAverage = 1,

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -248,27 +248,26 @@ class ApogeeSQ212 : public Sensor {
      * default values for voltage readings, but a pointer to a custom
      * AnalogVoltageBase object can be passed in if desired.
      *
-     * @note ModularSensors only supports connecting the ADS1x15 to the primary
-     * hardware I2C instance defined in the Arduino core. Connecting the ADS to
-     * a secondary hardware or software I2C instance is *not* supported!
-     *
      * @param powerPin The pin on the mcu controlling power to the Apogee
      * SQ-212.  Use -1 if it is continuously powered.
      * - The SQ-212 requires 3.3 to 24 V DC; current draw 10 µA
-     * @param analogChannel The analog data channel or processor pin that the
-     * OBS3 is connected to.  The significance of the channel number depends on
-     * the specific AnalogVoltageBase implementation used for voltage readings.
-     * For example, with the TI ADS1x15, this would be the ADC channel (0-3)
-     * that the sensor is connected to.
+     * @param analogChannel The analog data channel or processor pin for voltage
+     * measurements.  The significance of the channel number depends on the
+     * specific AnalogVoltageBase implementation used for voltage readings. For
+     * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
+     * the sensor is connected to.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new TIADS1x15Base
-     * object.
-     * @note  The ADS is expected to be either continuously powered or have
-     * its power controlled by the same pin as the SQ-212.  This library does
-     * not support any other configuration.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * allocate a TIADS1x15Base object automatically (owned and deleted by this
+     * instance).  If a non-null pointer is supplied, the caller retains
+     * ownership and must ensure its lifetime exceeds that of this object.
+     *
+     * @note  The ADS is expected to be either continuously powered or have its
+     * power controlled by the same pin as the SQ-212.  This library does not
+     * support any other configuration.
      */
     ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
                 uint8_t            measurementsToAverage = 1,
@@ -277,6 +276,15 @@ class ApogeeSQ212 : public Sensor {
      * @brief Destroy the ApogeeSQ212 object
      */
     ~ApogeeSQ212();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    ApogeeSQ212(const ApogeeSQ212&)            = delete;
+    ApogeeSQ212& operator=(const ApogeeSQ212&) = delete;
+
+    // Delete move constructor and move assignment operator
+    ApogeeSQ212(ApogeeSQ212&&)            = delete;
+    ApogeeSQ212& operator=(ApogeeSQ212&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -293,6 +293,8 @@ class ApogeeSQ212 : public Sensor {
 
     String getSensorLocation(void) override;
 
+    bool setup(void) override;
+
     bool addSingleMeasurementResult(void) override;
 
  private:

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -141,15 +141,16 @@ class AnalogVoltageBase;
  */
 #define SQ212_WARM_UP_TIME_MS 2
 /**
- * @brief Sensor::_stabilizationTime_ms; the ADS1115 is stable after 2ms.
+ * @brief Sensor::_stabilizationTime_ms; the default ADS1115 voltage reader is
+ * stable after 2ms.
  *
  * The stabilization time of the SQ-212 itself is not known!
  *
  * @todo Measure stabilization time of the SQ-212
  */
 #define SQ212_STABILIZATION_TIME_MS 2
-/// @brief Sensor::_measurementTime_ms; ADS1115 takes almost 2ms to complete a
-/// measurement (860/sec).
+/// @brief Sensor::_measurementTime_ms; with the default ADS1115 voltage reader,
+/// it takes almost 2ms to complete a measurement (860/sec).
 #define SQ212_MEASUREMENT_TIME_MS 2
 /**@}*/
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -126,9 +126,6 @@
  */
 #define SQ212_CALIBRATION_FACTOR 1
 #endif
-
-/// The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
 /**@}*/
 
 /**
@@ -266,7 +263,7 @@ class ApogeeSQ212 : public Sensor {
      * not support any other configuration.
      */
     ApogeeSQ212(int8_t powerPin, uint8_t adsChannel,
-                uint8_t i2cAddress            = ADS1115_ADDRESS,
+                uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
                 uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the ApogeeSQ212 object - no action needed

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -242,9 +242,11 @@ class ApogeeSQ212 : public Sensor {
  public:
     /**
      * @brief Construct a new Apogee SQ-212 object - need the power pin and the
-     * analog data channel.  By default, this constructor will use a new
-     * TIADS1x15Base object with all default values for voltage readings, but a
-     * pointer to a custom AnalogVoltageBase object can be passed in if desired.
+     * analog data channel.
+     *
+     * By default, this constructor will use a new TIADS1x15Base object with all
+     * default values for voltage readings, but a pointer to a custom
+     * AnalogVoltageBase object can be passed in if desired.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core. Connecting the ADS to

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -91,7 +91,9 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
+
+// Forward declaration
+class AnalogVoltageBase;
 
 /** @ingroup sensor_sq212 */
 /**@{*/

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -292,10 +292,10 @@ class ApogeeSQ212 : public Sensor {
 
  private:
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -291,11 +291,11 @@ class ApogeeSQ212 : public Sensor {
     bool addSingleMeasurementResult(void) override;
 
  private:
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -253,7 +253,8 @@ class ApogeeSQ212 : public Sensor {
      * measurements.  The significance of the channel number depends on the
      * specific AnalogVoltageBase implementation used for voltage readings. For
      * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
-     * the sensor is connected to.
+     * the sensor is connected to.  Negative or invalid channel numbers are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -261,7 +261,7 @@ class ApogeeSQ212 : public Sensor {
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
      * internally create and own an analog voltage reader.  For backward
-     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
      */

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -12,8 +12,6 @@
  * ApogeeSQ212_PAR and ApogeeSQ212_Voltage.
  *
  * These are used for the Apogee SQ-212 quantum light sensor.
- *
- * This depends on the Adafruit ADS1X15 v2.x library.
  */
 /* clang-format off */
 /**
@@ -265,7 +263,7 @@ class ApogeeSQ212 : public Sensor {
      * instance).  If a non-null pointer is supplied, the caller retains
      * ownership and must ensure its lifetime exceeds that of this object.
      */
-    ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
+    ApogeeSQ212(int8_t powerPin, int8_t analogChannel,
                 uint8_t            measurementsToAverage = 1,
                 AnalogVoltageBase* analogVoltageReader   = nullptr);
     /**

--- a/src/sensors/ApogeeSQ212.h
+++ b/src/sensors/ApogeeSQ212.h
@@ -264,10 +264,6 @@ class ApogeeSQ212 : public Sensor {
      * allocate a TIADS1x15Base object automatically (owned and deleted by this
      * instance).  If a non-null pointer is supplied, the caller retains
      * ownership and must ensure its lifetime exceeds that of this object.
-     *
-     * @note  The ADS is expected to be either continuously powered or have its
-     * power controlled by the same pin as the SQ-212.  This library does not
-     * support any other configuration.
      */
     ApogeeSQ212(int8_t powerPin, uint8_t analogChannel,
                 uint8_t            measurementsToAverage = 1,

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -26,12 +26,8 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t analogChannel,
       _x0_coeff_C(x0_coeff_C) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = new TIADS1x15Base();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;
@@ -73,8 +69,8 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999.0f;
+    bool  success    = false;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -23,13 +23,12 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t analogChannel,
              analogChannel, measurementsToAverage, OBS3_INC_CALC_VARIABLES),
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C) {
+      _x0_coeff_C(x0_coeff_C),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -64,13 +64,13 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    float adcVoltage = -9999.0f;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _x2_coeff_A, F("x^2 +"),
            _x1_coeff_B, F("x +"), _x0_coeff_C);
+
+    float adcVoltage = -9999.0f;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Read the single-ended analog voltage using the AnalogVoltageBase
     // interface.

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -60,7 +60,6 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -74,8 +73,8 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
     // NOTE: All implementations of the AnalogVoltageBase class validate both
     // the input channel and the resulting voltage, so we can trust that a
     // successful read will give us a valid voltage value to work with.
-    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
-                                                           adcVoltage);
+    bool success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                adcVoltage);
     if (success) {
         // Apply the unique calibration curve for the given sensor
         float calibResult = (_x2_coeff_A * sq(adcVoltage)) +

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -24,13 +24,11 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t analogChannel,
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
       _x0_coeff_C(x0_coeff_C),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 CampbellOBS3::~CampbellOBS3() {
@@ -51,9 +49,9 @@ String CampbellOBS3::getSensorLocation(void) {
 
 
 bool CampbellOBS3::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -64,7 +62,7 @@ bool CampbellOBS3::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -50,6 +50,25 @@ String CampbellOBS3::getSensorLocation(void) {
 }
 
 
+bool CampbellOBS3::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool CampbellOBS3::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -45,14 +45,11 @@ CampbellOBS3::~CampbellOBS3() {
 
 
 String CampbellOBS3::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
-            String(_dataPin);
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_Channel");
+    sensorLocation += String(_dataPin);
+    return sensorLocation;
 }
 
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -23,11 +23,15 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t analogChannel,
              analogChannel, measurementsToAverage, OBS3_INC_CALC_VARIABLES),
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new TIADS1x15Base()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _x0_coeff_C(x0_coeff_C) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 CampbellOBS3::~CampbellOBS3() {

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -23,16 +23,11 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t analogChannel,
              analogChannel, measurementsToAverage, OBS3_INC_CALC_VARIABLES),
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _x0_coeff_C(x0_coeff_C),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new TIADS1x15Base()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 CampbellOBS3::~CampbellOBS3() {

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -40,7 +40,7 @@ CampbellOBS3::~CampbellOBS3() {
 
 String CampbellOBS3::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getAnalogLocation(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
         return String("Unknown_AnalogVoltageReader");
     }

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -75,7 +75,11 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
     MS_DBG(F("  Input calibration Curve:"), _x2_coeff_A, F("x^2 +"),
            _x1_coeff_B, F("x +"), _x0_coeff_C);
 
-    // Read voltage using the AnalogVoltageBase interface
+    // Read the single-ended analog voltage using the AnalogVoltageBase
+    // interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
     if (success) {

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -40,12 +40,9 @@ CampbellOBS3::~CampbellOBS3() {
 
 String CampbellOBS3::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
-            String(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -14,7 +14,7 @@
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
-CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t analogChannel,
+CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t analogChannel,
                            float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
                            uint8_t            measurementsToAverage,
                            AnalogVoltageBase* analogVoltageReader)

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -34,7 +34,6 @@ CampbellOBS3::~CampbellOBS3() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -70,8 +70,7 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
     }
 
     bool  success     = false;
-    float adcVoltage  = -9999;
-    float calibResult = -9999;
+    float adcVoltage  = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
@@ -84,7 +83,7 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
                                                            adcVoltage);
     if (success) {
         // Apply the unique calibration curve for the given sensor
-        calibResult = (_x2_coeff_A * sq(adcVoltage)) +
+        float calibResult = (_x2_coeff_A * sq(adcVoltage)) +
             (_x1_coeff_B * adcVoltage) + _x0_coeff_C;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(OBS3_TURB_VAR_NUM, calibResult);

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -45,7 +45,7 @@ String CampbellOBS3::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
         return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -12,7 +12,6 @@
 #include "CampbellOBS3.h"
 #include "TIADS1x15.h"
 #include "ProcessorAnalog.h"
-#include <Adafruit_ADS1X15.h>
 
 
 // Primary constructor using AnalogVoltageBase abstraction

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -26,8 +26,12 @@ CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t analogChannel,
       _x0_coeff_C(x0_coeff_C) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
+        _analogVoltageReader = new TIADS1x15Base();
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -10,35 +10,49 @@
 
 
 #include "CampbellOBS3.h"
-#include <Adafruit_ADS1X15.h>
+#include "TIADS1x15.h"
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
-CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t adsChannel,
+CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t analogChannel,
                            float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
-                           uint8_t i2cAddress, uint8_t measurementsToAverage)
+                           uint8_t            measurementsToAverage,
+                           AnalogVoltageBase* analogVoltageReader)
     : Sensor("CampbellOBS3", OBS3_NUM_VARIABLES, OBS3_WARM_UP_TIME_MS,
-             OBS3_STABILIZATION_TIME_MS, OBS3_MEASUREMENT_TIME_MS, powerPin, -1,
-             measurementsToAverage, OBS3_INC_CALC_VARIABLES),
-      _adsChannel(adsChannel),
+             OBS3_STABILIZATION_TIME_MS, OBS3_MEASUREMENT_TIME_MS, powerPin,
+             analogChannel, measurementsToAverage, OBS3_INC_CALC_VARIABLES),
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C),
-      _i2cAddress(i2cAddress) {}
+      _x0_coeff_C(x0_coeff_C) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
+
 // Destructor
-CampbellOBS3::~CampbellOBS3() {}
+CampbellOBS3::~CampbellOBS3() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
 
 
 String CampbellOBS3::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_adsChannel);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
+            String(_dataPin);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 
@@ -48,65 +62,35 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   calibResult = -9999;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-// Create an auxiliary ADC object
-// We create and set up the ADC object here so that each sensor using
-// the ADC may set the gain appropriately without effecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-
-    // Bump the gain up to 1x = +/- 4.096V range
-    // Sensor return range is 0-2.5V, but the next gain option is 2x which
-    // only allows up to 2.048V
-    ads.setGain(GAIN_ONE);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
+
+    bool  success     = false;
+    float adcVoltage  = -9999;
+    float calibResult = -9999;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _x2_coeff_A, F("x^2 +"),
            _x1_coeff_B, F("x +"), _x0_coeff_C);
 
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the ADC raw count
-    adcCounts = ads.readADC_SingleEnded(_adsChannel);
-    // Convert ADC raw counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"), adcCounts,
-           '=', adcVoltage);
-
-    // @todo Verify the voltage range for the OBS3 sensor -
-    // Here we are using the range of the ADS when it is powered at 3.3V
-    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+    // Read voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                           adcVoltage);
+    if (success) {
         // Apply the unique calibration curve for the given sensor
         calibResult = (_x2_coeff_A * sq(adcVoltage)) +
             (_x1_coeff_B * adcVoltage) + _x0_coeff_C;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(OBS3_TURB_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(OBS3_VOLTAGE_VAR_NUM, adcVoltage);
-        success = true;
+    } else {
+        MS_DBG(F("  Failed to get valid voltage from analog reader"));
     }
 
     // Return success value when finished

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -10,79 +10,35 @@
 
 
 #include "CampbellOBS3.h"
-#include "TIADS1x15.h"
-#include "ProcessorAnalog.h"
+#include <Adafruit_ADS1X15.h>
 
 
-// Primary constructor using AnalogVoltageBase abstraction
-CampbellOBS3::CampbellOBS3(int8_t             powerPin,
-                           AnalogVoltageBase* analogVoltageReader,
-                           float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
-                           uint8_t measurementsToAverage)
-    : Sensor("CampbellOBS3", OBS3_NUM_VARIABLES, OBS3_WARM_UP_TIME_MS,
-             OBS3_STABILIZATION_TIME_MS, OBS3_MEASUREMENT_TIME_MS, powerPin, -1,
-             measurementsToAverage, OBS3_INC_CALC_VARIABLES),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsVoltageReader(false),
-      _x2_coeff_A(x2_coeff_A),
-      _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C) {}
-
-// Constructor that creates a TIADS1x15 object internally
+// The constructor - need the power pin, the data pin, and the calibration info
 CampbellOBS3::CampbellOBS3(int8_t powerPin, uint8_t adsChannel,
                            float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
-                           uint8_t measurementsToAverage,
-                           float voltageMultiplier, adsGain_t adsGain,
-                           uint8_t i2cAddress, float adsSupplyVoltage)
+                           uint8_t i2cAddress, uint8_t measurementsToAverage)
     : Sensor("CampbellOBS3", OBS3_NUM_VARIABLES, OBS3_WARM_UP_TIME_MS,
              OBS3_STABILIZATION_TIME_MS, OBS3_MEASUREMENT_TIME_MS, powerPin, -1,
              measurementsToAverage, OBS3_INC_CALC_VARIABLES),
-      _analogVoltageReader(nullptr),
-      _ownsVoltageReader(true),
+      _adsChannel(adsChannel),
       _x2_coeff_A(x2_coeff_A),
       _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C) {
-    // Create a TIADS1x15 object for analog voltage reading
-    _analogVoltageReader =
-        new TIADS1x15(powerPin, adsChannel, voltageMultiplier, adsGain,
-                      i2cAddress, measurementsToAverage, adsSupplyVoltage);
-}
-
-// Constructor that creates a ProcessorAnalog object internally
-CampbellOBS3::CampbellOBS3(int8_t powerPin, int8_t dataPin, float x2_coeff_A,
-                           float x1_coeff_B, float x0_coeff_C,
-                           float voltageMultiplier, float operatingVoltage,
-                           uint8_t measurementsToAverage)
-    : Sensor("CampbellOBS3", OBS3_NUM_VARIABLES, OBS3_WARM_UP_TIME_MS,
-             OBS3_STABILIZATION_TIME_MS, OBS3_MEASUREMENT_TIME_MS, powerPin, -1,
-             measurementsToAverage, OBS3_INC_CALC_VARIABLES),
-      _analogVoltageReader(nullptr),
-      _ownsVoltageReader(true),
-      _x2_coeff_A(x2_coeff_A),
-      _x1_coeff_B(x1_coeff_B),
-      _x0_coeff_C(x0_coeff_C) {
-    // Create a ProcessorAnalog object for analog voltage reading
-    _analogVoltageReader =
-        new ProcessorAnalog(powerPin, dataPin, voltageMultiplier,
-                            operatingVoltage, measurementsToAverage);
-}
+      _x0_coeff_C(x0_coeff_C),
+      _i2cAddress(i2cAddress) {}
 // Destructor
-CampbellOBS3::~CampbellOBS3() {
-    // Clean up owned voltage reader if created by constructor
-    if (_ownsVoltageReader && _analogVoltageReader != nullptr) {
-        delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
-    }
-}
+CampbellOBS3::~CampbellOBS3() {}
 
 
 String CampbellOBS3::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation();
-    } else {
-        // Fallback for cases where voltage reader is not set
-        return F("CampbellOBS3_UnknownLocation");
-    }
+#ifndef MS_USE_ADS1015
+    String sensorLocation = F("ADS1115_0x");
+#else
+    String sensorLocation = F("ADS1015_0x");
+#endif
+    sensorLocation += String(_i2cAddress, HEX);
+    sensorLocation += F("_Channel");
+    sensorLocation += String(_adsChannel);
+    return sensorLocation;
 }
 
 
@@ -92,35 +48,65 @@ bool CampbellOBS3::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Ensure we have a valid voltage reader
-    if (_analogVoltageReader == nullptr) {
-        MS_DBG(F("  No analog voltage reader configured!"));
-        return bumpMeasurementAttemptCount(false);
-    }
-
     bool    success     = false;
+    int16_t adcCounts   = -9999;
     float   adcVoltage  = -9999;
     float   calibResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
+// Create an auxiliary ADC object
+// We create and set up the ADC object here so that each sensor using
+// the ADC may set the gain appropriately without effecting others.
+#ifndef MS_USE_ADS1015
+    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
+#else
+    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
+#endif
+    // ADS Library default settings:
+    //  - TI ADS1115 (16 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 128 samples per second (8ms conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+    //  - TI ADS1015 (12 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 1600 samples per second (625µs conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+
+    // Bump the gain up to 1x = +/- 4.096V range
+    // Sensor return range is 0-2.5V, but the next gain option is 2x which
+    // only allows up to 2.048V
+    ads.setGain(GAIN_ONE);
+    // Begin ADC, returns true if anything was detected at the address
+    if (!ads.begin(_i2cAddress)) {
+        MS_DBG(F("  ADC initialization failed at 0x"),
+               String(_i2cAddress, HEX));
+        return bumpMeasurementAttemptCount(false);
+    }
+
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _x2_coeff_A, F("x^2 +"),
            _x1_coeff_B, F("x +"), _x0_coeff_C);
 
-    // Use the abstracted voltage reading method
-    success = _analogVoltageReader->readVoltageSingleEnded(adcVoltage);
+    // Read Analog to Digital Converter (ADC)
+    // Taking this reading includes the 8ms conversion delay.
+    // Measure the ADC raw count
+    adcCounts = ads.readADC_SingleEnded(_adsChannel);
+    // Convert ADC raw counts value to voltage (V)
+    adcVoltage = ads.computeVolts(adcCounts);
+    MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"), adcCounts,
+           '=', adcVoltage);
 
-    if (success) {
+    // @todo Verify the voltage range for the OBS3 sensor -
+    // Here we are using the range of the ADS when it is powered at 3.3V
+    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
         // Apply the unique calibration curve for the given sensor
         calibResult = (_x2_coeff_A * sq(adcVoltage)) +
             (_x1_coeff_B * adcVoltage) + _x0_coeff_C;
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(OBS3_TURB_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(OBS3_VOLTAGE_VAR_NUM, adcVoltage);
-
-    } else {
-        MS_DBG(F("  Failed to read voltage from analog voltage reader"));
+        success = true;
     }
 
     // Return success value when finished

--- a/src/sensors/CampbellOBS3.cpp
+++ b/src/sensors/CampbellOBS3.cpp
@@ -40,11 +40,14 @@ CampbellOBS3::~CampbellOBS3() {
 
 
 String CampbellOBS3::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_dataPin);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
+            String(_dataPin);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -9,8 +9,6 @@
  * CampbellOBS3_Turbidity and CampbellOBS3_Voltage.
  *
  * These are used for the Campbell Scientific OBS-3+.
- *
- * This depends on the Adafruit ADS1X15 v2.x library
  */
 /* clang-format off */
 /**

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -257,9 +257,10 @@ class CampbellOBS3 : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.  If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     CampbellOBS3(int8_t powerPin, int8_t analogChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -288,11 +288,11 @@ class CampbellOBS3 : public Sensor {
     float _x2_coeff_A;  ///< Internal reference to the x^2 coefficient
     float _x1_coeff_B;  ///< Internal reference to the x coefficient
     float _x0_coeff_C;  ///< Internal reference to the x^0 coefficient
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -285,9 +285,12 @@ class CampbellOBS3 : public Sensor {
     bool addSingleMeasurementResult(void) override;
 
  private:
-    float _x2_coeff_A;  ///< The x^2 (A) calibration coefficient
-    float _x1_coeff_B;  ///< The x^1 (B) calibration coefficient
-    float _x0_coeff_C;  ///< The x^0 (C) calibration coefficient
+    /// @brief The x^2 (A) calibration coefficient
+    float _x2_coeff_A;
+    /// @brief The x^1 (B) calibration coefficient
+    float _x1_coeff_B;
+    /// @brief The x^0 (C) calibration coefficient
+    float _x0_coeff_C;
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -249,7 +249,8 @@ class CampbellOBS3 : public Sensor {
      * measurements.  The significance of the channel number depends on the
      * specific AnalogVoltageBase implementation used for voltage readings. For
      * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
-     * the sensor is connected to.
+     * the sensor is connected to.  Negative or invalid channel numbers are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param x2_coeff_A The x2 (A) coefficient for the calibration _in volts_
      * @param x1_coeff_B The x (B) coefficient for the calibration _in volts_
      * @param x0_coeff_C The x0 (C) coefficient for the calibration _in volts_

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -261,6 +261,14 @@ class CampbellOBS3 : public Sensor {
      * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
+     *
+     * @warning In library versions 0.37.0 and earlier, a different constructor
+     * was used that the I2C address of the ADS1x15 was an optional input
+     * parameter which came *before* the optional input parameter for the number
+     * of measurements to average.  The input parameter for the I2C address has
+     * been *removed* and the input for the number of measurements to average
+     * has been moved up in the order!  Please update your code to prevent a
+     * compiler error or a silent reading error.
      */
     CampbellOBS3(int8_t powerPin, int8_t analogChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -88,6 +88,7 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
+#include "AnalogVoltageBase.h"
 
 /** @ingroup sensor_obs3 */
 /**@{*/
@@ -244,8 +245,24 @@
 /* clang-format on */
 class CampbellOBS3 : public Sensor {
  public:
-    // The constructor - need the power pin, the ADS1X15 data channel, and the
-    // calibration info
+    /**
+     * @brief Construct a new Campbell OBS3 object using a pre-configured
+     * AnalogVoltageBase
+     *
+     * @param powerPin The pin on the mcu controlling power to the OBS3+
+     * Use -1 if it is continuously powered.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage readings
+     * @param x2_coeff_A The x2 (A) coefficient for calibration _in volts_
+     * @param x1_coeff_B The x (B) coefficient for calibration _in volts_
+     * @param x0_coeff_C The x0 (C) coefficient for calibration _in volts_
+     * @param measurementsToAverage Number of measurements to average
+     * (default=1)
+     */
+    CampbellOBS3(int8_t powerPin, AnalogVoltageBase* analogVoltageReader,
+                 float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
+                 uint8_t measurementsToAverage = 1);
+
     /**
      * @brief Construct a new Campbell OBS3 object - need the power pin, the
      * ADS1X15 data channel, and the calibration info.
@@ -265,15 +282,41 @@ class CampbellOBS3 : public Sensor {
      * @param x2_coeff_A The x2 (A) coefficient for the calibration _in volts_
      * @param x1_coeff_B The x (B) coefficient for the calibration _in volts_
      * @param x0_coeff_C The x0 (C) coefficient for the calibration _in volts_
+     * @param voltageMultiplier The voltage multiplier for voltage dividers
+     * (default=1)
+     * @param adsGain The internal gain setting (default=GAIN_ONE)
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
+     * @param adsSupplyVoltage ADS supply voltage in volts (default=3.3V)
      */
     CampbellOBS3(int8_t powerPin, uint8_t adsChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,
-                 uint8_t i2cAddress            = ADS1115_ADDRESS,
+                 uint8_t i2cAddress      = ADS1115_ADDRESS,
+                 float voltageMultiplier = 1.0, adsGain_t adsGain = GAIN_ONE,
+                 uint8_t measurementsToAverage = 1,
+                 float   adsSupplyVoltage      = 3.3);
+
+    /**
+     * @brief Construct a new Campbell OBS3 object using processor ADC
+     *
+     * @param powerPin The pin on the mcu controlling power to the OBS3+
+     * Use -1 if it is continuously powered.
+     * @param dataPin The processor ADC pin for voltage readings
+     * @param x2_coeff_A The x2 (A) coefficient for calibration _in volts_
+     * @param x1_coeff_B The x (B) coefficient for calibration _in volts_
+     * @param x0_coeff_C The x0 (C) coefficient for calibration _in volts_
+     * @param voltageMultiplier The voltage multiplier for voltage dividers
+     * (default=1)
+     * @param operatingVoltage Processor operating voltage (default=3.3V)
+     * @param measurementsToAverage Number of measurements to average
+     * (default=1)
+     */
+    CampbellOBS3(int8_t powerPin, int8_t dataPin, float x2_coeff_A,
+                 float x1_coeff_B, float x0_coeff_C,
+                 float voltageMultiplier = 1.0, float operatingVoltage = 3.3,
                  uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the Campbell OBS3 object
@@ -286,17 +329,16 @@ class CampbellOBS3 : public Sensor {
 
  private:
     /**
-     * @brief Internal reference to the ADS channel number of the Campbell OBS
-     * 3+
+     * @brief Internal reference to the analog voltage reading object
      */
-    uint8_t _adsChannel;
+    AnalogVoltageBase* _analogVoltageReader;
+    /**
+     * @brief Internal flag indicating if this instance owns the voltage reader
+     */
+    bool    _ownsVoltageReader;
     float   _x2_coeff_A;  ///< Internal reference to the x^2 coefficient
     float   _x1_coeff_B;  ///< Internal reference to the x coefficient
     float   _x0_coeff_C;  ///< Internal reference to the x^0 coefficient
-    /**
-     * @brief Internal reference to the I2C address of the TI-ADS1x15
-     */
-    uint8_t _i2cAddress;
 };
 
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -82,7 +82,9 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
+
+// Forward declaration
+class AnalogVoltageBase;
 
 /** @ingroup sensor_obs3 */
 /**@{*/

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -88,8 +88,6 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
-#include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_obs3 */
 /**@{*/
@@ -236,24 +234,8 @@
 /* clang-format on */
 class CampbellOBS3 : public Sensor {
  public:
-    /**
-     * @brief Construct a new Campbell OBS3 object using a pre-configured
-     * AnalogVoltageBase
-     *
-     * @param powerPin The pin on the mcu controlling power to the OBS3+
-     * Use -1 if it is continuously powered.
-     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage readings
-     * @param x2_coeff_A The x2 (A) coefficient for calibration _in volts_
-     * @param x1_coeff_B The x (B) coefficient for calibration _in volts_
-     * @param x0_coeff_C The x0 (C) coefficient for calibration _in volts_
-     * @param measurementsToAverage Number of measurements to average
-     * (default=1)
-     */
-    CampbellOBS3(int8_t powerPin, AnalogVoltageBase* analogVoltageReader,
-                 float x2_coeff_A, float x1_coeff_B, float x0_coeff_C,
-                 uint8_t measurementsToAverage = 1);
-
+    // The constructor - need the power pin, the ADS1X15 data channel, and the
+    // calibration info
     /**
      * @brief Construct a new Campbell OBS3 object - need the power pin, the
      * ADS1X15 data channel, and the calibration info.
@@ -273,41 +255,15 @@ class CampbellOBS3 : public Sensor {
      * @param x2_coeff_A The x2 (A) coefficient for the calibration _in volts_
      * @param x1_coeff_B The x (B) coefficient for the calibration _in volts_
      * @param x0_coeff_C The x0 (C) coefficient for the calibration _in volts_
-     * @param voltageMultiplier The voltage multiplier for voltage dividers
-     * (default=1)
-     * @param adsGain The internal gain setting (default=GAIN_ONE)
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
-     * @param adsSupplyVoltage ADS supply voltage in volts (default=3.3V)
      */
     CampbellOBS3(int8_t powerPin, uint8_t adsChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,
-                 uint8_t i2cAddress      = MS_DEFAULT_ADS1X15_ADDRESS,
-                 float voltageMultiplier = 1.0, adsGain_t adsGain = GAIN_ONE,
-                 uint8_t measurementsToAverage = 1,
-                 float   adsSupplyVoltage      = 3.3);
-
-    /**
-     * @brief Construct a new Campbell OBS3 object using processor ADC
-     *
-     * @param powerPin The pin on the mcu controlling power to the OBS3+
-     * Use -1 if it is continuously powered.
-     * @param dataPin The processor ADC pin for voltage readings
-     * @param x2_coeff_A The x2 (A) coefficient for calibration _in volts_
-     * @param x1_coeff_B The x (B) coefficient for calibration _in volts_
-     * @param x0_coeff_C The x0 (C) coefficient for calibration _in volts_
-     * @param voltageMultiplier The voltage multiplier for voltage dividers
-     * (default=1)
-     * @param operatingVoltage Processor operating voltage (default=3.3V)
-     * @param measurementsToAverage Number of measurements to average
-     * (default=1)
-     */
-    CampbellOBS3(int8_t powerPin, int8_t dataPin, float x2_coeff_A,
-                 float x1_coeff_B, float x0_coeff_C,
-                 float voltageMultiplier = 1.0, float operatingVoltage = 3.3,
+                 uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
                  uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the Campbell OBS3 object
@@ -320,16 +276,17 @@ class CampbellOBS3 : public Sensor {
 
  private:
     /**
-     * @brief Internal reference to the analog voltage reading object
+     * @brief Internal reference to the ADS channel number of the Campbell OBS
+     * 3+
      */
-    AnalogVoltageBase* _analogVoltageReader;
-    /**
-     * @brief Internal flag indicating if this instance owns the voltage reader
-     */
-    bool    _ownsVoltageReader;
+    uint8_t _adsChannel;
     float   _x2_coeff_A;  ///< Internal reference to the x^2 coefficient
     float   _x1_coeff_B;  ///< Internal reference to the x coefficient
     float   _x0_coeff_C;  ///< Internal reference to the x^0 coefficient
+    /**
+     * @brief Internal reference to the I2C address of the TI-ADS1x15
+     */
+    uint8_t _i2cAddress;
 };
 
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -290,6 +290,8 @@ class CampbellOBS3 : public Sensor {
 
     String getSensorLocation(void) override;
 
+    bool setup(void) override;
+
     bool addSingleMeasurementResult(void) override;
 
  private:

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -237,10 +237,11 @@ class CampbellOBS3 : public Sensor {
  public:
     /**
      * @brief Construct a new Campbell OBS3 object - need the power pin, the
-     * analog data channel, and the calibration info.  By default, this
-     * constructor will use a new TIADS1x15Base object with all default values
-     * for voltage readings, but a pointer to a custom AnalogVoltageBase object
-     * can be passed in if desired.
+     * analog data channel, and the calibration info.
+     *
+     * By default, this constructor will use a new TIADS1x15Base object with all
+     * default values for voltage readings, but a pointer to a custom
+     * AnalogVoltageBase object can be passed in if desired.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core.  Connecting the ADS to

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -258,7 +258,7 @@ class CampbellOBS3 : public Sensor {
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
      * internally create and own an analog voltage reader.  For backward
-     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
      */

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -243,19 +243,15 @@ class CampbellOBS3 : public Sensor {
      * default values for voltage readings, but a pointer to a custom
      * AnalogVoltageBase object can be passed in if desired.
      *
-     * @note ModularSensors only supports connecting the ADS1x15 to the primary
-     * hardware I2C instance defined in the Arduino core.  Connecting the ADS to
-     * a secondary hardware or software I2C instance is *not* supported!
-     *
      * @param powerPin The pin on the mcu controlling power to the OBS3+
      * Use -1 if it is continuously powered.
      * - The OBS-3 itself requires a 5-15V power supply, which can be turned off
      * between measurements.
-     * @param analogChannel The analog data channel or processor pin that the
-     * OBS3 is connected to.  The significance of the channel number depends on
-     * the specific AnalogVoltageBase implementation used for voltage readings.
-     * For example, with the TI ADS1x15, this would be the ADC channel (0-3)
-     * that the sensor is connected to.
+     * @param analogChannel The analog data channel or processor pin for voltage
+     * measurements.  The significance of the channel number depends on the
+     * specific AnalogVoltageBase implementation used for voltage readings. For
+     * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
+     * the sensor is connected to.
      * @param x2_coeff_A The x2 (A) coefficient for the calibration _in volts_
      * @param x1_coeff_B The x (B) coefficient for the calibration _in volts_
      * @param x0_coeff_C The x0 (C) coefficient for the calibration _in volts_
@@ -263,8 +259,8 @@ class CampbellOBS3 : public Sensor {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new TIADS1x15Base
-     * object.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a TIADS1x15Base instance.
      */
     CampbellOBS3(int8_t powerPin, uint8_t analogChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,
@@ -274,6 +270,15 @@ class CampbellOBS3 : public Sensor {
      * @brief Destroy the Campbell OBS3 object
      */
     ~CampbellOBS3();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    CampbellOBS3(const CampbellOBS3&)            = delete;
+    CampbellOBS3& operator=(const CampbellOBS3&) = delete;
+
+    // Delete move constructor and move assignment operator
+    CampbellOBS3(CampbellOBS3&&)            = delete;
+    CampbellOBS3& operator=(CampbellOBS3&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -258,9 +258,11 @@ class CampbellOBS3 : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.
+     * internally create and own a TIADS1x15Base instance.  If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      */
-    CampbellOBS3(int8_t powerPin, uint8_t analogChannel, float x2_coeff_A,
+    CampbellOBS3(int8_t powerPin, int8_t analogChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,
                  uint8_t            measurementsToAverage = 1,
                  AnalogVoltageBase* analogVoltageReader   = nullptr);

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -237,9 +237,9 @@ class CampbellOBS3 : public Sensor {
      * @brief Construct a new Campbell OBS3 object - need the power pin, the
      * analog data channel, and the calibration info.
      *
-     * By default, this constructor will use a new TIADS1x15Base object with all
-     * default values for voltage readings, but a pointer to a custom
-     * AnalogVoltageBase object can be passed in if desired.
+     * By default, this constructor will internally create a default
+     * AnalogVoltageBase implementation for voltage readings, but a pointer to
+     * a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @param powerPin The pin on the mcu controlling power to the OBS3+
      * Use -1 if it is continuously powered.
@@ -285,9 +285,9 @@ class CampbellOBS3 : public Sensor {
     bool addSingleMeasurementResult(void) override;
 
  private:
-    float _x2_coeff_A;  ///< Internal reference to the x^2 coefficient
-    float _x1_coeff_B;  ///< Internal reference to the x coefficient
-    float _x0_coeff_C;  ///< Internal reference to the x^0 coefficient
+    float _x2_coeff_A;  ///< The x^2 (A) calibration coefficient
+    float _x1_coeff_B;  ///< The x^1 (B) calibration coefficient
+    float _x0_coeff_C;  ///< The x^0 (C) calibration coefficient
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -289,10 +289,10 @@ class CampbellOBS3 : public Sensor {
     float _x1_coeff_B;  ///< Internal reference to the x coefficient
     float _x0_coeff_C;  ///< Internal reference to the x^0 coefficient
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -246,9 +246,9 @@ class CampbellOBS3 : public Sensor {
      * @param analogChannel The analog data channel or processor pin for voltage
      * measurements.  The significance of the channel number depends on the
      * specific AnalogVoltageBase implementation used for voltage readings. For
-     * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
-     * the sensor is connected to.  Negative or invalid channel numbers are not
-     * clamped and will cause the reading to fail and emit a warning.
+     * example, with the default TI ADS1x15, this would be the ADC channel (0-3)
+     * that the sensor is connected to.  Negative or invalid channel numbers are
+     * not clamped and will cause the reading to fail and emit a warning.
      * @param x2_coeff_A The x2 (A) coefficient for the calibration _in volts_
      * @param x1_coeff_B The x (B) coefficient for the calibration _in volts_
      * @param x0_coeff_C The x0 (C) coefficient for the calibration _in volts_

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -48,10 +48,6 @@
  * for the calibrated turbidity.  To get both high and low range values, create
  * two sensor objects!
  *
- * @section sensor_obs3_flags Build flags
- * - ```-D MS_USE_ADS1015```
- *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
- *
  * @section sensor_obs3_ctor Sensor Constructor
  * {{ @ref CampbellOBS3::CampbellOBS3 }}
  *

--- a/src/sensors/CampbellOBS3.h
+++ b/src/sensors/CampbellOBS3.h
@@ -89,6 +89,7 @@
 #include "VariableBase.h"
 #include "SensorBase.h"
 #include "AnalogVoltageBase.h"
+#include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_obs3 */
 /**@{*/
@@ -111,16 +112,6 @@
 /// @brief Sensor::_incCalcValues; turbidity is calculated from raw voltage
 /// using the input calibration equation.
 #define OBS3_INC_CALC_VARIABLES 1
-/**@}*/
-
-/**
- * @anchor sensor_obs3_config
- * @name Configuration Defines
- * Defines to set the address of the ADD.
- */
-/**@{*/
-/// @brief The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
 /**@}*/
 
 /**
@@ -294,7 +285,7 @@ class CampbellOBS3 : public Sensor {
      */
     CampbellOBS3(int8_t powerPin, uint8_t adsChannel, float x2_coeff_A,
                  float x1_coeff_B, float x0_coeff_C,
-                 uint8_t i2cAddress      = ADS1115_ADDRESS,
+                 uint8_t i2cAddress      = MS_DEFAULT_ADS1X15_ADDRESS,
                  float voltageMultiplier = 1.0, adsGain_t adsGain = GAIN_ONE,
                  uint8_t measurementsToAverage = 1,
                  float   adsSupplyVoltage      = 3.3);

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -22,16 +22,11 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
              measurementsToAverage, ALSPT19_INC_CALC_VARIABLES),
       _alsSupplyVoltage((alsSupplyVoltage > 0.0f) ? alsSupplyVoltage
                                                   : OPERATING_VOLTAGE),
-      _loadResistor(loadResistor) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _loadResistor(loadResistor),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new ProcessorAnalogBase()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 #if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
      defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
      defined(BUILT_IN_ALS_LOADING_RESISTANCE)) ||                         \
@@ -44,16 +39,10 @@ EverlightALSPT19::EverlightALSPT19(uint8_t            measurementsToAverage,
              BUILT_IN_ALS_DATA_PIN, measurementsToAverage,
              ALSPT19_INC_CALC_VARIABLES),
       _alsSupplyVoltage(BUILT_IN_ALS_SUPPLY_VOLTAGE),
-      _loadResistor(BUILT_IN_ALS_LOADING_RESISTANCE) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _loadResistor(BUILT_IN_ALS_LOADING_RESISTANCE),
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new ProcessorAnalogBase()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 #endif
 
 // Destructor

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -111,7 +111,7 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
 
         // convert current to illuminance
         // from sensor datasheet, typical 200µA current for 1000 Lux
-        float calibResult = current_val * (1000.0f / ALSPT19_CURRENT_PER_LUX);
+        float calibResult = current_val * (1000.0f / ALSPT19_UA_PER_1000LUX);
         MS_DBG(F("  Illuminance:"), calibResult, F("lux"));
 
         verifyAndAddMeasurementResult(ALSPT19_CURRENT_VAR_NUM, current_val);

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -105,9 +105,8 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
             MS_DBG(getSensorNameAndLocation(),
                    F("Light sensor has reached saturation!  Clamping current "
                      "and illumination values!"));
-            adcVoltage = _alsSupplyVoltage - 0.4f;
+            adcVoltage = max(0.0f, _alsSupplyVoltage - 0.4f);
         }
-
         // convert volts to current
         // resistance is entered in kΩ and we want µA
         float current_val = (adcVoltage / (_loadResistor * 1000.0f)) * 1e6f;

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -9,30 +9,74 @@
  */
 
 #include "EverlightALSPT19.h"
+#include "ProcessorAnalog.h"
 
 
 EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
                                    float supplyVoltage, float loadResistor,
-                                   uint8_t measurementsToAverage)
+                                   uint8_t            measurementsToAverage,
+                                   AnalogVoltageBase* analogVoltageReader)
     : Sensor("Everlight ALS-PT19", ALSPT19_NUM_VARIABLES,
              ALSPT19_WARM_UP_TIME_MS, ALSPT19_STABILIZATION_TIME_MS,
              ALSPT19_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, ALSPT19_INC_CALC_VARIABLES),
       _supplyVoltage(supplyVoltage),
-      _loadResistor(loadResistor) {}
-#if defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
-    defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
-    defined(BUILT_IN_ALS_LOADING_RESISTANCE)
-EverlightALSPT19::EverlightALSPT19(uint8_t measurementsToAverage)
+      _loadResistor(loadResistor) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new ProcessorAnalogBase();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
+#if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
+     defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
+     defined(BUILT_IN_ALS_LOADING_RESISTANCE)) ||                         \
+    defined(DOXYGEN)
+EverlightALSPT19::EverlightALSPT19(uint8_t            measurementsToAverage,
+                                   AnalogVoltageBase* analogVoltageReader)
     : Sensor("Everlight ALS-PT19", ALSPT19_NUM_VARIABLES,
              ALSPT19_WARM_UP_TIME_MS, ALSPT19_STABILIZATION_TIME_MS,
              ALSPT19_MEASUREMENT_TIME_MS, BUILT_IN_ALS_POWER_PIN,
              BUILT_IN_ALS_DATA_PIN, measurementsToAverage,
              ALSPT19_INC_CALC_VARIABLES),
       _supplyVoltage(BUILT_IN_ALS_SUPPLY_VOLTAGE),
-      _loadResistor(BUILT_IN_ALS_LOADING_RESISTANCE) {}
+      _loadResistor(BUILT_IN_ALS_LOADING_RESISTANCE) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new ProcessorAnalogBase();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 #endif
-EverlightALSPT19::~EverlightALSPT19() {}
+
+// Destructor
+EverlightALSPT19::~EverlightALSPT19() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
+
+
+String EverlightALSPT19::getSensorLocation(void) {
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
+}
 
 
 bool EverlightALSPT19::addSingleMeasurementResult(void) {
@@ -41,45 +85,38 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    float volt_val    = -9999;
-    float current_val = -9999;
-    float lux_val     = -9999;
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    bool  success    = false;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // First measure the analog voltage.
-    // The return value from analogRead() is IN BITS NOT IN VOLTS!!
-    // Take a priming reading.
-    // First reading will be low - discard
-    analogRead(_dataPin);
-    // Take the reading we'll keep
-    uint32_t sensor_adc = analogRead(_dataPin);
-    MS_DEEP_DBG("  ADC Bits:", sensor_adc);
+    // Read the analog voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                           adcVoltage);
 
-    if (sensor_adc == 0) {
-        volt_val    = 0.0;
-        current_val = 0.0;
-        lux_val     = 0.0;
-    } else {
-        // convert bits to volts
-        volt_val = (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX)) *
-            static_cast<float>(sensor_adc);
+    if (success) {
         // convert volts to current
         // resistance is entered in kΩ and we want µA
-        current_val = (volt_val / (_loadResistor * 1000)) * 1e6;
+        float current_val = (adcVoltage / (_loadResistor * 1000)) * 1e6;
+        MS_DBG(F("  Current:"), current_val, F("µA"));
+
         // convert current to illuminance
         // from sensor datasheet, typical 200µA current for 1000 Lux
-        lux_val = current_val * (1000. / 200.);
+        float calibResult = current_val * (1000. / 200.);
+        MS_DBG(F("  Illuminance:"), calibResult, F("lux"));
+
+        verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, adcVoltage);
+        verifyAndAddMeasurementResult(ALSPT19_CURRENT_VAR_NUM, current_val);
+        verifyAndAddMeasurementResult(ALSPT19_ILLUMINANCE_VAR_NUM, calibResult);
+    } else {
+        MS_DBG(F("  Failed to get valid voltage from analog reader"));
     }
-
-    MS_DBG(F("  Voltage:"), volt_val, F("V"));
-    MS_DBG(F("  Current:"), current_val, F("µA"));
-    MS_DBG(F("  Illuminance:"), lux_val, F("lux"));
-
-    // NOTE: We don't actually have any criteria for if the reading was any
-    // good or not, so we mark it as successful no matter what.
-    verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, volt_val);
-    verifyAndAddMeasurementResult(ALSPT19_CURRENT_VAR_NUM, current_val);
-    verifyAndAddMeasurementResult(ALSPT19_ILLUMINANCE_VAR_NUM, lux_val);
-    return bumpMeasurementAttemptCount(true);
+    return bumpMeasurementAttemptCount(success);
 }

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -50,7 +50,7 @@ EverlightALSPT19::~EverlightALSPT19() {
 
 String EverlightALSPT19::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getAnalogLocation(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
         return String("Unknown_AnalogVoltageReader");
     }

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -66,16 +66,11 @@ EverlightALSPT19::~EverlightALSPT19() {
 
 
 String EverlightALSPT19::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_");
+    sensorLocation += String(_dataPin);
+    return sensorLocation;
 }
 
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -22,11 +22,15 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
              measurementsToAverage, ALSPT19_INC_CALC_VARIABLES),
       _alsSupplyVoltage((alsSupplyVoltage > 0.0f) ? alsSupplyVoltage
                                                   : OPERATING_VOLTAGE),
-      _loadResistor(loadResistor),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new ProcessorAnalogBase()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _loadResistor(loadResistor) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 #if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
      defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
      defined(BUILT_IN_ALS_LOADING_RESISTANCE)) ||                         \

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -87,6 +87,12 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
+    // Check if we have a valid load resistor
+    if (_loadResistor <= 0) {
+        MS_DBG(getSensorNameAndLocation(), F("Invalid load resistor value"));
+        return bumpMeasurementAttemptCount(false);
+    }
+
     bool  success    = false;
     float adcVoltage = -9999.0f;
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -24,12 +24,8 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
       _loadResistor(loadResistor) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = new ProcessorAnalogBase();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _analogVoltageReader     = new ProcessorAnalogBase();
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;
@@ -51,11 +47,7 @@ EverlightALSPT19::EverlightALSPT19(uint8_t            measurementsToAverage,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new ProcessorAnalogBase();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -92,7 +92,11 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    // Read the analog voltage using the AnalogVoltageBase interface
+    // Read the single-ended analog voltage using the AnalogVoltageBase
+    // interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -22,15 +22,13 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
              measurementsToAverage, ALSPT19_INC_CALC_VARIABLES),
       _alsSupplyVoltage((alsSupplyVoltage > 0.0f) ? alsSupplyVoltage
                                                   : OPERATING_VOLTAGE),
+      // If no analog voltage reader was provided, create a default one
       _loadResistor(loadResistor),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader =
-            createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    }
-}
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new ProcessorAnalogBase()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+
 #if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
      defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
      defined(BUILT_IN_ALS_LOADING_RESISTANCE)) ||                         \
@@ -62,9 +60,9 @@ String EverlightALSPT19::getSensorLocation(void) {
 
 
 bool EverlightALSPT19::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -75,7 +73,7 @@ bool EverlightALSPT19::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -33,16 +33,10 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
     defined(DOXYGEN)
 EverlightALSPT19::EverlightALSPT19(uint8_t            measurementsToAverage,
                                    AnalogVoltageBase* analogVoltageReader)
-    : Sensor("Everlight ALS-PT19", ALSPT19_NUM_VARIABLES,
-             ALSPT19_WARM_UP_TIME_MS, ALSPT19_STABILIZATION_TIME_MS,
-             ALSPT19_MEASUREMENT_TIME_MS, BUILT_IN_ALS_POWER_PIN,
-             BUILT_IN_ALS_DATA_PIN, measurementsToAverage,
-             ALSPT19_INC_CALC_VARIABLES),
-      _alsSupplyVoltage(BUILT_IN_ALS_SUPPLY_VOLTAGE),
-      _loadResistor(BUILT_IN_ALS_LOADING_RESISTANCE),
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new ProcessorAnalogBase()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+    : EverlightALSPT19(BUILT_IN_ALS_POWER_PIN, BUILT_IN_ALS_DATA_PIN,
+                       BUILT_IN_ALS_SUPPLY_VOLTAGE,
+                       BUILT_IN_ALS_LOADING_RESISTANCE, measurementsToAverage,
+                       analogVoltageReader) {}
 #endif
 
 // Destructor
@@ -50,7 +44,6 @@ EverlightALSPT19::~EverlightALSPT19() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 
@@ -122,7 +115,7 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
 
         // convert current to illuminance
         // from sensor datasheet, typical 200µA current for 1000 Lux
-        float calibResult = current_val * (1000. / ALSPT19_CURRENT_PER_LUX);
+        float calibResult = current_val * (1000.0f / ALSPT19_CURRENT_PER_LUX);
         MS_DBG(F("  Illuminance:"), calibResult, F("lux"));
 
         verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, adcVoltage);

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -50,14 +50,9 @@ EverlightALSPT19::~EverlightALSPT19() {
 
 String EverlightALSPT19::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return _analogVoltageReader->getAnalogLocation(_dataPin);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -98,11 +98,11 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
         // - V(out) = I(PH) * R(L)
         // At saturation:
         // - V(out) ＝ Vcc－0.4V
-        if (adcVoltage > _alsSupplyVoltage - 0.4) {
+        if (adcVoltage > _alsSupplyVoltage - 0.4f) {
             MS_DBG(getSensorNameAndLocation(),
                    F("Light sensor has reached saturation!  Clamping current "
                      "and illumination values!"));
-            adcVoltage = _alsSupplyVoltage - 0.4;
+            adcVoltage = _alsSupplyVoltage - 0.4f;
         }
 
         // convert volts to current

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -61,6 +61,25 @@ String EverlightALSPT19::getSensorLocation(void) {
 }
 
 
+bool EverlightALSPT19::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool EverlightALSPT19::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -76,7 +76,6 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -86,8 +85,8 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
     // NOTE: All implementations of the AnalogVoltageBase class validate both
     // the input channel and the resulting voltage, so we can trust that a
     // successful read will give us a valid voltage value to work with.
-    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
-                                                           adcVoltage);
+    bool success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                adcVoltage);
 
     if (success) {
         verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, adcVoltage);
@@ -107,7 +106,7 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
 
         // convert volts to current
         // resistance is entered in kΩ and we want µA
-        float current_val = (adcVoltage / (_loadResistor * 1000)) * 1e6;
+        float current_val = (adcVoltage / (_loadResistor * 1000.0f)) * 1e6f;
         MS_DBG(F("  Current:"), current_val, F("µA"));
 
         // convert current to illuminance

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -55,7 +55,7 @@ String EverlightALSPT19::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
         return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -95,6 +95,8 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
                                                            adcVoltage);
 
     if (success) {
+        verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, adcVoltage);
+
         // From the datasheet:
         // The output voltage V(out) is the product of photocurrent I(PH) and
         // loading resistor R(L):
@@ -118,7 +120,6 @@ bool EverlightALSPT19::addSingleMeasurementResult(void) {
         float calibResult = current_val * (1000.0f / ALSPT19_CURRENT_PER_LUX);
         MS_DBG(F("  Illuminance:"), calibResult, F("lux"));
 
-        verifyAndAddMeasurementResult(ALSPT19_VOLTAGE_VAR_NUM, adcVoltage);
         verifyAndAddMeasurementResult(ALSPT19_CURRENT_VAR_NUM, current_val);
         verifyAndAddMeasurementResult(ALSPT19_ILLUMINANCE_VAR_NUM, calibResult);
     } else {

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -22,13 +22,12 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
              measurementsToAverage, ALSPT19_INC_CALC_VARIABLES),
       _alsSupplyVoltage((alsSupplyVoltage > 0.0f) ? alsSupplyVoltage
                                                   : OPERATING_VOLTAGE),
-      _loadResistor(loadResistor) {
+      _loadResistor(loadResistor),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 #if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -56,11 +56,16 @@ EverlightALSPT19::~EverlightALSPT19() {
 
 
 String EverlightALSPT19::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_");
-    sensorLocation += String(_dataPin);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 

--- a/src/sensors/EverlightALSPT19.cpp
+++ b/src/sensors/EverlightALSPT19.cpp
@@ -24,8 +24,12 @@ EverlightALSPT19::EverlightALSPT19(int8_t powerPin, int8_t dataPin,
       _loadResistor(loadResistor) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
+        _analogVoltageReader = new ProcessorAnalogBase();
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;
@@ -47,7 +51,11 @@ EverlightALSPT19::EverlightALSPT19(uint8_t            measurementsToAverage,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new ProcessorAnalogBase();
-        _ownsAnalogVoltageReader = true;
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -253,7 +253,7 @@ class EverlightALSPT19 : public Sensor {
      * - ie, A1.
      * @param alsSupplyVoltage The power supply voltage (in volts) of the
      * ALS-PT19. This does not have to be the same as the board operating
-     * voltage or the supply voltage of the analog AnalogVoltageBase reader.
+     * voltage or the supply voltage of the AnalogVoltageBase reader.
      * This is used to clamp the light values when the sensor is over-saturated.
      * @param loadResistor The size of the loading resistor, in kiloohms (kΩ).
      * @param measurementsToAverage The number of measurements to take and

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -315,9 +315,9 @@ class EverlightALSPT19 : public Sensor {
 
  private:
     /// @brief The PT-19 power supply voltage
-    float _alsSupplyVoltage;
+    float _alsSupplyVoltage = 0.0f;
     /// @brief The loading resistance
-    float _loadResistor;
+    float _loadResistor = 0.0f;
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -28,14 +28,14 @@
  * @section sensor_alspt19_datasheet Sensor Datasheet
  * [Datasheet](https://github.com/EnviroDIY/ModularSensors/wiki/Sensor-Datasheets/Everlight-ALS-PT19.pdf)
  *
- * @section sensor_analog_cond_flags Build flags
+ * @section sensor_alspt19_config_flags Build flags
  * - `-D ALSPT19_CURRENT_PER_LUX=##`
  *      - used to set current equivalent to 1000lux, which is used to calculate
  *        lux from the sensor
  *
  * @section sensor_alspt19_ctor Sensor Constructors
- * {{ @ref EverlightALSPT19::EverlightALSPT19(uint8_t) }}
- * {{ @ref EverlightALSPT19::EverlightALSPT19(int8_t, int8_t, float, float, uint8_t) }}
+ * {{ @ref EverlightALSPT19::EverlightALSPT19(uint8_t, AnalogVoltageBase*) }}
+ * {{ @ref EverlightALSPT19::EverlightALSPT19(int8_t, int8_t, float, float, uint8_t, AnalogVoltageBase*) }}
  *
  * @section sensor_alspt19_examples Example Code
  *
@@ -96,7 +96,7 @@
 /**
  * @anchor sensor_alspt19_config
  * @name Configuration Defines
- * Defines to for the ALS calibration between current and lux.
+ * Define for the ALS calibration between current and lux.
  */
 /**@{*/
 #if !defined(ALSPT19_CURRENT_PER_LUX) || defined(DOXYGEN)

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -219,17 +219,22 @@ class EverlightALSPT19 : public Sensor {
      * as analog pins generally are numbered with an "A" in front of the number
      * - ie, A1.
      * @param supplyVoltage The power supply voltage (in volts) of the ALS-PT19.
+     * This does not have to be the same as the board operating voltage or the
+     * supply voltage of the analog AnalogVoltageBase reader, but it is needed
+     * to calculate the current and illuminance.
      * @param loadResistor The size of the loading resistor, in kilaohms (kΩ).
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 10.
      */
     EverlightALSPT19(int8_t powerPin, int8_t dataPin, float supplyVoltage,
-                     float loadResistor, uint8_t measurementsToAverage = 10);
+                     float loadResistor, uint8_t measurementsToAverage = 10,
+                     AnalogVoltageBase* analogVoltageReader = nullptr);
 
-#if defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
-    defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
-    defined(BUILT_IN_ALS_LOADING_RESISTANCE)
+#if (defined(BUILT_IN_ALS_POWER_PIN) && defined(BUILT_IN_ALS_DATA_PIN) && \
+     defined(BUILT_IN_ALS_SUPPLY_VOLTAGE) &&                              \
+     defined(BUILT_IN_ALS_LOADING_RESISTANCE)) ||                         \
+    defined(DOXYGEN)
     /**
      * @brief Construct a new EverlightALSPT19 object with pins and resistors
      * for boards with a built-in ALS-PT19 configured in KnownProcessors.h.
@@ -242,14 +247,25 @@ class EverlightALSPT19 : public Sensor {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 10.
      */
-    explicit EverlightALSPT19(uint8_t measurementsToAverage = 10);
+    explicit EverlightALSPT19(uint8_t            measurementsToAverage = 10,
+                              AnalogVoltageBase* analogVoltageReader = nullptr);
 #endif
     /**
      * @brief Destroy the EverlightALSPT19 object - no action needed.
      */
     ~EverlightALSPT19();
 
-    bool addSingleMeasurementResult(void) override;
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    EverlightALSPT19(const EverlightALSPT19&)            = delete;
+    EverlightALSPT19& operator=(const EverlightALSPT19&) = delete;
+
+    // Delete move constructor and move assignment operator
+    EverlightALSPT19(EverlightALSPT19&&)            = delete;
+    EverlightALSPT19& operator=(EverlightALSPT19&&) = delete;
+
+    String getSensorLocation(void) override;
+    bool   addSingleMeasurementResult(void) override;
 
  private:
     /**
@@ -260,6 +276,11 @@ class EverlightALSPT19 : public Sensor {
      * @brief The loading resistance
      */
     float _loadResistor;
+    AnalogVoltageBase*
+         _analogVoltageReader;      ///< Pointer to analog voltage reader
+    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
+                                    ///< analog voltage reader and should delete
+                                    ///< it in the destructor
 };
 
 

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -251,7 +251,10 @@ class EverlightALSPT19 : public Sensor {
                               AnalogVoltageBase* analogVoltageReader = nullptr);
 #endif
     /**
-     * @brief Destroy the EverlightALSPT19 object - no action needed.
+     * @brief Destroy the EverlightALSPT19 object.
+     * 
+     * Conditionally deletes the _analogVoltageReader member if the ownership
+     * flag _ownsAnalogVoltageReader is true, otherwise leaves it unmodified.
      */
     ~EverlightALSPT19();
 

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -276,11 +276,11 @@ class EverlightALSPT19 : public Sensor {
      * @brief The loading resistance
      */
     float _loadResistor;
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -261,9 +261,10 @@ class EverlightALSPT19 : public Sensor {
      * default value of 10.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a ProcessorAnalogBase instance. If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses the processor's internal ADC. If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     EverlightALSPT19(int8_t powerPin, int8_t dataPin, float alsSupplyVoltage,
                      float loadResistor, uint8_t measurementsToAverage = 10,
@@ -286,9 +287,10 @@ class EverlightALSPT19 : public Sensor {
      * default value of 10.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a ProcessorAnalogBase instance. If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses the processor's internal ADC. If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     explicit EverlightALSPT19(uint8_t            measurementsToAverage = 10,
                               AnalogVoltageBase* analogVoltageReader = nullptr);

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -116,7 +116,7 @@
  * Lux, which doesn't appear to align with the datasheet.
  */
 #define ALSPT19_UA_PER_1000LUX 200.0f
-#endif  // !defined(ALSPT19_UA_PER_1000LUX) || defined(DOXYGEN)
+#endif
 /**@}*/
 
 /**

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -199,6 +199,8 @@
 #define ALSPT19_ILLUMINANCE_DEFAULT_CODE "ALSPT19Lux"
 /**@}*/
 
+// Forward declaration
+class AnalogVoltageBase;
 
 /* clang-format off */
 /**

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -255,7 +255,7 @@ class EverlightALSPT19 : public Sensor {
      * ALS-PT19. This does not have to be the same as the board operating
      * voltage or the supply voltage of the analog AnalogVoltageBase reader.
      * This is used to clamp the light values when the sensor is over-saturated.
-     * @param loadResistor The size of the loading resistor, in kilaohms (kΩ).
+     * @param loadResistor The size of the loading resistor, in kiloohms (kΩ).
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 10.

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -228,6 +228,11 @@ class EverlightALSPT19 : public Sensor {
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 10.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a ProcessorAnalogBase instance. If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      */
     EverlightALSPT19(int8_t powerPin, int8_t dataPin, float supplyVoltage,
                      float loadResistor, uint8_t measurementsToAverage = 10,
@@ -248,6 +253,11 @@ class EverlightALSPT19 : public Sensor {
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 10.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a ProcessorAnalogBase instance. If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      */
     explicit EverlightALSPT19(uint8_t            measurementsToAverage = 10,
                               AnalogVoltageBase* analogVoltageReader = nullptr);

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -313,7 +313,10 @@ class EverlightALSPT19 : public Sensor {
     EverlightALSPT19& operator=(EverlightALSPT19&&) = delete;
 
     String getSensorLocation(void) override;
-    bool   addSingleMeasurementResult(void) override;
+
+    bool setup(void) override;
+
+    bool addSingleMeasurementResult(void) override;
 
  private:
     /// @brief The PT-19 power supply voltage

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -48,7 +48,7 @@
 #include "ModSensorConfig.h"
 
 // Include the known processors for default values
-#include "sensors/KnownProcessors.h"
+#include "KnownProcessors.h"
 
 // Include the debugging config
 #include "ModSensorDebugConfig.h"

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -29,7 +29,7 @@
  * [Datasheet](https://github.com/EnviroDIY/ModularSensors/wiki/Sensor-Datasheets/Everlight-ALS-PT19.pdf)
  *
  * @section sensor_alspt19_config_flags Build flags
- * - `-D ALSPT19_CURRENT_PER_LUX=##`
+ * - `-D ALSPT19_UA_PER_1000LUX=##`
  *      - used to set current equivalent to 1000lux, which is used to calculate
  *        lux from the sensor
  *
@@ -99,7 +99,7 @@
  * Define for the ALS calibration between current and lux.
  */
 /**@{*/
-#if !defined(ALSPT19_CURRENT_PER_LUX) || defined(DOXYGEN)
+#if !defined(ALSPT19_UA_PER_1000LUX) || defined(DOXYGEN)
 /**
  * @brief The default current (in µA) that is equivalent to 1000 lux of
  * illuminance.
@@ -115,8 +115,8 @@
  * @todo Find the source of the calibration of typical 200µA current for 1000
  * Lux, which doesn't appear to align with the datasheet.
  */
-#define ALSPT19_CURRENT_PER_LUX 200.0f
-#endif  // ALSPT19_CURRENT_PER_LUX
+#define ALSPT19_UA_PER_1000LUX 200.0f
+#endif  // !defined(ALSPT19_UA_PER_1000LUX) || defined(DOXYGEN)
 /**@}*/
 
 /**

--- a/src/sensors/EverlightALSPT19.h
+++ b/src/sensors/EverlightALSPT19.h
@@ -254,7 +254,7 @@ class EverlightALSPT19 : public Sensor {
 #endif
     /**
      * @brief Destroy the EverlightALSPT19 object.
-     * 
+     *
      * Conditionally deletes the _analogVoltageReader member if the ownership
      * flag _ownsAnalogVoltageReader is true, otherwise leaves it unmodified.
      */
@@ -282,10 +282,10 @@ class EverlightALSPT19 : public Sensor {
      */
     float _loadResistor;
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/PaleoTerraRedox.cpp
+++ b/src/sensors/PaleoTerraRedox.cpp
@@ -145,9 +145,10 @@ bool PaleoTerraRedox::addSingleMeasurementResult(void) {
     res = 0;
     // Assemble the 18-bit raw sample from the three bytes
     // Only use the lower 2 bits of res1 (D17 D16), ignore sign-extension bits
-    adcValue = ((res1 & 0x03) << 16)  // extract D17 D16 and shift to position
-        | (res2 << 8)                 // shift res2 up to middle byte
-        | res3;  // res3 is already in the right place as the LSB
+    // Cast to uint32_t to ensure sufficient bit width for left shift operations
+    adcValue = (((uint32_t)(res1 & 0x03)) << 16)  // extract D17 D16 and shift to position
+        | (((uint32_t)res2) << 8)                 // shift res2 up to middle byte
+        | ((uint32_t)res3);  // res3 is already in the right place as the LSB
 
     // Check if this is a negative value (sign bit 17 is set)
     if (res1 & 0x02) {  // Test bit 17

--- a/src/sensors/PaleoTerraRedox.cpp
+++ b/src/sensors/PaleoTerraRedox.cpp
@@ -155,7 +155,7 @@ bool PaleoTerraRedox::addSingleMeasurementResult(void) {
     // Check if this is a negative value (sign bit 17 is set)
     if (res1 & 0x02) {  // Test bit 17
         // Sign-extend the 18-bit value to get correct negative magnitude
-        adcValue |= 0xFF000000;  // Sign extend from bit 17
+        adcValue |= 0xFFFC0000;  // Sign extend from bit 17 (set all bits 18-31)
     }
 
     // convert the raw ADC value to voltage in microvolts (uV)

--- a/src/sensors/PaleoTerraRedox.cpp
+++ b/src/sensors/PaleoTerraRedox.cpp
@@ -146,9 +146,11 @@ bool PaleoTerraRedox::addSingleMeasurementResult(void) {
     // Assemble the 18-bit raw sample from the three bytes
     // Only use the lower 2 bits of res1 (D17 D16), ignore sign-extension bits
     // Cast to uint32_t to ensure sufficient bit width for left shift operations
-    adcValue = (((uint32_t)(res1 & 0x03)) << 16)  // extract D17 D16 and shift to position
-        | (((uint32_t)res2) << 8)                 // shift res2 up to middle byte
-        | ((uint32_t)res3);  // res3 is already in the right place as the LSB
+    adcValue = static_cast<int32_t>(
+        (((uint32_t)(res1 & 0x03))
+         << 16)                    // extract D17 D16 and shift to position
+        | (((uint32_t)res2) << 8)  // shift res2 up to middle byte
+        | ((uint32_t)res3));  // res3 is already in the right place as the LSB
 
     // Check if this is a negative value (sign bit 17 is set)
     if (res1 & 0x02) {  // Test bit 17

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -94,13 +94,13 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
              PROCESSOR_ANALOG_WARM_UP_TIME_MS,
              PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
              PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
-             measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES) {
+             measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog base provided, create one with default settings
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
+        _analogVoltageReader =
+            createProcessorAnalogBase(_ownsAnalogVoltageReader);
     }
 }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -52,7 +52,7 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
 
 String ProcessorAnalogBase::getSensorLocation(void) {
     String sensorLocation = F("ProcessorAnalog_Pin");
-    sensorLocation += String(_analogChannel);
+    sensorLocation += String((int)_analogChannel);
     return sensorLocation;
 }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -133,14 +133,11 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
              PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
              PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog base provided, create one with default settings
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader =
-            createProcessorAnalogBase(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog base provided, create one with default settings
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new ProcessorAnalogBase()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 ProcessorAnalog::~ProcessorAnalog() {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -95,7 +95,7 @@ float ProcessorAnalogBase::calculateAnalogResolutionVolts(void) {
     // (single-ended measurements from 0V to supply voltage)
     float fullScaleRangeVolts = _supplyVoltage;
 
-    if (resolutionBits == 0 || resolutionBits > 32 ||
+    if (resolutionBits == 0 || resolutionBits >= 32 ||
         fullScaleRangeVolts <= 0.0f) {
         MS_DBG(F("Invalid ADC configuration - bits: "), resolutionBits,
                F(", supply voltage: "), fullScaleRangeVolts, F("V"));

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -68,7 +68,7 @@ bool ProcessorAnalogBase::readVoltageDifferential(
     int8_t /*analogChannel*/, int8_t /*analogReferenceChannel*/,
     float& resultValue) {
     // ProcessorAnalog does not support differential measurements
-    resultValue = -9999.0;
+    resultValue = -9999.0f;
     return false;
 }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -33,10 +33,11 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
                   "MS_PROCESSOR_ADC_RESOLUTION configuration.");
 
     // Validate parameters
-    if (analogChannel < 0 || analogChannel > 100 || _supplyVoltage <= 0 ||
-        _voltageMultiplier <= 0) {
-        MS_DBG(F("Invalid configuration: analog channel (must be 0-100), "
-                 "supply voltage, "
+    if (analogChannel < 0 || analogChannel > PROCESSOR_ANALOG_MAX_CHANNEL ||
+        _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
+        MS_DBG(F("Invalid configuration: analog channel (must be 0-"),
+               PROCESSOR_ANALOG_MAX_CHANNEL,
+               F("), supply voltage, "
                  "or voltage multiplier is not set!"));
         resultValue = -9999.0f;
         return false;
@@ -48,7 +49,8 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
     analogRead(analogChannel);  // priming reading
     // The return value from analogRead() is IN BITS NOT IN VOLTS!!
     analogRead(analogChannel);  // another priming reading
-    float rawAnalog = analogRead(analogChannel);
+    int   rawAdc    = analogRead(analogChannel);
+    float rawAnalog = static_cast<float>(rawAdc);
     MS_DBG(F("Raw analog pin reading in bits:"), rawAnalog);
 
     // convert bits to volts

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -102,7 +102,7 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
 ProcessorAnalog::~ProcessorAnalog() {}
 
 String ProcessorAnalog::getSensorLocation() {
-    return ProcessorAnalogBase::getAnalogLocation(_dataPin);
+    return ProcessorAnalogBase::getAnalogLocation(_dataPin, -1);
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -97,7 +97,10 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
 ProcessorAnalog::~ProcessorAnalog() {}
 
 String ProcessorAnalog::getSensorLocation() {
-    return ProcessorAnalogBase::getSensorLocation();
+    String sensorLocation = ProcessorAnalogBase::getSensorLocation();
+    sensorLocation += F("_Pin");
+    sensorLocation += String(_dataPin);
+    return sensorLocation;
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -34,8 +34,8 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
         return false;
     }
     if (analogChannel < 0 || _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
-        MS_DBG(F("Missing one or more required parameters: analog pin, "
-                 "operating voltage, or voltage divider!"));
+        MS_DBG(F("Invalid configuration: analog channel, supply voltage, "
+                 "or voltage multiplier is not set!"));
         resultValue = -9999.0f;
         return false;
     }

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -33,7 +33,7 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
                   "MS_PROCESSOR_ADC_RESOLUTION configuration.");
 
     // Validate parameters
-    if (analogChannel < 0 || analogChannel > PROCESSOR_ANALOG_MAX_CHANNEL ||
+    if (analogChannel < 0 || analogChannel > MS_PROCESSOR_ANALOG_MAX_CHANNEL ||
         _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
         MS_DBG(F("Invalid configuration: either the analog channel, the supply "
                  "voltage, or the voltage multiplier is not set correctly!"));
@@ -117,13 +117,20 @@ String ProcessorAnalog::getSensorLocation() {
     if (_analogVoltageReader != nullptr) {
         return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -30,11 +30,13 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
     // Validate parameters
     if (PROCESSOR_ADC_MAX <= 0) {
         MS_DBG(F("Processor ADC max value is not set or invalid!"));
+        resultValue = -9999.0f;
         return false;
     }
     if (analogChannel < 0 || _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
         MS_DBG(F("Missing one or more required parameters: analog pin, "
                  "operating voltage, or voltage divider!"));
+        resultValue = -9999.0f;
         return false;
     }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -62,8 +62,9 @@ String ProcessorAnalogBase::getSensorLocation(void) {
     return sensorLocation;
 }
 
-bool ProcessorAnalogBase::readVoltageDifferential(int8_t, int8_t,
-                                                  float& resultValue) {
+bool ProcessorAnalogBase::readVoltageDifferential(
+    int8_t /*analogChannel*/, int8_t /*analogReferenceChannel*/,
+    float& resultValue) {
     // ProcessorAnalog does not support differential measurements
     resultValue = -9999.0;
     return false;

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -35,10 +35,8 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
     // Validate parameters
     if (analogChannel < 0 || analogChannel > PROCESSOR_ANALOG_MAX_CHANNEL ||
         _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
-        MS_DBG(F("Invalid configuration: analog channel (must be 0-"),
-               PROCESSOR_ANALOG_MAX_CHANNEL,
-               F("), supply voltage, "
-                 "or voltage multiplier is not set!"));
+        MS_DBG(F("Invalid configuration: either the analog channel, the supply "
+                 "voltage, or the voltage multiplier is not set correctly!"));
         resultValue = -9999.0f;
         return false;
     }
@@ -69,8 +67,7 @@ String
 ProcessorAnalogBase::getAnalogLocation(int8_t analogChannel,
                                        int8_t /*analogReferenceChannel*/) {
     String sensorLocation;
-    sensorLocation += F("ProcessorAnalog");
-    sensorLocation += F("_Pin");
+    sensorLocation += F("ProcessorAnalog_Pin");
     sensorLocation += String(analogChannel);
     return sensorLocation;
 }
@@ -79,6 +76,7 @@ bool ProcessorAnalogBase::readVoltageDifferential(
     int8_t /*analogChannel*/, int8_t /*analogReferenceChannel*/,
     float& resultValue) {
     // ProcessorAnalog does not support differential measurements
+    MS_DBG(F("ProcessorAnalog does not support differential measurements"));
     resultValue = -9999.0f;
     return false;
 }

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -65,3 +65,11 @@ bool ProcessorAnalog::addSingleMeasurementResult(void) {
     verifyAndAddMeasurementResult(PROCESSOR_ANALOG_VAR_NUM, sensorValue_analog);
     return bumpMeasurementAttemptCount(true);
 }
+
+void ProcessorAnalog::setVoltageMultiplier(float voltageMultiplier) {
+    _voltageMultiplier = voltageMultiplier;
+}
+
+float ProcessorAnalog::getVoltageMultiplier(void) {
+    return _voltageMultiplier;
+}

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -63,6 +63,12 @@ String ProcessorAnalogBase::getSensorLocation(void) {
     return sensorLocation;
 }
 
+bool ProcessorAnalogBase::readVoltageDifferential(float& resultValue) {
+    // ProcessorAnalog does not support differential measurements
+    resultValue = -9999.0;
+    return false;
+}
+
 // ============================================================================
 // ProcessorAnalog Functions
 // ============================================================================

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -25,6 +25,12 @@ ProcessorAnalogBase::ProcessorAnalogBase(float voltageMultiplier,
 // ProcessorAnalogBase Functions
 // ============================================================================
 
+bool ProcessorAnalogBase::begin(void) {
+    // For processor analog systems, no special initialization is required
+    // beyond what is done in the constructor
+    return true;
+}
+
 bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
                                                  float& resultValue) {
     // Compile-time validation of ADC configuration

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -89,33 +89,32 @@ bool ProcessorAnalogBase::readVoltageDifferential(
 // value, and the operating voltage
 ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
                                  uint8_t              measurementsToAverage,
-                                 ProcessorAnalogBase* analogBase)
+                                 ProcessorAnalogBase* analogVoltageReader)
     : Sensor("ProcessorAnalog", PROCESSOR_ANALOG_NUM_VARIABLES,
              PROCESSOR_ANALOG_WARM_UP_TIME_MS,
              PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
              PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES) {
     // If no analog base provided, create one with default settings
-    if (analogBase == nullptr) {
-        _analogBase     = new ProcessorAnalogBase();
-        _ownsAnalogBase = true;
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createProcessorAnalogBase(_ownsAnalogVoltageReader);
     } else {
-        _analogBase     = analogBase;
-        _ownsAnalogBase = false;
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
     }
 }
 
 // Destructor
 ProcessorAnalog::~ProcessorAnalog() {
     // Clean up the analog base object if we created it
-    if (_ownsAnalogBase && _analogBase != nullptr) {
-        delete _analogBase;
-        _analogBase = nullptr;
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
     }
 }
 
 String ProcessorAnalog::getSensorLocation() {
-    return _analogBase->getAnalogLocation(_dataPin, -1);
+    return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {
@@ -127,7 +126,8 @@ bool ProcessorAnalog::addSingleMeasurementResult(void) {
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     float resultValue = -9999.0f;
-    bool  success = _analogBase->readVoltageSingleEnded(_dataPin, resultValue);
+    bool  success     = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                     resultValue);
 
     if (success) {
         verifyAndAddMeasurementResult(PROCESSOR_ANALOG_VAR_NUM, resultValue);

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -50,7 +50,8 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
     MS_DBG(F("Raw analog pin reading in bits:"), rawAnalog);
 
     // convert bits to volts
-    resultValue = (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX)) *
+    // Use (PROCESSOR_ADC_MAX + 1) as divisor for correct 2^n scaling
+    resultValue = (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX + 1)) *
         _voltageMultiplier * rawAnalog;
     MS_DBG(F("Voltage:"), resultValue);
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -13,6 +13,16 @@
 
 
 // ============================================================================
+// ProcessorAnalogBase Constructor
+// ============================================================================
+
+ProcessorAnalogBase::ProcessorAnalogBase(int8_t dataPin,
+                                         float  voltageMultiplier,
+                                         float  operatingVoltage)
+    : AnalogVoltageBase(dataPin, voltageMultiplier, operatingVoltage, -1) {}
+
+
+// ============================================================================
 // ProcessorAnalogBase Functions
 // ============================================================================
 
@@ -38,12 +48,9 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
     MS_DBG(F("Raw analog pin reading in bits:"), rawAnalog);
 
     // convert bits to volts
-    float sensorValue_analog =
-        (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX)) *
+    resultValue = (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX)) *
         _voltageMultiplier * rawAnalog;
-    MS_DBG(F("Voltage:"), sensorValue_analog);
-
-    resultValue = sensorValue_analog;
+    MS_DBG(F("Voltage:"), resultValue);
 
     // NOTE: We don't actually have any criteria for if the reading was any
     // good or not, so we mark it as successful no matter what.
@@ -52,7 +59,7 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
 
 String ProcessorAnalogBase::getSensorLocation(void) {
     String sensorLocation = F("ProcessorAnalog_Pin");
-    sensorLocation += String((int)_analogChannel);
+    sensorLocation += String(static_cast<int>(_analogChannel));
     return sensorLocation;
 }
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -27,14 +27,16 @@ ProcessorAnalogBase::ProcessorAnalogBase(float voltageMultiplier,
 
 bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
                                                  float& resultValue) {
+    // Compile-time validation of ADC configuration
+    static_assert(PROCESSOR_ADC_MAX > 0,
+                  "PROCESSOR_ADC_MAX must be greater than 0. Check "
+                  "MS_PROCESSOR_ADC_RESOLUTION configuration.");
+
     // Validate parameters
-    if (PROCESSOR_ADC_MAX <= 0) {
-        MS_DBG(F("Processor ADC max value is not set or invalid!"));
-        resultValue = -9999.0f;
-        return false;
-    }
-    if (analogChannel < 0 || _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
-        MS_DBG(F("Invalid configuration: analog channel, supply voltage, "
+    if (analogChannel < 0 || analogChannel > 100 || _supplyVoltage <= 0 ||
+        _voltageMultiplier <= 0) {
+        MS_DBG(F("Invalid configuration: analog channel (must be 0-100), "
+                 "supply voltage, "
                  "or voltage multiplier is not set!"));
         resultValue = -9999.0f;
         return false;
@@ -51,7 +53,8 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
 
     // convert bits to volts
     // Use (PROCESSOR_ADC_MAX + 1) as divisor for correct 2^n scaling
-    resultValue = (_supplyVoltage / static_cast<float>(PROCESSOR_ADC_MAX + 1)) *
+    resultValue =
+        (_supplyVoltage / (static_cast<float>(PROCESSOR_ADC_MAX) + 1.0f)) *
         _voltageMultiplier * rawAnalog;
     MS_DBG(F("Voltage:"), resultValue);
 

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -81,6 +81,38 @@ bool ProcessorAnalogBase::readVoltageDifferential(
     return false;
 }
 
+float ProcessorAnalogBase::calculateAnalogResolutionVolts(void) {
+    // Use the configured processor ADC resolution
+    uint8_t resolutionBits = MS_PROCESSOR_ADC_RESOLUTION;
+
+    // For processor ADCs, the full scale range is the supply voltage
+    // (single-ended measurements from 0V to supply voltage)
+    float fullScaleRangeVolts = _supplyVoltage;
+
+    if (resolutionBits == 0 || resolutionBits > 32 ||
+        fullScaleRangeVolts <= 0.0f) {
+        MS_DBG(F("Invalid ADC configuration - bits: "), resolutionBits,
+               F(", supply voltage: "), fullScaleRangeVolts, F("V"));
+        return -9999.0f;
+    }
+
+    // Calculate the total number of ADC codes
+    uint32_t totalCodes = 1UL << resolutionBits;  // 2^resolutionBits
+
+    // Voltage resolution is the full scale range divided by total codes
+    float resolutionVolts = fullScaleRangeVolts /
+        static_cast<float>(totalCodes);
+
+    MS_DBG(F("Processor ADC resolution calculation:"));
+    MS_DBG(F("  ADC resolution: "), resolutionBits, F(" bits"));
+    MS_DBG(F("  Supply voltage: "), fullScaleRangeVolts, F("V"));
+    MS_DBG(F("  Total codes: "), totalCodes);
+    MS_DBG(F("  Voltage resolution: "), resolutionVolts, F("V/LSB"));
+
+    return resolutionVolts;
+}
+
+
 // ============================================================================
 // ProcessorAnalog Functions
 // ============================================================================

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -16,35 +16,35 @@
 // ProcessorAnalogBase Constructor
 // ============================================================================
 
-ProcessorAnalogBase::ProcessorAnalogBase(int8_t dataPin,
-                                         float  voltageMultiplier,
-                                         float  operatingVoltage)
-    : AnalogVoltageBase(dataPin, voltageMultiplier, operatingVoltage, -1) {}
+ProcessorAnalogBase::ProcessorAnalogBase(float voltageMultiplier,
+                                         float operatingVoltage)
+    : AnalogVoltageBase(voltageMultiplier, operatingVoltage) {}
 
 
 // ============================================================================
 // ProcessorAnalogBase Functions
 // ============================================================================
 
-bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
+bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
+                                                 float& resultValue) {
     // Validate parameters
     if (PROCESSOR_ADC_MAX <= 0) {
         MS_DBG(F("Processor ADC max value is not set or invalid!"));
         return false;
     }
-    if (_analogChannel < 0 || _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
+    if (analogChannel < 0 || _supplyVoltage <= 0 || _voltageMultiplier <= 0) {
         MS_DBG(F("Missing one or more required parameters: analog pin, "
                  "operating voltage, or voltage divider!"));
         return false;
     }
 
     // Get the analog voltage
-    MS_DBG(F("Getting analog voltage from pin"), _analogChannel);
-    pinMode(_analogChannel, INPUT);
-    analogRead(_analogChannel);  // priming reading
+    MS_DBG(F("Getting analog voltage from pin"), analogChannel);
+    pinMode(analogChannel, INPUT);
+    analogRead(analogChannel);  // priming reading
     // The return value from analogRead() is IN BITS NOT IN VOLTS!!
-    analogRead(_analogChannel);  // another priming reading
-    float rawAnalog = analogRead(_analogChannel);
+    analogRead(analogChannel);  // another priming reading
+    float rawAnalog = analogRead(analogChannel);
     MS_DBG(F("Raw analog pin reading in bits:"), rawAnalog);
 
     // convert bits to volts
@@ -58,12 +58,12 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
 }
 
 String ProcessorAnalogBase::getSensorLocation(void) {
-    String sensorLocation = F("ProcessorAnalog_Pin");
-    sensorLocation += String(static_cast<int>(_analogChannel));
+    String sensorLocation = F("ProcessorAnalog");
     return sensorLocation;
 }
 
-bool ProcessorAnalogBase::readVoltageDifferential(float& resultValue) {
+bool ProcessorAnalogBase::readVoltageDifferential(int8_t, int8_t,
+                                                  float& resultValue) {
     // ProcessorAnalog does not support differential measurements
     resultValue = -9999.0;
     return false;
@@ -84,7 +84,7 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
              PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
              PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
              measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES),
-      ProcessorAnalogBase(dataPin, voltageMultiplier, operatingVoltage) {}
+      ProcessorAnalogBase(voltageMultiplier, operatingVoltage) {}
 
 // Destructor
 ProcessorAnalog::~ProcessorAnalog() {}
@@ -98,7 +98,7 @@ bool ProcessorAnalog::addSingleMeasurementResult(void) {
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     float resultValue = -9999;
-    bool  success     = readVoltageSingleEnded(resultValue);
+    bool  success     = readVoltageSingleEnded(_dataPin, resultValue);
 
     if (success) {
         verifyAndAddMeasurementResult(PROCESSOR_ANALOG_VAR_NUM, resultValue);

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -92,6 +92,10 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
 // Destructor
 ProcessorAnalog::~ProcessorAnalog() {}
 
+String ProcessorAnalog::getSensorLocation() {
+    return ProcessorAnalogBase::getSensorLocation();
+}
+
 bool ProcessorAnalog::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -114,7 +114,11 @@ ProcessorAnalog::~ProcessorAnalog() {
 }
 
 String ProcessorAnalog::getSensorLocation() {
-    return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
+    } else {
+        return String("Unknown_AnalogVoltageReader");
+    }
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -65,8 +65,13 @@ bool ProcessorAnalogBase::readVoltageSingleEnded(int8_t analogChannel,
     return true;
 }
 
-String ProcessorAnalogBase::getSensorLocation(void) {
-    String sensorLocation = F("ProcessorAnalog");
+String
+ProcessorAnalogBase::getAnalogLocation(int8_t analogChannel,
+                                       int8_t /*analogReferenceChannel*/) {
+    String sensorLocation;
+    sensorLocation += F("ProcessorAnalog");
+    sensorLocation += F("_Pin");
+    sensorLocation += String(analogChannel);
     return sensorLocation;
 }
 
@@ -99,10 +104,7 @@ ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
 ProcessorAnalog::~ProcessorAnalog() {}
 
 String ProcessorAnalog::getSensorLocation() {
-    String sensorLocation = ProcessorAnalogBase::getSensorLocation();
-    sensorLocation += F("_Pin");
-    sensorLocation += String(_dataPin);
-    return sensorLocation;
+    return ProcessorAnalogBase::getAnalogLocation(_dataPin);
 }
 
 bool ProcessorAnalog::addSingleMeasurementResult(void) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -104,7 +104,7 @@ bool ProcessorAnalog::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    float resultValue = -9999;
+    float resultValue = -9999.0f;
     bool  success     = readVoltageSingleEnded(_dataPin, resultValue);
 
     if (success) {

--- a/src/sensors/ProcessorAnalog.cpp
+++ b/src/sensors/ProcessorAnalog.cpp
@@ -12,40 +12,9 @@
 #include "ProcessorAnalog.h"
 
 
-// The constructor - need the power pin, the data pin, the voltage divider
-// value, and the operating voltage
-ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
-                                 float   voltageMultiplier,
-                                 float   operatingVoltage,
-                                 uint8_t measurementsToAverage)
-    : Sensor("ProcessorAnalog", PROCESSOR_ANALOG_NUM_VARIABLES,
-             PROCESSOR_ANALOG_WARM_UP_TIME_MS,
-             PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
-             PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
-             measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES),
-      ProcessorAnalogBase(dataPin, voltageMultiplier, operatingVoltage) {}
-// Destructor
-ProcessorAnalog::~ProcessorAnalog() {}
-
-
-bool ProcessorAnalog::addSingleMeasurementResult(void) {
-    // Immediately quit if the measurement was not successfully started
-    if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {
-        return bumpMeasurementAttemptCount(false);
-    }
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-    float resultValue = -9999;
-    bool  success     = readVoltageSingleEnded(resultValue);
-
-    if (success) {
-        verifyAndAddMeasurementResult(PROCESSOR_ANALOG_VAR_NUM, resultValue);
-    }
-
-    // Return success value when finished
-    return bumpMeasurementAttemptCount(success);
-}
+// ============================================================================
+// ProcessorAnalogBase Functions
+// ============================================================================
 
 bool ProcessorAnalogBase::readVoltageSingleEnded(float& resultValue) {
     // Validate parameters
@@ -85,4 +54,43 @@ String ProcessorAnalogBase::getSensorLocation(void) {
     String sensorLocation = F("ProcessorAnalog_Pin");
     sensorLocation += String(_analogChannel);
     return sensorLocation;
+}
+
+// ============================================================================
+// ProcessorAnalog Functions
+// ============================================================================
+
+// The constructor - need the power pin, the data pin, the voltage divider
+// value, and the operating voltage
+ProcessorAnalog::ProcessorAnalog(int8_t powerPin, int8_t dataPin,
+                                 float   voltageMultiplier,
+                                 float   operatingVoltage,
+                                 uint8_t measurementsToAverage)
+    : Sensor("ProcessorAnalog", PROCESSOR_ANALOG_NUM_VARIABLES,
+             PROCESSOR_ANALOG_WARM_UP_TIME_MS,
+             PROCESSOR_ANALOG_STABILIZATION_TIME_MS,
+             PROCESSOR_ANALOG_MEASUREMENT_TIME_MS, powerPin, dataPin,
+             measurementsToAverage, PROCESSOR_ANALOG_INC_CALC_VARIABLES),
+      ProcessorAnalogBase(dataPin, voltageMultiplier, operatingVoltage) {}
+
+// Destructor
+ProcessorAnalog::~ProcessorAnalog() {}
+
+bool ProcessorAnalog::addSingleMeasurementResult(void) {
+    // Immediately quit if the measurement was not successfully started
+    if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {
+        return bumpMeasurementAttemptCount(false);
+    }
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+    float resultValue = -9999;
+    bool  success     = readVoltageSingleEnded(resultValue);
+
+    if (success) {
+        verifyAndAddMeasurementResult(PROCESSOR_ANALOG_VAR_NUM, resultValue);
+    }
+
+    // Return success value when finished
+    return bumpMeasurementAttemptCount(success);
 }

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -211,11 +211,6 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
                                  int8_t /*analogReferenceChannel*/,
                                  float& resultValue) override;
 
-    /**
-     * @brief Get the sensor location string
-     *
-     * @return A string describing the processor analog pin location
-     */
     String getSensorLocation(void) override;
 };
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -211,7 +211,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
                                  int8_t /*analogReferenceChannel*/,
                                  float& resultValue) override;
 
-    String getSensorLocation(void) override;
+    String getAnalogLocation(int8_t analogChannel,
+                             int8_t analogReferenceChannel = -1) override;
 };
 
 /* clang-format off */

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -238,35 +238,6 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
 
 };
 
-// Inline utility function implementation
-/**
- * @brief Create a ProcessorAnalogBase analog voltage reader with ownership
- * tracking
- *
- * This utility function safely creates a new ProcessorAnalogBase object with
- * default settings and verifies it was created successfully. It handles the
- * pattern of creating default analog voltage readers when none is provided to
- * sensor constructors.
- *
- * @param[out] ownsAnalogVoltageReader Reference to bool that tracks ownership.
- *   Set to true if the reader was created successfully, false if creation
- * failed.
- * @return Pointer to created ProcessorAnalogBase object, or nullptr if creation
- * failed
- *
- * @note This function is designed for use in sensor constructors that need a
- * default analog voltage reader. The ownership flag should be used to determine
- * whether the returned pointer needs to be deleted in the sensor's destructor.
- */
-inline ProcessorAnalogBase*
-createProcessorAnalogBase(bool& ownsAnalogVoltageReader) {
-    ProcessorAnalogBase* reader = new ProcessorAnalogBase();
-    // verify that the voltage reader was created successfully
-    // this could fail silently on no-exceptions Arduino targets
-    ownsAnalogVoltageReader = (reader != nullptr);
-    return reader;
-}
-
 /* clang-format off */
 /**
  * @brief The Sensor sub-class for the

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -186,7 +186,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * @brief Read a single-ended voltage measurement from the processor ADC
      *
      * @param analogChannel The processor ADC pin used to read the target
-     * voltage
+     * voltage.  Negative or invalid channel numbers are not clamped and will
+     * cause the reading to fail and emit a warning.
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful
      */

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -168,17 +168,14 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
     /**
      * @brief Construct a new ProcessorAnalogBase object
      *
-     * @param dataPin The processor ADC pin used to read the target voltage. Not
-     * all processor pins can be used as analog pins.  Those usable as analog
-     * pins generally are numbered with an "A" in front of the number - ie, A1.
      * @param voltageMultiplier Any multiplier needed to convert raw battery
      * readings from `analogRead()` into true battery values based on any
      * resistors or voltage dividers
      * @param operatingVoltage The processor's operating voltage; most
      * likely 3.3 or 5.
      */
-    explicit ProcessorAnalogBase(int8_t dataPin, float voltageMultiplier = 1.0,
-                                 float operatingVoltage = OPERATING_VOLTAGE);
+    explicit ProcessorAnalogBase(float voltageMultiplier = 1.0,
+                                 float operatingVoltage  = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the ProcessorAnalogBase object
@@ -188,10 +185,13 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
     /**
      * @brief Read a single-ended voltage measurement from the processor ADC
      *
+     * @param analogChannel The processor ADC pin used to read the target
+     * voltage
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful
      */
-    bool readVoltageSingleEnded(float& resultValue) override;
+    bool readVoltageSingleEnded(int8_t analogChannel,
+                                float& resultValue) override;
 
     /**
      * @brief Read a differential voltage measurement from the processor ADC
@@ -199,11 +199,16 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * ProcessorAnalog does not support differential measurements, so this
      * always returns false.
      *
+     * @param analogChannel The primary analog channel (ignored)
+     * @param analogReferenceChannel The secondary (reference) analog channel
+     * (ignored)
      * @param resultValue Reference to store the resulting voltage measurement.
      * This will be set to -9999.0 to indicate an invalid reading.
      * @return Always false (differential not supported)
      */
-    bool readVoltageDifferential(float& resultValue) override;
+    bool readVoltageDifferential(int8_t analogChannel,
+                                 int8_t analogReferenceChannel,
+                                 float& resultValue) override;
 
     /**
      * @brief Get the sensor location string

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -212,7 +212,7 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
                                  float& resultValue) override;
 
     String getAnalogLocation(int8_t analogChannel,
-                             int8_t analogReferenceChannel = -1) override;
+                             int8_t analogReferenceChannel) override;
 };
 
 /* clang-format off */

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -194,6 +194,22 @@ class ProcessorAnalog : public Sensor {
 
     bool addSingleMeasurementResult(void) override;
 
+    /**
+     * @brief Set the voltage multiplier for the processor analog sensor
+     *
+     * @param voltageMultiplier Any multiplier needed to convert raw readings
+     * from analogRead() into true voltage values based on any resistors or
+     * voltage dividers
+     */
+    void setVoltageMultiplier(float voltageMultiplier);
+
+    /**
+     * @brief Get the voltage multiplier for the processor analog sensor
+     *
+     * @return The voltage multiplier value
+     */
+    float getVoltageMultiplier(void);
+
  private:
     float _voltageMultiplier;  ///< Internal reference to any multiplier needed
                                ///< to convert raw battery readings into true

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -194,6 +194,17 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
     bool readVoltageSingleEnded(float& resultValue) override;
 
     /**
+     * @brief Read a differential voltage measurement from the processor ADC
+     *
+     * ProcessorAnalog does not support differential measurements, so this
+     * always returns false.
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return Always false (differential not supported)
+     */
+    bool readVoltageDifferential(float& resultValue) override;
+
+    /**
      * @brief Get the sensor location string
      *
      * @return A string describing the processor analog pin location

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -247,16 +247,16 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      */
-    explicit ProcessorAnalog(int8_t powerPin, int8_t dataPin,
-                             float   voltageMultiplier     = 1.0f,
-                             float   operatingVoltage      = OPERATING_VOLTAGE,
-                             uint8_t measurementsToAverage = 1);
+    ProcessorAnalog(int8_t powerPin, int8_t dataPin,
+                    float   voltageMultiplier     = 1.0f,
+                    float   operatingVoltage      = OPERATING_VOLTAGE,
+                    uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the Processor Analog object
      */
     ~ProcessorAnalog();
 
-    String getSensorLocation() override;
+    String getSensorLocation(void) override;
 
     bool addSingleMeasurementResult(void) override;
 };

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -215,6 +215,20 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
                              int8_t analogReferenceChannel) override;
 };
 
+// Inline utility function implementation
+inline ProcessorAnalogBase*
+createProcessorAnalogBase(bool& ownsAnalogVoltageReader) {
+    ProcessorAnalogBase* reader = new ProcessorAnalogBase();
+    // verify that the voltage reader was created successfully
+    // this could fail silently on no-exceptions Arduino targets
+    if (reader != nullptr) {
+        ownsAnalogVoltageReader = true;
+    } else {
+        ownsAnalogVoltageReader = false;
+    }
+    return reader;
+}
+
 /* clang-format off */
 /**
  * @brief The Sensor sub-class for the
@@ -238,13 +252,13 @@ class ProcessorAnalog : public Sensor {
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
-     * @param analogBase Pointer to ProcessorAnalogBase object for analog
-     * functionality. If nullptr (default), creates a new ProcessorAnalogBase
-     * with default settings.
+     * @param analogVoltageReader Pointer to ProcessorAnalogBase object for
+     * analog functionality. If nullptr (default), creates a new
+     * ProcessorAnalogBase with default settings.
      */
     ProcessorAnalog(int8_t powerPin, int8_t dataPin,
                     uint8_t              measurementsToAverage = 1,
-                    ProcessorAnalogBase* analogBase            = nullptr);
+                    ProcessorAnalogBase* analogVoltageReader   = nullptr);
     /**
      * @brief Destroy the Processor Analog object
      */
@@ -259,13 +273,13 @@ class ProcessorAnalog : public Sensor {
      * @brief Pointer to the ProcessorAnalogBase object providing analog
      * functionality
      */
-    ProcessorAnalogBase* _analogBase = nullptr;
+    ProcessorAnalogBase* _analogVoltageReader = nullptr;
 
     /**
-     * @brief Whether this object owns the _analogBase pointer and should delete
-     * it
+     * @brief Whether this object owns the _analogVoltageReader pointer and
+     * should delete it
      */
-    bool _ownsAnalogBase = false;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -61,7 +61,7 @@
 #include "ModSensorDebugConfig.h"
 
 // Include the known processors for default values
-#include "sensors/KnownProcessors.h"
+#include "KnownProcessors.h"
 
 // Define the print label[s] for the debugger
 #ifdef MS_PROCESSOR_ANALOG_DEBUG

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -221,11 +221,7 @@ createProcessorAnalogBase(bool& ownsAnalogVoltageReader) {
     ProcessorAnalogBase* reader = new ProcessorAnalogBase();
     // verify that the voltage reader was created successfully
     // this could fail silently on no-exceptions Arduino targets
-    if (reader != nullptr) {
-        ownsAnalogVoltageReader = true;
-    } else {
-        ownsAnalogVoltageReader = false;
-    }
+    ownsAnalogVoltageReader = (reader != nullptr);
     return reader;
 }
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -177,8 +177,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * @param operatingVoltage The processor's operating voltage; most
      * likely 3.3 or 5.
      */
-    ProcessorAnalogBase(int8_t dataPin, float voltageMultiplier,
-                        float operatingVoltage = OPERATING_VOLTAGE);
+    explicit ProcessorAnalogBase(int8_t dataPin, float voltageMultiplier = 1.0,
+                                 float operatingVoltage = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the ProcessorAnalogBase object
@@ -230,9 +230,10 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      */
-    ProcessorAnalog(int8_t powerPin, int8_t dataPin, float voltageMultiplier,
-                    float   operatingVoltage      = OPERATING_VOLTAGE,
-                    uint8_t measurementsToAverage = 1);
+    explicit ProcessorAnalog(int8_t powerPin, int8_t dataPin,
+                             float   voltageMultiplier     = 1.0,
+                             float   operatingVoltage      = OPERATING_VOLTAGE,
+                             uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the Processor Analog object
      */

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -256,6 +256,8 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
      */
     ~ProcessorAnalog();
 
+    String getSensorLocation() override;
+
     bool addSingleMeasurementResult(void) override;
 };
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -174,8 +174,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * @param operatingVoltage The processor's operating voltage; most
      * likely 3.3 or 5.
      */
-    explicit ProcessorAnalogBase(float voltageMultiplier = 1.0f,
-                                 float operatingVoltage  = OPERATING_VOLTAGE);
+    ProcessorAnalogBase(float voltageMultiplier = 1.0f,
+                        float operatingVoltage  = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the ProcessorAnalogBase object
@@ -207,8 +207,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * This will be set to -9999.0 to indicate an invalid reading.
      * @return Always false (differential not supported)
      */
-    bool readVoltageDifferential(int8_t /*analogChannel*/,
-                                 int8_t /*analogReferenceChannel*/,
+    bool readVoltageDifferential(int8_t analogChannel,
+                                 int8_t analogReferenceChannel,
                                  float& resultValue) override;
 
     String getAnalogLocation(int8_t analogChannel,

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -76,6 +76,7 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
+#include "AnalogVoltageBase.h"
 
 /** @ingroup sensor_processor_analog */
 /**@{*/
@@ -155,6 +156,52 @@
 #endif
 /**@}*/
 
+/**
+ * @brief Processor analog base class that inherits from AnalogVoltageBase
+ *
+ * This class provides processor-specific analog functionality on top of
+ * the generic AnalogVoltageBase class. It handles processor ADC configuration
+ * and maintains the data pin information for analog readings.
+ */
+class ProcessorAnalogBase : public AnalogVoltageBase {
+ public:
+    /**
+     * @brief Construct a new ProcessorAnalogBase object
+     *
+     * @param dataPin The processor ADC pin used to read the target voltage. Not
+     * all processor pins can be used as analog pins.  Those usable as analog
+     * pins generally are numbered with an "A" in front of the number - ie, A1.
+     * @param voltageMultiplier Any multiplier needed to convert raw battery
+     * readings from `analogRead()` into true battery values based on any
+     * resistors or voltage dividers
+     * @param operatingVoltage The processor's operating voltage; most
+     * likely 3.3 or 5.
+     */
+    ProcessorAnalogBase(int8_t dataPin, float voltageMultiplier,
+                        float operatingVoltage = OPERATING_VOLTAGE)
+        : AnalogVoltageBase(dataPin, voltageMultiplier, operatingVoltage, -1) {}
+
+    /**
+     * @brief Destroy the ProcessorAnalogBase object
+     */
+    virtual ~ProcessorAnalogBase() = default;
+
+    /**
+     * @brief Read a single-ended voltage measurement from the processor ADC
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful
+     */
+    bool readVoltageSingleEnded(float& resultValue) override;
+
+    /**
+     * @brief Get the sensor location string
+     *
+     * @return A string describing the processor analog pin location
+     */
+    String getSensorLocation(void) override;
+};
+
 /* clang-format off */
 /**
  * @brief The Sensor sub-class for the
@@ -163,7 +210,7 @@
  * @ingroup sensor_processor_analog
  */
 /* clang-format on */
-class ProcessorAnalog : public Sensor {
+class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
  public:
     /**
      * @brief Construct a new Processor Analog object - need the power pin and
@@ -193,39 +240,6 @@ class ProcessorAnalog : public Sensor {
     ~ProcessorAnalog();
 
     bool addSingleMeasurementResult(void) override;
-
-    /**
-     * @brief Set the voltage multiplier for the processor analog sensor
-     *
-     * @param voltageMultiplier Any multiplier needed to convert raw readings
-     * from analogRead() into true voltage values based on any resistors or
-     * voltage dividers
-     */
-    void setVoltageMultiplier(float voltageMultiplier);
-
-    /**
-     * @brief Get the voltage multiplier for the processor analog sensor
-     *
-     * @return The voltage multiplier value
-     */
-    float getVoltageMultiplier(void);
-
- protected:
-    /**
-     * @brief Read a single-ended voltage measurement from the processor ADC
-     *
-     * @param resultValue Reference to store the resulting voltage measurement
-     * @return True if the voltage reading was successful
-     */
-    virtual bool readVoltageSingleEnded(float& resultValue);
-
- private:
-    float _voltageMultiplier;  ///< Internal reference to any multiplier needed
-                               ///< to convert raw battery readings into true
-                               ///< battery values based on any resistors or
-                               ///< voltage dividers
-    float _operatingVoltage;   ///< Internal reference to processor's operating
-                               ///< voltage
 };
 
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -213,6 +213,19 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
 
     String getAnalogLocation(int8_t analogChannel,
                              int8_t analogReferenceChannel) override;
+
+    /**
+     * @brief Calculate the analog resolution in volts for the processor ADC
+     *
+     * For processor ADCs, this calculates the voltage resolution based on the
+     * configured ADC resolution and supply voltage. The calculation uses:
+     * - ADC resolution in bits: MS_PROCESSOR_ADC_RESOLUTION
+     * - Full scale range: processor supply voltage (single-ended, 0V to Vcc)
+     *
+     * @return The analog resolution in volts per LSB
+     */
+    float calculateAnalogResolutionVolts(void) override;
+
 };
 
 // Inline utility function implementation

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -199,7 +199,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * ProcessorAnalog does not support differential measurements, so this
      * always returns false.
      *
-     * @param resultValue Reference to store the resulting voltage measurement
+     * @param resultValue Reference to store the resulting voltage measurement.
+     * This will be set to -9999.0 to indicate an invalid reading.
      * @return Always false (differential not supported)
      */
     bool readVoltageDifferential(float& resultValue) override;

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -159,9 +159,9 @@
 /**
  * @brief Processor analog base class that inherits from AnalogVoltageBase
  *
- * This class provides processor-specific analog functionality on top of
- * the generic AnalogVoltageBase class. It handles processor ADC configuration
- * and maintains the data pin information for analog readings.
+ * This class provides processor-specific analog functionality on top of the
+ * generic AnalogVoltageBase class. It handles processor ADC configuration and
+ * processor-based analog voltage reads for requested channels.
  */
 class ProcessorAnalogBase : public AnalogVoltageBase {
  public:
@@ -235,7 +235,6 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * @return The analog resolution in volts per LSB
      */
     float calculateAnalogResolutionVolts(void) override;
-
 };
 
 /* clang-format off */

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -216,6 +216,25 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
 };
 
 // Inline utility function implementation
+/**
+ * @brief Create a ProcessorAnalogBase analog voltage reader with ownership
+ * tracking
+ *
+ * This utility function safely creates a new ProcessorAnalogBase object with
+ * default settings and verifies it was created successfully. It handles the
+ * pattern of creating default analog voltage readers when none is provided to
+ * sensor constructors.
+ *
+ * @param[out] ownsAnalogVoltageReader Reference to bool that tracks ownership.
+ *   Set to true if the reader was created successfully, false if creation
+ * failed.
+ * @return Pointer to created ProcessorAnalogBase object, or nullptr if creation
+ * failed
+ *
+ * @note This function is designed for use in sensor constructors that need a
+ * default analog voltage reader. The ownership flag should be used to determine
+ * whether the returned pointer needs to be deleted in the sensor's destructor.
+ */
 inline ProcessorAnalogBase*
 createProcessorAnalogBase(bool& ownsAnalogVoltageReader) {
     ProcessorAnalogBase* reader = new ProcessorAnalogBase();

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -223,7 +223,7 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
  * @ingroup sensor_processor_analog
  */
 /* clang-format on */
-class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
+class ProcessorAnalog : public Sensor {
  public:
     /**
      * @brief Construct a new Processor Analog object - need the power pin and
@@ -235,19 +235,16 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
      * all processor pins can be used as analog pins.  Those usable as analog
      * pins generally are numbered with an "A" in front of the number
      * - ie, A1.
-     * @param voltageMultiplier Any multiplier needed to convert raw battery
-     * readings from `analogRead()` into true battery values based on any
-     * resistors or voltage dividers
-     * @param operatingVoltage The processor's operating voltage; most
-     * likely 3.3 or 5.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
+     * @param analogBase Pointer to ProcessorAnalogBase object for analog
+     * functionality. If nullptr (default), creates a new ProcessorAnalogBase
+     * with default settings.
      */
     ProcessorAnalog(int8_t powerPin, int8_t dataPin,
-                    float   voltageMultiplier     = 1.0f,
-                    float   operatingVoltage      = OPERATING_VOLTAGE,
-                    uint8_t measurementsToAverage = 1);
+                    uint8_t              measurementsToAverage = 1,
+                    ProcessorAnalogBase* analogBase            = nullptr);
     /**
      * @brief Destroy the Processor Analog object
      */
@@ -256,6 +253,19 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
     String getSensorLocation(void) override;
 
     bool addSingleMeasurementResult(void) override;
+
+ private:
+    /**
+     * @brief Pointer to the ProcessorAnalogBase object providing analog
+     * functionality
+     */
+    ProcessorAnalogBase* _analogBase = nullptr;
+
+    /**
+     * @brief Whether this object owns the _analogBase pointer and should delete
+     * it
+     */
+    bool _ownsAnalogBase = false;
 };
 
 

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -210,6 +210,15 @@ class ProcessorAnalog : public Sensor {
      */
     float getVoltageMultiplier(void);
 
+ protected:
+    /**
+     * @brief Read a single-ended voltage measurement from the processor ADC
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful
+     */
+    virtual bool readVoltageSingleEnded(float& resultValue);
+
  private:
     float _voltageMultiplier;  ///< Internal reference to any multiplier needed
                                ///< to convert raw battery readings into true

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -174,7 +174,7 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * @param operatingVoltage The processor's operating voltage; most
      * likely 3.3 or 5.
      */
-    explicit ProcessorAnalogBase(float voltageMultiplier = 1.0,
+    explicit ProcessorAnalogBase(float voltageMultiplier = 1.0f,
                                  float operatingVoltage  = OPERATING_VOLTAGE);
 
     /**
@@ -248,7 +248,7 @@ class ProcessorAnalog : public Sensor, public ProcessorAnalogBase {
      * default value of 1.
      */
     explicit ProcessorAnalog(int8_t powerPin, int8_t dataPin,
-                             float   voltageMultiplier     = 1.0,
+                             float   voltageMultiplier     = 1.0f,
                              float   operatingVoltage      = OPERATING_VOLTAGE,
                              uint8_t measurementsToAverage = 1);
     /**

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -183,6 +183,16 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
     virtual ~ProcessorAnalogBase() = default;
 
     /**
+     * @brief Initialize the processor analog system
+     *
+     * For processor analog systems, no special initialization is required
+     * beyond what is done in the constructor, so this function does nothing.
+     *
+     * @return Always true indicating successful initialization
+     */
+    bool begin(void) override;
+
+    /**
      * @brief Read a single-ended voltage measurement from the processor ADC
      *
      * @param analogChannel The processor ADC pin used to read the target

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -178,8 +178,7 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * likely 3.3 or 5.
      */
     ProcessorAnalogBase(int8_t dataPin, float voltageMultiplier,
-                        float operatingVoltage = OPERATING_VOLTAGE)
-        : AnalogVoltageBase(dataPin, voltageMultiplier, operatingVoltage, -1) {}
+                        float operatingVoltage = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the ProcessorAnalogBase object

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -206,8 +206,8 @@ class ProcessorAnalogBase : public AnalogVoltageBase {
      * This will be set to -9999.0 to indicate an invalid reading.
      * @return Always false (differential not supported)
      */
-    bool readVoltageDifferential(int8_t analogChannel,
-                                 int8_t analogReferenceChannel,
+    bool readVoltageDifferential(int8_t /*analogChannel*/,
+                                 int8_t /*analogReferenceChannel*/,
                                  float& resultValue) override;
 
     /**

--- a/src/sensors/ProcessorAnalog.h
+++ b/src/sensors/ProcessorAnalog.h
@@ -279,6 +279,15 @@ class ProcessorAnalog : public Sensor {
      */
     ~ProcessorAnalog();
 
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    ProcessorAnalog(const ProcessorAnalog&)            = delete;
+    ProcessorAnalog& operator=(const ProcessorAnalog&) = delete;
+
+    // Delete move constructor and move assignment operator
+    ProcessorAnalog(ProcessorAnalog&&)            = delete;
+    ProcessorAnalog& operator=(ProcessorAnalog&&) = delete;
+
     String getSensorLocation(void) override;
 
     bool addSingleMeasurementResult(void) override;

--- a/src/sensors/ProcessorStats.h
+++ b/src/sensors/ProcessorStats.h
@@ -63,7 +63,7 @@
 #include "ModSensorDebugConfig.h"
 
 // Include the known processors for default values
-#include "sensors/KnownProcessors.h"
+#include "KnownProcessors.h"
 
 // Define the print label[s] for the debugger
 #ifdef MS_PROCESSORSTATS_DEBUG

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -250,34 +250,14 @@ adsGain_t TIADS1x15Base::getADSGain(void) const {
 TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
                      float voltageMultiplier, adsGain_t adsGain,
                      uint8_t i2cAddress, uint8_t measurementsToAverage,
-                     float adsSupplyVoltage)
+                     float adsSupplyVoltage, int8_t differentialChannel)
     : Sensor("TIADS1x15", TIADS1X15_NUM_VARIABLES, TIADS1X15_WARM_UP_TIME_MS,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, adsChannel, measurementsToAverage,
              TIADS1X15_INC_CALC_VARIABLES),
       TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage) {
-    // Set for single-ended measurements
-    setDifferentialChannel(-1);
-    // NOTE: We DO NOT validate the channel numbers in this constructor!  We
-    // CANNOT print a warning here about invalid channel because the Serial
-    // object may not be initialized yet, and we don't want to cause a crash.
-    // The readVoltageSingleEnded and readVoltageDifferential functions will
-    // handle validation and return false if the channel configuration is
-    // invalid, but we can't do that here in the constructor
-}
-
-// Constructor for differential measurements
-TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
-                     float voltageMultiplier, adsGain_t adsGain,
-                     uint8_t i2cAddress, uint8_t measurementsToAverage,
-                     float adsSupplyVoltage)
-    : Sensor("TIADS1x15", TIADS1X15_NUM_VARIABLES, TIADS1X15_WARM_UP_TIME_MS,
-             TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
-             powerPin, adsChannel1, measurementsToAverage,
-             TIADS1X15_INC_CALC_VARIABLES),
-      TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage) {
-    // Set for differential measurements
-    setDifferentialChannel(adsChannel2);
+    // Set differential channel configuration
+    setDifferentialChannel(differentialChannel);
     // NOTE: We DO NOT validate the channel numbers and pairings in this
     // constructor!  We CANNOT print a warning here about invalid channel
     // because the Serial object may not be initialized yet, and we don't want

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -16,17 +16,18 @@
 #include <Adafruit_ADS1X15.h>
 
 
-// The constructor - need the power pin the data pin, and gain if non standard
-TIADS1x15::TIADS1x15(int8_t powerPin, uint8_t adsChannel, float gain,
-                     uint8_t i2cAddress, uint8_t measurementsToAverage,
-                     float adsSupplyVoltage_V)
+// The constructor - need the power pin the data pin, and voltage multiplier if
+// non standard
+TIADS1x15::TIADS1x15(int8_t powerPin, uint8_t adsChannel,
+                     float voltageMultiplier, uint8_t i2cAddress,
+                     uint8_t measurementsToAverage, float adsSupplyVoltage)
     : Sensor("TIADS1x15", TIADS1X15_NUM_VARIABLES, TIADS1X15_WARM_UP_TIME_MS,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, -1, measurementsToAverage, TIADS1X15_INC_CALC_VARIABLES),
       _adsChannel(adsChannel),
-      _gain(gain),
+      _voltageMultiplier(voltageMultiplier),
       _i2cAddress(i2cAddress),
-      _adsSupplyVoltage_V(adsSupplyVoltage_V) {}
+      _adsSupplyVoltage(adsSupplyVoltage) {}
 // Destructor
 TIADS1x15::~TIADS1x15() {}
 
@@ -53,13 +54,13 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
     bool    success     = false;
     int16_t adcCounts   = -9999;
     float   adcVoltage  = -9999;
-    float   calibResult = -9999;
+    float   scaledResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
 // Create an auxiliary ADC object
 // We create and set up the ADC object here so that each sensor using
-// the ADC may set the gain appropriately without effecting others.
+// the ADC may set the internal gain appropriately without affecting others.
 #ifndef MS_USE_ADS1015
     Adafruit_ADS1115 ads;  // Use this for the 16-bit version
 #else
@@ -97,20 +98,20 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
     // Valid range is approximately -0.3V to (supply voltage + 0.3V) with
     // absolute maximum of 5.5V per datasheet
     float minValidVoltage = -0.3;
-    float maxValidVoltage = _adsSupplyVoltage_V + 0.3;
+    float maxValidVoltage = _adsSupplyVoltage + 0.3;
     if (maxValidVoltage > 5.5) {
         maxValidVoltage = 5.5;  // Absolute maximum per datasheet
     }
 
-    MS_DBG(F("  ADS supply voltage:"), _adsSupplyVoltage_V, F("V"));
+    MS_DBG(F("  ADS supply voltage:"), _adsSupplyVoltage, F("V"));
     MS_DBG(F("  Valid voltage range:"), minValidVoltage, F("V to"),
            maxValidVoltage, F("V"));
 
     if (adcVoltage < maxValidVoltage && adcVoltage > minValidVoltage) {
-        // Apply the gain calculation, with a default gain of 10 V/V Gain
-        calibResult = adcVoltage * _gain;
-        MS_DBG(F("  calibResult:"), calibResult);
-        verifyAndAddMeasurementResult(TIADS1X15_VAR_NUM, calibResult);
+        // Apply the voltage multiplier scaling, with a default multiplier of 1
+        scaledResult = adcVoltage * _voltageMultiplier;
+        MS_DBG(F("  scaledResult:"), scaledResult);
+        verifyAndAddMeasurementResult(TIADS1X15_VAR_NUM, scaledResult);
         success = true;
     } else {
         MS_DBG(F("  ADC voltage "), adcVoltage, F("V out of valid range"));
@@ -121,10 +122,10 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
 }
 
 // Setter and getter methods for ADS supply voltage
-void TIADS1x15::setADSSupplyVoltage(float adsSupplyVoltage_V) {
-    _adsSupplyVoltage_V = adsSupplyVoltage_V;
+void TIADS1x15::setADSSupplyVoltage(float adsSupplyVoltage) {
+    _adsSupplyVoltage = adsSupplyVoltage;
 }
 
 float TIADS1x15::getADSSupplyVoltage(void) {
-    return _adsSupplyVoltage_V;
+    return _adsSupplyVoltage;
 }

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -56,8 +56,8 @@ TIADS1x15Base::TIADS1x15Base(uint8_t adsChannel1, uint8_t adsChannel2,
     } else if (_supplyVoltage > 5.5f) {
         _supplyVoltage = 5.5f;
     }
-    // NOTE: We DO NOT clamp orvalidate the channel numbers and pairings in this
-    // constructor!  We CANNOT print a warning here about invalid channel
+    // NOTE: We DO NOT clamp or validate the channel numbers and pairings in
+    // this constructor!  We CANNOT print a warning here about invalid channel
     // because the Serial object may not be initialized yet, and we don't want
     // to cause a crash. The readVoltageSingleEnded and readVoltageDifferential
     // functions will handle validation and return false if the channel

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -277,13 +277,12 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, adsChannel, measurementsToAverage,
              TIADS1X15_INC_CALC_VARIABLES),
-      _analogReferenceChannel(analogReferenceChannel) {
+      _analogReferenceChannel(analogReferenceChannel),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 
     // NOTE: We DO NOT validate the channel numbers and pairings in this

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -304,8 +304,12 @@ TIADS1x15::~TIADS1x15() {
 }
 
 String TIADS1x15::getSensorLocation(void) {
-    return _analogVoltageReader->getAnalogLocation(_dataPin,
-                                                   _analogReferenceChannel);
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getAnalogLocation(_dataPin,
+                                                       _analogReferenceChannel);
+    } else {
+        return String("Unknown_AnalogVoltageReader");
+    }
 }
 
 bool TIADS1x15::addSingleMeasurementResult(void) {
@@ -314,10 +318,10 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
     float resultValue = -9999.0f;
     bool  success     = false;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Use differential or single-ended reading based on configuration
     if (_analogVoltageReader->isValidDifferentialPair(
@@ -325,7 +329,7 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
         success = _analogVoltageReader->readVoltageDifferential(
             _dataPin, _analogReferenceChannel, resultValue);
     } else {
-        if (_analogReferenceChannel >= 0 && _analogReferenceChannel <= 3) {
+        if (_analogReferenceChannel >= 0) {
             MS_DBG(F("  Warning: reference channel "), _analogReferenceChannel,
                    F(" set but pair is not a valid differential config;"
                      " falling back to single-ended on channel "),

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -24,7 +24,8 @@ TIADS1x15Base::TIADS1x15Base(float voltageMultiplier, adsGain_t adsGain,
                              uint8_t i2cAddress, float adsSupplyVoltage)
     : AnalogVoltageBase(voltageMultiplier, adsSupplyVoltage),
       _adsGain(adsGain),
-      _i2cAddress(i2cAddress) {
+      _i2cAddress(i2cAddress),
+      _adsDifferentialChannel(-1) {
     // Clamp supply voltage to valid ADS1x15 range: 0.0V to 5.5V per datasheet
     // NOTE: This clamp is intentionally silent — Serial/MS_DBG is NOT safe to
     // call during construction (the Serial object may not be initialized yet on
@@ -254,8 +255,9 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, adsChannel, measurementsToAverage,
              TIADS1X15_INC_CALC_VARIABLES),
-      TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage),
-      _adsDifferentialChannel(-1) {
+      TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage) {
+    // Set for single-ended measurements
+    setDifferentialChannel(-1);
     // NOTE: We DO NOT validate the channel numbers in this constructor!  We
     // CANNOT print a warning here about invalid channel because the Serial
     // object may not be initialized yet, and we don't want to cause a crash.
@@ -273,8 +275,9 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, adsChannel1, measurementsToAverage,
              TIADS1X15_INC_CALC_VARIABLES),
-      TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage),
-      _adsDifferentialChannel(adsChannel2) {
+      TIADS1x15Base(voltageMultiplier, adsGain, i2cAddress, adsSupplyVoltage) {
+    // Set for differential measurements
+    setDifferentialChannel(adsChannel2);
     // NOTE: We DO NOT validate the channel numbers and pairings in this
     // constructor!  We CANNOT print a warning here about invalid channel
     // because the Serial object may not be initialized yet, and we don't want

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -252,6 +252,8 @@ bool TIADS1x15Base::isValidDifferentialPair(int8_t channel1, int8_t channel2) {
 void TIADS1x15Base::setADSGain(adsGain_t adsGain) {
     // Update the per-instance driver with new gain setting
     _ads.setGain(adsGain);
+    // Keep cached value in sync
+    _adsGain = adsGain;
 }
 
 adsGain_t TIADS1x15Base::getADSGain(void) {
@@ -262,6 +264,8 @@ adsGain_t TIADS1x15Base::getADSGain(void) {
 void TIADS1x15Base::setADSDataRate(uint16_t adsDataRate) {
     // Update the per-instance driver with new data rate setting
     _ads.setDataRate(adsDataRate);
+    // Keep cached value in sync
+    _adsDataRate = adsDataRate;
 }
 
 uint16_t TIADS1x15Base::getADSDataRate(void) {

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -327,14 +327,14 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
 // Override setSupplyVoltage in TIADS1x15 to validate range
 void TIADS1x15::setSupplyVoltage(float supplyVoltage) {
     // Validate supply voltage range: 0.0V to 5.5V per datasheet
-    if (supplyVoltage < 0.0) {
+    if (supplyVoltage < 0.0f) {
         MS_DBG(F("ADS supply voltage "), supplyVoltage,
                F("V is below minimum, clamping to 0.0V"));
-        _supplyVoltage = 0.0;
-    } else if (supplyVoltage > 5.5) {
+        _supplyVoltage = 0.0f;
+    } else if (supplyVoltage > 5.5f) {
         MS_DBG(F("ADS supply voltage "), supplyVoltage,
                F("V exceeds maximum, clamping to 5.5V"));
-        _supplyVoltage = 5.5;
+        _supplyVoltage = 5.5f;
     } else {
         _supplyVoltage = supplyVoltage;
     }

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -50,7 +50,7 @@ String TIADS1x15Base::getAnalogLocation(int8_t analogChannel,
     sensorLocation += F("ADS1015_0x");
 #endif
     sensorLocation += String(_i2cAddress, HEX);
-    if (!isValidDifferentialPair(analogChannel, analogReferenceChannel)) {
+    if (isValidDifferentialPair(analogChannel, analogReferenceChannel)) {
         sensorLocation += F("_Diff_");
         sensorLocation += String(analogChannel);
         sensorLocation += F("_");
@@ -313,6 +313,12 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
     if (isValidDifferentialPair(_dataPin, _analogReferenceChannel)) {
         success = readVoltageDifferential(_dataPin, _analogReferenceChannel,
                                           resultValue);
+        if (_analogReferenceChannel >= 0 && _analogReferenceChannel <= 3) {
+            MS_DBG(F("  Warning: reference channel "), _analogReferenceChannel,
+                   F(" set but pair is not a valid differential config;"
+                     " falling back to single-ended on channel "),
+                   _dataPin);
+        }
     } else {
         success = readVoltageSingleEnded(_dataPin, resultValue);
     }

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -338,13 +338,15 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
             _dataPin, _analogReferenceChannel, resultValue);
     } else {
         if (_analogReferenceChannel >= 0) {
-            MS_DBG(F("  Warning: reference channel "), _analogReferenceChannel,
-                   F(" set but pair is not a valid differential config;"
-                     " falling back to single-ended on channel "),
-                   _dataPin);
+            // Differential was requested but pair is invalid - fail the measurement
+            MS_DBG(F("  Error: Invalid differential pair ("), _dataPin, F("-"),
+                   _analogReferenceChannel, F("). Measurement failed."));
+            success = false;
+        } else {
+            // No reference channel specified, use single-ended
+            success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                   resultValue);
         }
-        success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
-                                                               resultValue);
     }
 
     if (success) {

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -301,7 +301,7 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
-    float resultValue = -9999;
+    float resultValue = -9999.0f;
     bool  success     = false;
 
     // Use differential or single-ended reading based on configuration

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -41,13 +41,24 @@ TIADS1x15Base::TIADS1x15Base(float voltageMultiplier, adsGain_t adsGain,
 // TIADS1x15Base Functions
 // ============================================================================
 
-String TIADS1x15Base::getSensorLocation(void) {
+String TIADS1x15Base::getAnalogLocation(int8_t analogChannel,
+                                        int8_t analogReferenceChannel) {
+    String sensorLocation;
 #ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
+    sensorLocation += F("ADS1115_0x");
 #else
-    String sensorLocation = F("ADS1015_0x");
+    sensorLocation += F("ADS1015_0x");
 #endif
     sensorLocation += String(_i2cAddress, HEX);
+    if (!isValidDifferentialPair(analogChannel, analogReferenceChannel)) {
+        sensorLocation += F("_Diff_");
+        sensorLocation += String(analogChannel);
+        sensorLocation += F("_");
+        sensorLocation += String(analogReferenceChannel);
+    } else {
+        sensorLocation += F("_Channel");
+        sensorLocation += String(analogChannel);
+    }
     return sensorLocation;
 }
 
@@ -284,17 +295,7 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
 TIADS1x15::~TIADS1x15() {}
 
 String TIADS1x15::getSensorLocation(void) {
-    String sensorLocation = TIADS1x15Base::getSensorLocation();
-    if (isValidDifferentialPair(_dataPin, _analogReferenceChannel)) {
-        sensorLocation += F("_Diff");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-    } else {
-        sensorLocation += F("_Channel");
-        sensorLocation += String(_dataPin);
-    }
-    return sensorLocation;
+    return TIADS1x15Base::getAnalogLocation(_dataPin, _analogReferenceChannel);
 }
 
 bool TIADS1x15::addSingleMeasurementResult(void) {

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -348,13 +348,11 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
              powerPin, adsChannel, measurementsToAverage,
              TIADS1X15_INC_CALC_VARIABLES),
       _analogReferenceChannel(analogReferenceChannel),
-      _analogVoltageReader(analogVoltageReader),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
       _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-
     // NOTE: We DO NOT validate the channel numbers and pairings in this
     // constructor!  We CANNOT print a warning here about invalid channel
     // because the Serial object may not be initialized yet, and we don't want
@@ -383,9 +381,9 @@ String TIADS1x15::getSensorLocation(void) {
 
 
 bool TIADS1x15::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -396,7 +394,7 @@ bool TIADS1x15::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -313,13 +313,13 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
     if (isValidDifferentialPair(_dataPin, _analogReferenceChannel)) {
         success = readVoltageDifferential(_dataPin, _analogReferenceChannel,
                                           resultValue);
+    } else {
         if (_analogReferenceChannel >= 0 && _analogReferenceChannel <= 3) {
             MS_DBG(F("  Warning: reference channel "), _analogReferenceChannel,
                    F(" set but pair is not a valid differential config;"
                      " falling back to single-ended on channel "),
                    _dataPin);
         }
-    } else {
         success = readVoltageSingleEnded(_dataPin, resultValue);
     }
 

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -262,7 +262,7 @@ TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel,
 }
 
 // Constructor for differential measurements
-TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel1, uint8_t adsChannel2,
+TIADS1x15::TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
                      float voltageMultiplier, adsGain_t adsGain,
                      uint8_t i2cAddress, uint8_t measurementsToAverage,
                      float adsSupplyVoltage)

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -85,7 +85,7 @@ bool TIADS1x15Base::readVoltageSingleEnded(int8_t analogChannel,
 
     // Read Analog to Digital Converter (ADC)
     // Validate ADS1x15 channel range for single-ended measurements
-    if (analogChannel > 3) {
+    if (analogChannel < 0 || analogChannel > 3) {
         MS_DBG(F("  Invalid ADS1x15 channel "), analogChannel,
                F(", valid range is 0-3"));
         return false;

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -212,8 +212,7 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
 }
 
 // Validation function for differential channel pairs
-bool TIADS1x15Base::isValidDifferentialPair(uint8_t channel1,
-                                            uint8_t channel2) {
+bool TIADS1x15Base::isValidDifferentialPair(int8_t channel1, int8_t channel2) {
     // Only canonical ordered pairs are valid (lower channel number first)
     // This ensures consistent polarity: channel1 is positive, channel2 is
     // negative Valid combinations are: 0-1, 0-3, 1-3, or 2-3 (in that order

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -53,8 +53,8 @@ bool TIADS1x15Base::readVoltageSingleEnded(int8_t analogChannel,
                                            float& resultValue) {
     bool    success      = false;
     int16_t adcCounts    = -9999;
-    float   adcVoltage   = -9999;
-    float   scaledResult = -9999;
+    float   adcVoltage   = -9999.0f;
+    float   scaledResult = -9999.0f;
 
 // Create an auxiliary ADC object
 // We create and set up the ADC object here so that each sensor using
@@ -100,10 +100,10 @@ bool TIADS1x15Base::readVoltageSingleEnded(int8_t analogChannel,
     // Verify the range based on the actual power supplied to the ADS.
     // Valid range is approximately -0.3V to (supply voltage + 0.3V) with
     // absolute maximum of 5.5V per datasheet
-    float minValidVoltage = -0.3;
-    float maxValidVoltage = _supplyVoltage + 0.3;
-    if (maxValidVoltage > 5.5) {
-        maxValidVoltage = 5.5;  // Absolute maximum per datasheet
+    float minValidVoltage = -0.3f;
+    float maxValidVoltage = _supplyVoltage + 0.3f;
+    if (maxValidVoltage > 5.5f) {
+        maxValidVoltage = 5.5f;  // Absolute maximum per datasheet
     }
 
     MS_DBG(F("  ADS supply voltage:"), _supplyVoltage, F("V"));
@@ -118,7 +118,7 @@ bool TIADS1x15Base::readVoltageSingleEnded(int8_t analogChannel,
         success     = true;
     } else {
         MS_DBG(F("  ADC voltage "), adcVoltage, F("V out of valid range"));
-        resultValue = -9999;
+        resultValue = -9999.0f;
     }
 
     return success;
@@ -129,8 +129,8 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
                                             float& resultValue) {
     bool    success      = false;
     int16_t adcCounts    = -9999;
-    float   adcVoltage   = -9999;
-    float   scaledResult = -9999;
+    float   adcVoltage   = -9999.0f;
+    float   scaledResult = -9999.0f;
 
 // Create an auxiliary ADC object
 #ifndef MS_USE_ADS1015
@@ -150,8 +150,9 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
 
     // Validate differential channel combination
     if (!isValidDifferentialPair(analogChannel, analogReferenceChannel)) {
-        MS_DBG(F("  Invalid differential channel pair: "), analogChannel,
-               F("-"), analogReferenceChannel);
+        MS_DBG(F("  Unsupported differential channel combination: "),
+               analogChannel, F("-"), analogReferenceChannel);
+        MS_DBG(F("  Use canonical ordered pairs: 0-1, 0-3, 1-3, or 2-3"));
         return false;
     }
 
@@ -167,11 +168,6 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
         adcCounts = ads.readADC_Differential_1_3();
     } else if (analogChannel == 2 && analogReferenceChannel == 3) {
         adcCounts = ads.readADC_Differential_2_3();
-    } else {
-        MS_DBG(F("  Unsupported differential channel combination: "),
-               analogChannel, F("-"), analogReferenceChannel);
-        MS_DBG(F("  Use canonical ordered pairs: 0-1, 0-3, 1-3, or 2-3"));
-        return false;
     }
 
     // Convert counts to voltage
@@ -183,16 +179,16 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
     // Based on gain setting rather than supply voltage
     float fullScaleVoltage;
     switch (_adsGain) {
-        case GAIN_TWOTHIRDS: fullScaleVoltage = 6.144; break;
-        case GAIN_ONE: fullScaleVoltage = 4.096; break;
-        case GAIN_TWO: fullScaleVoltage = 2.048; break;
-        case GAIN_FOUR: fullScaleVoltage = 1.024; break;
-        case GAIN_EIGHT: fullScaleVoltage = 0.512; break;
-        case GAIN_SIXTEEN: fullScaleVoltage = 0.256; break;
+        case GAIN_TWOTHIRDS: fullScaleVoltage = 6.144f; break;
+        case GAIN_ONE: fullScaleVoltage = 4.096f; break;
+        case GAIN_TWO: fullScaleVoltage = 2.048f; break;
+        case GAIN_FOUR: fullScaleVoltage = 1.024f; break;
+        case GAIN_EIGHT: fullScaleVoltage = 0.512f; break;
+        case GAIN_SIXTEEN: fullScaleVoltage = 0.256f; break;
         default:
             MS_DBG(F("  Unknown ADS gain value:"), _adsGain,
                    F(" using conservative 4.096V range"));
-            fullScaleVoltage = 4.096;  // Conservative fallback
+            fullScaleVoltage = 4.096f;  // Conservative fallback
             break;
     }
     float minValidVoltage = -fullScaleVoltage;
@@ -209,7 +205,7 @@ bool TIADS1x15Base::readVoltageDifferential(int8_t analogChannel,
         success     = true;
     } else {
         MS_DBG(F("  Differential voltage out of valid range"));
-        resultValue = -9999;
+        resultValue = -9999.0f;
     }
 
     return success;

--- a/src/sensors/TIADS1x15.cpp
+++ b/src/sensors/TIADS1x15.cpp
@@ -19,13 +19,15 @@
 // The constructor - need the power pin the data pin, and voltage multiplier if
 // non standard
 TIADS1x15::TIADS1x15(int8_t powerPin, uint8_t adsChannel,
-                     float voltageMultiplier, uint8_t i2cAddress,
-                     uint8_t measurementsToAverage, float adsSupplyVoltage)
+                     float voltageMultiplier, adsGain_t adsGain,
+                     uint8_t i2cAddress, uint8_t measurementsToAverage,
+                     float adsSupplyVoltage)
     : Sensor("TIADS1x15", TIADS1X15_NUM_VARIABLES, TIADS1X15_WARM_UP_TIME_MS,
              TIADS1X15_STABILIZATION_TIME_MS, TIADS1X15_MEASUREMENT_TIME_MS,
              powerPin, -1, measurementsToAverage, TIADS1X15_INC_CALC_VARIABLES),
       _adsChannel(adsChannel),
       _voltageMultiplier(voltageMultiplier),
+      _adsGain(adsGain),
       _i2cAddress(i2cAddress),
       _adsSupplyVoltage(adsSupplyVoltage) {}
 // Destructor
@@ -51,9 +53,9 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
+    bool    success      = false;
+    int16_t adcCounts    = -9999;
+    float   adcVoltage   = -9999;
     float   scaledResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -76,8 +78,8 @@ bool TIADS1x15::addSingleMeasurementResult(void) {
     //    - 1600 samples per second (625µs conversion time)
     //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
 
-    // Bump the gain up to 1x = +/- 4.096V range
-    ads.setGain(GAIN_ONE);
+    // Set the internal gain according to user configuration
+    ads.setGain(_adsGain);
     // Begin ADC, returns true if anything was detected at the address
     if (!ads.begin(_i2cAddress)) {
         MS_DBG(F("  ADC initialization failed at 0x"),
@@ -128,4 +130,12 @@ void TIADS1x15::setADSSupplyVoltage(float adsSupplyVoltage) {
 
 float TIADS1x15::getADSSupplyVoltage(void) {
     return _adsSupplyVoltage;
+}
+
+void TIADS1x15::setADSGain(adsGain_t adsGain) {
+    _adsGain = adsGain;
+}
+
+adsGain_t TIADS1x15::getADSGain(void) {
+    return _adsGain;
 }

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -337,6 +337,15 @@ class TIADS1x15 : public Sensor {
      */
     adsGain_t getADSGain(void);
 
+ protected:
+    /**
+     * @brief Read a single-ended voltage measurement from the ADS1x15
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful and within valid range
+     */
+    virtual bool readVoltageSingleEnded(float& resultValue);
+
  private:
     /**
      * @brief Internal reference to the ADS channel number of the device

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -153,7 +153,7 @@
 #include "ModSensorDebugConfig.h"
 
 // Include known processor settings for default operating voltage
-#include "sensors/KnownProcessors.h"
+#include "KnownProcessors.h"
 
 // Define the print label[s] for the debugger
 #ifdef MS_TIADS1X15_DEBUG

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -397,15 +397,11 @@ class TIADS1x15Base : public AnalogVoltageBase {
  * @ingroup sensor_ads1x15
  */
 /* clang-format on */
-class TIADS1x15 : public Sensor, public TIADS1x15Base {
+class TIADS1x15 : public Sensor {
  public:
     /**
      * @brief Construct a new TIADS1x15 object for single-ended or differential
      * voltage measurements
-     *
-     * The voltage multiplier value, I2C address, and number of measurements to
-     * average are optional.  If nothing is given a 1x voltage multiplier is
-     * used.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core. Connecting the ADS to
@@ -416,28 +412,20 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * @param adsChannel The ADS channel of interest (0-3, physical channel
      * only). For differential measurements, this is the first (positive)
      * channel.
-     * @param voltageMultiplier The voltage multiplier, if a voltage divider is
-     * used.
-     * @param adsGain The internal gain setting of the ADS1x15; defaults to
-     * GAIN_ONE for +/- 4.096V range
-     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
-     * = GND)
-     * @param measurementsToAverage The number of measurements to take and
-     * average before giving a "final" result from the sensor; optional with a
-     * default value of 1.
-     * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
-     * volts; defaults to the processor operating voltage from KnownProcessors.h
      * @param analogReferenceChannel The second (reference/negative) ADS channel
      * for differential measurement (0-3, physical channel only). Valid pairs
      * are: 0-1, 0-3, 1-3, or 2-3. Use -1 (default) for single-ended
      * measurements.
+     * @param measurementsToAverage The number of measurements to take and
+     * average before giving a "final" result from the sensor; optional with a
+     * default value of 1.
+     * @param adsBase Pointer to TIADS1x15Base object for ADS functionality.
+     * If nullptr (default), creates a new TIADS1x15Base with default settings.
      */
     TIADS1x15(int8_t powerPin, int8_t adsChannel,
-              float voltageMultiplier = 1.0f, adsGain_t adsGain = GAIN_ONE,
-              uint8_t i2cAddress             = MS_DEFAULT_ADS1X15_ADDRESS,
-              uint8_t measurementsToAverage  = 1,
-              float   adsSupplyVoltage       = OPERATING_VOLTAGE,
-              int8_t  analogReferenceChannel = -1);
+              int8_t         analogReferenceChannel = -1,
+              uint8_t        measurementsToAverage  = 1,
+              TIADS1x15Base* adsBase                = nullptr);
     /**
      * @brief Destroy the External Voltage object
      */
@@ -456,6 +444,16 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * For differential measurements: the second ADS channel (0-3)
      */
     int8_t _analogReferenceChannel = -1;
+
+    /**
+     * @brief Pointer to the TIADS1x15Base object providing ADS functionality
+     */
+    TIADS1x15Base* _adsBase = nullptr;
+
+    /**
+     * @brief Whether this object owns the _adsBase pointer and should delete it
+     */
+    bool _ownsAdsBase = false;
 };
 
 /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -271,7 +271,7 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @param i2cAddress The I2C address of the ADS 1x15
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in volts
      */
-    explicit TIADS1x15Base(float     voltageMultiplier = 1.0,
+    explicit TIADS1x15Base(float     voltageMultiplier = 1.0f,
                            adsGain_t adsGain           = GAIN_ONE,
                            uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
                            float     adsSupplyVoltage = OPERATING_VOLTAGE);

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -465,11 +465,12 @@ class TIADS1x15 : public Sensor {
 
  private:
     /**
-     * @brief Internal reference to the secondary (reference) analog channel for
-     * differential measurements
+     * @brief The second (reference) pin for differential voltage measurements.
      *
      * For single-ended measurements: -1 (not used)
      * For differential measurements: the second ADS channel (0-3)
+     *
+     * @note The primary pin is stored as Sensor::_dataPin.
      */
     int8_t _analogReferenceChannel = -1;
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -146,6 +146,9 @@
 // Include the debugging config
 #include "ModSensorDebugConfig.h"
 
+// Include known processor settings for default operating voltage
+#include "sensors/KnownProcessors.h"
+
 // Define the print label[s] for the debugger
 #ifdef MS_TIADS1X15_DEBUG
 #define MS_DEBUGGING_STD "TIADS1x15"
@@ -287,10 +290,13 @@ class TIADS1x15 : public Sensor {
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
+     * @param adsSupplyVoltage_V The power supply voltage for the ADS1x15 in volts;
+     * defaults to the processor operating voltage from KnownProcessors.h
      */
     TIADS1x15(int8_t powerPin, uint8_t adsChannel, float gain = 1,
               uint8_t i2cAddress            = ADS1115_ADDRESS,
-              uint8_t measurementsToAverage = 1);
+              uint8_t measurementsToAverage = 1,
+              float adsSupplyVoltage_V      = OPERATING_VOLTAGE);
     /**
      * @brief Destroy the External Voltage object
      */
@@ -299,6 +305,20 @@ class TIADS1x15 : public Sensor {
     String getSensorLocation(void) override;
 
     bool addSingleMeasurementResult(void) override;
+
+    /**
+     * @brief Set the power supply voltage for the ADS1x15
+     *
+     * @param adsSupplyVoltage_V The power supply voltage in volts (2.0-5.5V range)
+     */
+    void setADSSupplyVoltage(float adsSupplyVoltage_V);
+
+    /**
+     * @brief Get the power supply voltage for the ADS1x15
+     *
+     * @return The power supply voltage in volts
+     */
+    float getADSSupplyVoltage(void);
 
  private:
     /**
@@ -314,6 +334,10 @@ class TIADS1x15 : public Sensor {
      * @brief Internal reference to the I2C address of the TI-ADS1x15
      */
     uint8_t _i2cAddress;
+    /**
+     * @brief Internal reference to the power supply voltage of the TI-ADS1x15
+     */
+    float _adsSupplyVoltage_V;
 };
 
 /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -351,6 +351,36 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @brief Internal reference to the I2C address of the TI-ADS1x15
      */
     uint8_t _i2cAddress;
+
+    /**
+     * @brief Internal reference to the secondary (reference) analog channel for
+     * differential measurements
+     *
+     * For single-ended measurements: -1 (not used)
+     * For differential measurements: the second ADS channel (0-3)
+     */
+    int8_t _adsDifferentialChannel = -1;
+
+    /**
+     * @brief Helper function to check if this sensor is configured for
+     * differential measurements
+     *
+     * @return True if this sensor uses differential measurements, false for
+     * single-ended
+     */
+    bool isDifferential() const {
+        return _adsDifferentialChannel != -1;
+    }
+
+    /**
+     * @brief Set the differential channel for differential measurements
+     *
+     * @param differentialChannel The secondary (reference) channel for 
+     * differential measurements (0-3), or -1 for single-ended
+     */
+    void setDifferentialChannel(int8_t differentialChannel) {
+        _adsDifferentialChannel = differentialChannel;
+    }
 };
 
 /* clang-format off */
@@ -391,11 +421,11 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
      * volts; defaults to the processor operating voltage from KnownProcessors.h
      */
-    TIADS1x15(int8_t powerPin, int8_t adsChannel, float voltageMultiplier = 1,
-              adsGain_t adsGain               = GAIN_ONE,
-              uint8_t   i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
-              uint8_t   measurementsToAverage = 1,
-              float     adsSupplyVoltage      = OPERATING_VOLTAGE);
+    TIADS1x15(int8_t powerPin, int8_t adsChannel,
+              float voltageMultiplier = 1.0f, adsGain_t adsGain = GAIN_ONE,
+              uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
+              uint8_t measurementsToAverage = 1,
+              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**
      * @brief Construct a new TIADS1x15 object for differential measurements
      *
@@ -439,27 +469,6 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * range)
      */
     void setSupplyVoltage(float supplyVoltage) override;
-
- protected:
-    /**
-     * @brief Internal reference to the secondary (reference) analog channel for
-     * differential measurements
-     *
-     * For single-ended measurements: -1 (not used)
-     * For differential measurements: the second ADS channel (0-3)
-     */
-    int8_t _adsDifferentialChannel = -1;
-
-    /**
-     * @brief Helper function to check if this sensor is configured for
-     * differential measurements
-     *
-     * @return True if this sensor uses differential measurements, false for
-     * single-ended
-     */
-    bool isDifferential() const {
-        return _adsDifferentialChannel != -1;
-    }
 };
 
 /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -286,7 +286,8 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @brief Read a single-ended voltage measurement from the ADS1x15
      *
      * @param analogChannel The ADS channel of interest (0-3, physical channel
-     * only)
+     * only).  Negative or invalid channel numbers are not clamped and will
+     * cause the reading to fail and emit a warning.
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful
      */
@@ -296,10 +297,14 @@ class TIADS1x15Base : public AnalogVoltageBase {
     /**
      * @brief Read a differential voltage measurement from the ADS1x15
      *
-     * @param analogChannel The first ADS channel for differential measurement
-     * (0-3, physical channel only)
-     * @param analogReferenceChannel The second (reference) ADS channel for
-     * differential measurement (0-3, physical channel only)
+     * @param analogChannel The primary analog channel for differential
+     * measurement. Negative or invalid channel numbers or parings between the
+     * analogChannel and analogReferenceChannel are not clamped and will cause
+     * the reading to fail and emit a warning.
+     * @param analogReferenceChannel The secondary (reference) analog channel
+     * for differential measurement. Negative or invalid channel numbers or
+     * parings between the analogChannel and analogReferenceChannel are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param resultValue Reference to store the resulting voltage measurement
      * @return True if the voltage reading was successful and within valid range
      */
@@ -375,7 +380,7 @@ class TIADS1x15Base : public AnalogVoltageBase {
     /**
      * @brief Set the differential channel for differential measurements
      *
-     * @param differentialChannel The secondary (reference) channel for 
+     * @param differentialChannel The secondary (reference) channel for
      * differential measurements (0-3), or -1 for single-ended
      */
     void setDifferentialChannel(int8_t differentialChannel) {

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -59,9 +59,9 @@
  * use the fork instead.
  *
  * @section analog_ads1x15_specs Specifications
- * @note *In all cases, we assume that the ADS1x15 is powered at 3.3V and set the ADC's internal gain to 1x.
+ * @note *In all cases, we assume that the ADS1x15 is powered at 3.3V by default with configurable internal gain settings.
  *
- * This divides the bit resolution over the range of 0-4.096V.
+ * The default gain setting is 1x (GAIN_ONE) which divides the bit resolution over the range of 0-4.096V.
  * - Response time: < 1ms
  * - Resample time: 860 samples per second (~1.2ms)
  * - Range:
@@ -162,6 +162,7 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
+#include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_ads1x15 */
 /**@{*/
@@ -282,6 +283,8 @@ class TIADS1x15 : public Sensor {
      * @param adsChannel The ADS channel of interest (0-3).
      * @param voltageMultiplier The voltage multiplier, if a voltage divider is
      * used.
+     * @param adsGain The internal gain setting of the ADS1x15; defaults to
+     * GAIN_ONE for +/- 4.096V range
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
@@ -291,9 +294,10 @@ class TIADS1x15 : public Sensor {
      * volts; defaults to the processor operating voltage from KnownProcessors.h
      */
     TIADS1x15(int8_t powerPin, uint8_t adsChannel, float voltageMultiplier = 1,
-              uint8_t i2cAddress            = ADS1115_ADDRESS,
-              uint8_t measurementsToAverage = 1,
-              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
+              adsGain_t adsGain               = GAIN_ONE,
+              uint8_t   i2cAddress            = ADS1115_ADDRESS,
+              uint8_t   measurementsToAverage = 1,
+              float     adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**
      * @brief Destroy the External Voltage object
      */
@@ -318,6 +322,21 @@ class TIADS1x15 : public Sensor {
      */
     float getADSSupplyVoltage(void);
 
+    /**
+     * @brief Set the internal gain setting for the ADS1x15
+     *
+     * @param adsGain The internal gain setting (GAIN_TWOTHIRDS, GAIN_ONE,
+     * GAIN_TWO, GAIN_FOUR, GAIN_EIGHT, GAIN_SIXTEEN)
+     */
+    void setADSGain(adsGain_t adsGain);
+
+    /**
+     * @brief Get the internal gain setting for the ADS1x15
+     *
+     * @return The internal gain setting
+     */
+    adsGain_t getADSGain(void);
+
  private:
     /**
      * @brief Internal reference to the ADS channel number of the device
@@ -328,6 +347,10 @@ class TIADS1x15 : public Sensor {
      * @brief Internal reference to the voltage multiplier for the TI-ADS1x15
      */
     float _voltageMultiplier;
+    /**
+     * @brief Internal reference to the internal gain setting of the TI-ADS1x15
+     */
+    adsGain_t _adsGain;
     /**
      * @brief Internal reference to the I2C address of the TI-ADS1x15
      */

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -216,25 +216,20 @@
  * @anchor sensor_ads1x15_volt
  * @name Voltage
  * The volt variable from a TI ADS1x15 analog-to-digital converter (ADC)
- *   - Range:
- *     - without voltage divider:  0 - 3.6V [when ADC is powered at 3.3V]
- *     - 1/gain = 3x: 0.3 ~ 12.9V
- *     - 1/gain = 10x: 1 ~ 43V
+ *   - Range (with no external voltage divider):
+ *     - 0 - min(4.096V, supply voltage + 0.3V) voltage + 0.3V)
  *   - Accuracy:
  *     - 16-bit ADC (ADS1115): < 0.25% (gain error), <0.25 LSB (offset error)
  *     - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): < 0.15%
  * (gain error), <3 LSB (offset error)
- *   - Resolution:
+ *   - Resolution (based on ADC's 4.096V internal reference with 1x gain and no
+ * external voltage divider):
  *     - 16-bit ADC (ADS1115):
  *       - @m_span{m-dim}@ref #TIADS1X15_RESOLUTION = 4@m_endspan
- *       - without voltage divider:  0.125 mV
- *       - 1/gain = 3x: 0.375 mV
- *       - 1/gain = 10x: 1.25 mV
+ *       - 0.125 mV
  *     - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```):
  *       - @m_span{m-dim}@ref #TIADS1X15_RESOLUTION = 1@m_endspan
- *       - without voltage divider:  2 mV
- *       - 1/gain = 3x: 6 mV
- *       - 1/gain = 10x: 20 mV *
+ *       - 2 mV
  *
  * {{ @ref TIADS1x15_Voltage::TIADS1x15_Voltage }}
  */

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -192,12 +192,12 @@
 /**
  * @brief Enum for the pins used for differential voltages.
  */
-typedef enum : uint16_t {
+enum class tiads1x15_adsDiffMux_t : uint16_t {
     TIADS1X15_DIFF_MUX_0_1,  ///< differential across pins 0 and 1
     TIADS1X15_DIFF_MUX_0_3,  ///< differential across pins 0 and 3
     TIADS1X15_DIFF_MUX_1_3,  ///< differential across pins 1 and 3
     TIADS1X15_DIFF_MUX_2_3   ///< differential across pins 2 and 3
-} tiads1x15_adsDiffMux_t;
+};
 
 /**
  * @anchor sensor_ads1x15_timing

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -271,11 +271,18 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @param adsGain The internal gain setting of the ADS1x15
      * @param i2cAddress The I2C address of the ADS 1x15
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in volts
+     * @param adsDataRate The data rate for the ADS1x15 (samples per second)
      */
     explicit TIADS1x15Base(float     voltageMultiplier = 1.0f,
                            adsGain_t adsGain           = GAIN_ONE,
                            uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
-                           float     adsSupplyVoltage = OPERATING_VOLTAGE);
+                           float     adsSupplyVoltage = OPERATING_VOLTAGE,
+#ifndef MS_USE_ADS1015
+                           uint16_t adsDataRate = RATE_ADS1115_128SPS
+#else
+                           uint16_t adsDataRate = RATE_ADS1015_1600SPS
+#endif
+    );
 
     /**
      * @brief Destroy the TIADS1x15Base object
@@ -328,7 +335,21 @@ class TIADS1x15Base : public AnalogVoltageBase {
      *
      * @return The internal gain setting
      */
-    adsGain_t getADSGain(void) const;
+    adsGain_t getADSGain(void);
+
+    /**
+     * @brief Set the data rate for the ADS1x15
+     *
+     * @param adsDataRate The data rate setting (samples per second)
+     */
+    void setADSDataRate(uint16_t adsDataRate);
+
+    /**
+     * @brief Get the data rate for the ADS1x15
+     *
+     * @return The data rate setting (samples per second)
+     */
+    uint16_t getADSDataRate(void);
 
     /**
      * @brief Check if the two channels form a valid differential pair
@@ -355,13 +376,17 @@ class TIADS1x15Base : public AnalogVoltageBase {
 
  protected:
     /**
-     * @brief Internal reference to the internal gain setting of the TI-ADS1x15
-     */
-    adsGain_t _adsGain;
-    /**
      * @brief Internal reference to the I2C address of the TI-ADS1x15
      */
     uint8_t _i2cAddress;
+    /**
+     * @brief Per-instance ADS1x15 driver to maintain separate I2C state
+     */
+#ifndef MS_USE_ADS1015
+    Adafruit_ADS1115 _ads;  // 16-bit version
+#else
+    Adafruit_ADS1015 _ads;  // 12-bit version
+#endif
 };
 
 /* clang-format off */

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -282,60 +282,42 @@ enum class tiads1x15_adsDiffMux_t : uint16_t {
  */
 class TIADS1x15Base : public AnalogVoltageBase {
  public:
-    /**
-     * @brief Check if the two channels form a valid differential pair
-     *
-     * @param channel1 First channel (0-3)
-     * @param channel2 Second channel (0-3)
-     * @return True if the combination is valid (0-1, 0-3, 1-3, or 2-3)
-     */
-    static bool isValidDifferentialPair(int8_t channel1, int8_t channel2);
 
     /**
      * @brief Construct a new TIADS1x15Base object for single-ended measurements
      *
-     * @param adsChannel The ADS channel of interest (0-3).
+     * @param adsChannel The ADS channel of interest (0-3, physical channel
+     * only).
      * @param voltageMultiplier The voltage multiplier for any voltage dividers
      * @param adsGain The internal gain setting of the ADS1x15
      * @param i2cAddress The I2C address of the ADS 1x15
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in volts
+     *
+     * @note adsChannel uses uint8_t to match Adafruit_ADS1X15 expectations.
+     * Negative sentinels are handled internally where needed.
      */
-    TIADS1x15Base(int8_t adsChannel, float voltageMultiplier, adsGain_t adsGain,
-                  uint8_t i2cAddress, float adsSupplyVoltage)
-        : AnalogVoltageBase(adsChannel, voltageMultiplier, adsSupplyVoltage,
-                            -1),
-          _adsGain(adsGain),
-          _i2cAddress(i2cAddress) {}
+    TIADS1x15Base(uint8_t adsChannel, float voltageMultiplier,
+                  adsGain_t adsGain, uint8_t i2cAddress,
+                  float adsSupplyVoltage);
 
     /**
      * @brief Construct a new TIADS1x15Base object for differential measurements
      *
      * @param adsChannel1 The first ADS channel for differential measurement
-     * (0-3)
+     * (0-3, physical channel only)
      * @param adsChannel2 The second ADS channel for differential measurement
-     * (0-3)
+     * (0-3, physical channel only)
      * @param voltageMultiplier The voltage multiplier for any voltage dividers
      * @param adsGain The internal gain setting of the ADS1x15
      * @param i2cAddress The I2C address of the ADS 1x15
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in volts
+     *
+     * @note Channel parameters use uint8_t to match Adafruit_ADS1X15
+     * expectations. Negative sentinels are handled internally where needed.
      */
-    TIADS1x15Base(int8_t adsChannel1, int8_t adsChannel2,
+    TIADS1x15Base(uint8_t adsChannel1, uint8_t adsChannel2,
                   float voltageMultiplier, adsGain_t adsGain,
-                  uint8_t i2cAddress, float adsSupplyVoltage)
-        : AnalogVoltageBase(adsChannel1, voltageMultiplier, adsSupplyVoltage,
-                            adsChannel2),
-          _adsGain(adsGain),
-          _i2cAddress(i2cAddress) {
-        // Validate differential channel combinations
-        if (!isValidDifferentialPair(adsChannel1, adsChannel2)) {
-            // Default to 0-1 if invalid combination
-            _analogChannel             = 0;
-            _analogDifferentialChannel = 1;
-        }
-        // NOTE: We CANNOT print a warning here about invalid channel clamping
-        // because the Serial object may not be initialized yet, and we don't
-        // want to cause a crash.
-    }
+                  uint8_t i2cAddress, float adsSupplyVoltage);
 
     /**
      * @brief Destroy the TIADS1x15Base object
@@ -380,6 +362,19 @@ class TIADS1x15Base : public AnalogVoltageBase {
      */
     adsGain_t getADSGain(void) const;
 
+    /**
+     * @brief Check if the two channels form a valid differential pair
+     *
+     * @param channel1 First channel (0-3, physical ADS channel indices only)
+     * @param channel2 Second channel (0-3, physical ADS channel indices only)
+     * @return True if the combination is valid (0-1, 0-3, 1-3, or 2-3)
+     *
+     * @note This function expects uint8_t to match
+     * Adafruit_ADS1X15::readADC_SingleEnded(uint8_t) and avoid sign-extension
+     * issues. Negative sentinel values are handled internally.
+     */
+    static bool isValidDifferentialPair(uint8_t channel1, uint8_t channel2);
+
  protected:
     /**
      * @brief Internal reference to the internal gain setting of the TI-ADS1x15
@@ -415,7 +410,8 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      *
      * @param powerPin The pin on the mcu controlling power to the sensor
      * Use -1 if it is continuously powered.
-     * @param adsChannel The ADS channel of interest (0-3).
+     * @param adsChannel The ADS channel of interest (0-3, physical channel
+     * only).
      * @param voltageMultiplier The voltage multiplier, if a voltage divider is
      * used.
      * @param adsGain The internal gain setting of the ADS1x15; defaults to
@@ -427,8 +423,12 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * default value of 1.
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
      * volts; defaults to the processor operating voltage from KnownProcessors.h
+     *
+     * @note adsChannel uses uint8_t to match
+     * Adafruit_ADS1X15::readADC_SingleEnded(uint8_t) and avoid sign-extension
+     * issues.
      */
-    TIADS1x15(int8_t powerPin, int8_t adsChannel, float voltageMultiplier = 1,
+    TIADS1x15(int8_t powerPin, uint8_t adsChannel, float voltageMultiplier = 1,
               adsGain_t adsGain               = GAIN_ONE,
               uint8_t   i2cAddress            = ADS1115_ADDRESS,
               uint8_t   measurementsToAverage = 1,
@@ -439,9 +439,10 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * @param powerPin The pin on the mcu controlling power to the sensor
      * Use -1 if it is continuously powered.
      * @param adsChannel1 The first ADS channel for differential measurement
-     * (0-3)
+     * (0-3, physical channel only)
      * @param adsChannel2 The second ADS channel for differential measurement
-     * (0-3) Valid combinations are: 0-1, 0-3, 1-3, or 2-3
+     * (0-3, physical channel only) Valid combinations are: 0-1, 0-3, 1-3, or
+     * 2-3
      * @param voltageMultiplier The voltage multiplier, if a voltage divider is
      * used.
      * @param adsGain The internal gain setting of the ADS1x15; defaults to
@@ -453,8 +454,11 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * default value of 1.
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
      * volts; defaults to the processor operating voltage from KnownProcessors.h
+     *
+     * @note Channel parameters use uint8_t to match Adafruit_ADS1X15
+     * expectations and avoid sign-extension issues.
      */
-    TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
+    TIADS1x15(int8_t powerPin, uint8_t adsChannel1, uint8_t adsChannel2,
               float voltageMultiplier = 1, adsGain_t adsGain = GAIN_ONE,
               uint8_t i2cAddress            = ADS1115_ADDRESS,
               uint8_t measurementsToAverage = 1,
@@ -462,7 +466,7 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
     /**
      * @brief Destroy the External Voltage object
      */
-    ~TIADS1x15();
+    ~TIADS1x15() override;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -61,20 +61,20 @@
  * @section analog_ads1x15_specs Specifications
  * @note *In all cases, we assume that the ADS1x15 is powered at 3.3V by default with configurable internal gain settings.
  *
- * The default gain setting is 1x (GAIN_ONE) which divides the bit resolution over the range of 0-4.096V.
- * In single-ended mode the actual ceiling is min(FSR, VDD + 0.3V) — typically 3.6V at 3.3V supply.
+ * The default gain setting is 1x (GAIN_ONE) which provides a PGA full-scale range (±4.096V).
+ * In single-ended mode the actual ceiling is min(Full-Scale Range (FSR), VDD + 0.3V) — typically 3.6V at 3.3V supply.
  * - Response time: < 1ms
  * - Resample time: 860 samples per second (~1.2ms)
  * - Range:
  *   - Single-ended measurements: Limited by supply voltage (VDD + 0.3V max, absolute max 5.5V)
  *     - 0 - 3.6V [when ADC is powered at 3.3V]
- *   - Differential measurements: Limited by internal PGA full-scale range (gain-dependent)
- *     - GAIN_TWOTHIRDS = ±6.144V
- *     - GAIN_ONE = ±4.096V
- *     - GAIN_TWO = ±2.048V
- *     - GAIN_FOUR = ±1.024V
- *     - GAIN_EIGHT = ±0.512V
- *     - GAIN_SIXTEEN = ±0.256V
+ *   - Differential measurements: Limited by PGA full-scale range (gain-dependent)
+ *     - GAIN_TWOTHIRDS = ±6.144V PGA full-scale range
+ *     - GAIN_ONE = ±4.096V PGA full-scale range
+ *     - GAIN_TWO = ±2.048V PGA full-scale range
+ *     - GAIN_FOUR = ±1.024V PGA full-scale range
+ *     - GAIN_EIGHT = ±0.512V PGA full-scale range
+ *     - GAIN_SIXTEEN = ±0.256V PGA full-scale range
  * - Accuracy:
  *   - 16-bit ADC (ADS1115): < 0.25% (gain error), <0.25 LSB (offset error)
  *   - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): < 0.15% (gain error), <3 LSB (offset error)

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -65,9 +65,15 @@
  * - Response time: < 1ms
  * - Resample time: 860 samples per second (~1.2ms)
  * - Range:
- *   - Range is determined by supply voltage - No more than VDD + 0.3 V r 5.5 V
- *     (whichever is smaller) must be applied to this device.
- *   - 0 - 3.6V [when ADC is powered at 3.3V]
+ *   - Single-ended measurements: Limited by supply voltage (VDD + 0.3V max, absolute max 5.5V)
+ *     - 0 - 3.6V [when ADC is powered at 3.3V]
+ *   - Differential measurements: Limited by internal PGA full-scale range (gain-dependent)
+ *     - GAIN_TWOTHIRDS = ±6.144V
+ *     - GAIN_ONE = ±4.096V
+ *     - GAIN_TWO = ±2.048V
+ *     - GAIN_FOUR = ±1.024V
+ *     - GAIN_EIGHT = ±0.512V
+ *     - GAIN_SIXTEEN = ±0.256V
  * - Accuracy:
  *   - 16-bit ADC (ADS1115): < 0.25% (gain error), <0.25 LSB (offset error)
  *   - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): < 0.15% (gain error), <3 LSB (offset error)
@@ -228,7 +234,7 @@ enum class tiads1x15_adsDiffMux_t : uint16_t {
  * @name Voltage
  * The volt variable from a TI ADS1x15 analog-to-digital converter (ADC)
  *   - Range (with no external voltage divider):
- *     - 0 - min(4.096V, supply voltage + 0.3V) voltage + 0.3V)
+ *     - 0 - min(4.096V, supply voltage + 0.3V)
  *   - Accuracy:
  *     - 16-bit ADC (ADS1115): < 0.25% (gain error), <0.25 LSB (offset error)
  *     - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): < 0.15%

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -389,6 +389,19 @@ class TIADS1x15Base : public AnalogVoltageBase {
 #endif
 };
 
+// Inline utility function implementation
+inline TIADS1x15Base* createTIADS1x15Base(bool& ownsAnalogVoltageReader) {
+    TIADS1x15Base* reader = new TIADS1x15Base();
+    // verify that the voltage reader was created successfully
+    // this could fail silently on no-exceptions Arduino targets
+    if (reader != nullptr) {
+        ownsAnalogVoltageReader = true;
+    } else {
+        ownsAnalogVoltageReader = false;
+    }
+    return reader;
+}
+
 /* clang-format off */
 /**
  * @brief The Sensor sub-class for the
@@ -419,13 +432,14 @@ class TIADS1x15 : public Sensor {
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
-     * @param adsBase Pointer to TIADS1x15Base object for ADS functionality.
-     * If nullptr (default), creates a new TIADS1x15Base with default settings.
+     * @param analogVoltageReader Pointer to TIADS1x15Base object for ADS
+     * functionality. If nullptr (default), creates a new TIADS1x15Base with
+     * default settings.
      */
     TIADS1x15(int8_t powerPin, int8_t adsChannel,
               int8_t         analogReferenceChannel = -1,
               uint8_t        measurementsToAverage  = 1,
-              TIADS1x15Base* adsBase                = nullptr);
+              TIADS1x15Base* analogVoltageReader    = nullptr);
     /**
      * @brief Destroy the External Voltage object
      */
@@ -448,12 +462,13 @@ class TIADS1x15 : public Sensor {
     /**
      * @brief Pointer to the TIADS1x15Base object providing ADS functionality
      */
-    TIADS1x15Base* _adsBase = nullptr;
+    TIADS1x15Base* _analogVoltageReader = nullptr;
 
     /**
-     * @brief Whether this object owns the _adsBase pointer and should delete it
+     * @brief Whether this object owns the _analogVoltageReader pointer and
+     * should delete it
      */
-    bool _ownsAdsBase = false;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -62,6 +62,7 @@
  * @note *In all cases, we assume that the ADS1x15 is powered at 3.3V by default with configurable internal gain settings.
  *
  * The default gain setting is 1x (GAIN_ONE) which divides the bit resolution over the range of 0-4.096V.
+ * In single-ended mode the actual ceiling is min(FSR, VDD + 0.3V) — typically 3.6V at 3.3V supply.
  * - Response time: < 1ms
  * - Resample time: 860 samples per second (~1.2ms)
  * - Range:

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -187,16 +187,6 @@
 /**@}*/
 
 /**
- * @anchor sensor_ads1x15_config
- * @name Configuration Defines
- * Defines to help configure the address of the ADD
- */
-/**@{*/
-/// @brief The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
-/**@}*/
-
-/**
  * @brief Enum for the pins used for differential voltages.
  */
 enum class tiads1x15_adsDiffMux_t : uint16_t {
@@ -297,8 +287,8 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * Negative sentinels are handled internally where needed.
      */
     explicit TIADS1x15Base(uint8_t adsChannel, float voltageMultiplier = 1.0,
-                           adsGain_t adsGain          = GAIN_ONE,
-                           uint8_t   i2cAddress       = ADS1115_ADDRESS,
+                           adsGain_t adsGain    = GAIN_ONE,
+                           uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
                            float     adsSupplyVoltage = OPERATING_VOLTAGE);
 
     /**
@@ -319,8 +309,8 @@ class TIADS1x15Base : public AnalogVoltageBase {
     explicit TIADS1x15Base(uint8_t adsChannel1, uint8_t adsChannel2,
                            float     voltageMultiplier = 1.0,
                            adsGain_t adsGain           = GAIN_ONE,
-                           uint8_t   i2cAddress        = ADS1115_ADDRESS,
-                           float     adsSupplyVoltage  = OPERATING_VOLTAGE);
+                           uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
+                           float     adsSupplyVoltage = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the TIADS1x15Base object
@@ -433,7 +423,7 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      */
     TIADS1x15(int8_t powerPin, uint8_t adsChannel, float voltageMultiplier = 1,
               adsGain_t adsGain               = GAIN_ONE,
-              uint8_t   i2cAddress            = ADS1115_ADDRESS,
+              uint8_t   i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
               uint8_t   measurementsToAverage = 1,
               float     adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**
@@ -463,7 +453,7 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      */
     TIADS1x15(int8_t powerPin, uint8_t adsChannel1, uint8_t adsChannel2,
               float voltageMultiplier = 1, adsGain_t adsGain = GAIN_ONE,
-              uint8_t i2cAddress            = ADS1115_ADDRESS,
+              uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
               uint8_t measurementsToAverage = 1,
               float   adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -336,9 +336,9 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @param channel2 Second channel (0-3, physical ADS channel indices only)
      * @return True if the combination is valid (0-1, 0-3, 1-3, or 2-3)
      *
-     * @note Channel parameters use uint8_t to be consistent with the
-     * Adafruit_ADS1X15 channel type convention and to avoid sign-extension
-     * when computing hardware MUX configuration values internally.
+     * @note Channel parameters use int8_t, consistent with the rest of the
+     * ModularSensors channel conventions. Negative values indicate invalid
+     * channels.
      */
     static bool isValidDifferentialPair(int8_t channel1, int8_t channel2);
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -312,12 +312,8 @@ class TIADS1x15Base : public AnalogVoltageBase {
                                  int8_t analogReferenceChannel,
                                  float& resultValue) override;
 
-    /**
-     * @brief Get the sensor location string
-     *
-     * @return A string describing the ADS1x15 sensor location
-     */
-    String getSensorLocation(void) override;
+    String getAnalogLocation(int8_t analogChannel,
+                             int8_t analogReferenceChannel = -1) override;
 
     /**
      * @brief Set the internal gain setting for the ADS1x15

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -112,8 +112,8 @@
  * If you are working with an EnviroDIY Mayfly, the easiest voltage divider to
  * connect is the Grove voltage divider sold by seeed studio.  The grove voltage
  * divider is a simple voltage divider designed to measure high external
- * voltages on a low voltage ADC.  This module employs a variable gain via two
- * pairs of voltage dividers, and a unity gain amplification to reduce output
+ * voltages on a low voltage ADC.  This module employs a variable voltage multiplier
+ * via two pairs of voltage dividers, and a unity gain amplification to reduce output
  * impedance of the module.
  *
  * @section sensor_ads1x15_datasheet Sensor Datasheet
@@ -274,8 +274,9 @@ class TIADS1x15 : public Sensor {
      * @brief Construct a new External Voltage object - need the power pin and
      * the data channel on the ADS1x15.
      *
-     * The gain value, I2C address, and number of measurements to average are
-     * optional.  If nothing is given a 1x gain is used.
+     * The voltage multiplier value, I2C address, and number of measurements to
+     * average are optional.  If nothing is given a 1x voltage multiplier is
+     * used.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core. Connecting the ADS to
@@ -284,19 +285,20 @@ class TIADS1x15 : public Sensor {
      * @param powerPin The pin on the mcu controlling power to the sensor
      * Use -1 if it is continuously powered.
      * @param adsChannel The ADS channel of interest (0-3).
-     * @param gain The gain multiplier, if a voltage divider is used.
+     * @param voltageMultiplier The voltage multiplier, if a voltage divider is
+     * used.
      * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
      * = GND)
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
-     * @param adsSupplyVoltage_V The power supply voltage for the ADS1x15 in volts;
-     * defaults to the processor operating voltage from KnownProcessors.h
+     * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
+     * volts; defaults to the processor operating voltage from KnownProcessors.h
      */
-    TIADS1x15(int8_t powerPin, uint8_t adsChannel, float gain = 1,
+    TIADS1x15(int8_t powerPin, uint8_t adsChannel, float voltageMultiplier = 1,
               uint8_t i2cAddress            = ADS1115_ADDRESS,
               uint8_t measurementsToAverage = 1,
-              float adsSupplyVoltage_V      = OPERATING_VOLTAGE);
+              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**
      * @brief Destroy the External Voltage object
      */
@@ -309,9 +311,10 @@ class TIADS1x15 : public Sensor {
     /**
      * @brief Set the power supply voltage for the ADS1x15
      *
-     * @param adsSupplyVoltage_V The power supply voltage in volts (2.0-5.5V range)
+     * @param adsSupplyVoltage The power supply voltage in volts (2.0-5.5V
+     * range)
      */
-    void setADSSupplyVoltage(float adsSupplyVoltage_V);
+    void setADSSupplyVoltage(float adsSupplyVoltage);
 
     /**
      * @brief Get the power supply voltage for the ADS1x15
@@ -327,9 +330,9 @@ class TIADS1x15 : public Sensor {
      */
     uint8_t _adsChannel;
     /**
-     * @brief Internal reference to the gain setting for the TI-ADS1x15
+     * @brief Internal reference to the voltage multiplier for the TI-ADS1x15
      */
-    float _gain;
+    float _voltageMultiplier;
     /**
      * @brief Internal reference to the I2C address of the TI-ADS1x15
      */
@@ -337,7 +340,7 @@ class TIADS1x15 : public Sensor {
     /**
      * @brief Internal reference to the power supply voltage of the TI-ADS1x15
      */
-    float _adsSupplyVoltage_V;
+    float _adsSupplyVoltage;
 };
 
 /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -455,9 +455,18 @@ class TIADS1x15 : public Sensor {
               uint8_t        measurementsToAverage  = 1,
               TIADS1x15Base* analogVoltageReader    = nullptr);
     /**
-     * @brief Destroy the External Voltage object
+     * @brief Destroy the TIADS1x15 object
      */
     ~TIADS1x15() override;
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    TIADS1x15(const TIADS1x15&)            = delete;
+    TIADS1x15& operator=(const TIADS1x15&) = delete;
+
+    // Delete move constructor and move assignment operator
+    TIADS1x15(TIADS1x15&&)            = delete;
+    TIADS1x15& operator=(TIADS1x15&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -187,16 +187,6 @@
 /**@}*/
 
 /**
- * @brief Enum for the pins used for differential voltages.
- */
-enum class tiads1x15_adsDiffMux_t : uint16_t {
-    TIADS1X15_DIFF_MUX_0_1,  ///< differential across pins 0 and 1
-    TIADS1X15_DIFF_MUX_0_3,  ///< differential across pins 0 and 3
-    TIADS1X15_DIFF_MUX_1_3,  ///< differential across pins 1 and 3
-    TIADS1X15_DIFF_MUX_2_3   ///< differential across pins 2 and 3
-};
-
-/**
  * @anchor sensor_ads1x15_timing
  * @name Sensor Timing
  * The sensor timing for a TI ADS1x15 analog-to-digital converter (ADC)

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -296,9 +296,10 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @note adsChannel uses uint8_t to match Adafruit_ADS1X15 expectations.
      * Negative sentinels are handled internally where needed.
      */
-    TIADS1x15Base(uint8_t adsChannel, float voltageMultiplier,
-                  adsGain_t adsGain, uint8_t i2cAddress,
-                  float adsSupplyVoltage);
+    explicit TIADS1x15Base(uint8_t adsChannel, float voltageMultiplier = 1.0,
+                           adsGain_t adsGain          = GAIN_ONE,
+                           uint8_t   i2cAddress       = ADS1115_ADDRESS,
+                           float     adsSupplyVoltage = OPERATING_VOLTAGE);
 
     /**
      * @brief Construct a new TIADS1x15Base object for differential measurements
@@ -315,9 +316,11 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @note Channel parameters use uint8_t to match Adafruit_ADS1X15
      * expectations. Negative sentinels are handled internally where needed.
      */
-    TIADS1x15Base(uint8_t adsChannel1, uint8_t adsChannel2,
-                  float voltageMultiplier, adsGain_t adsGain,
-                  uint8_t i2cAddress, float adsSupplyVoltage);
+    explicit TIADS1x15Base(uint8_t adsChannel1, uint8_t adsChannel2,
+                           float     voltageMultiplier = 1.0,
+                           adsGain_t adsGain           = GAIN_ONE,
+                           uint8_t   i2cAddress        = ADS1115_ADDRESS,
+                           float     adsSupplyVoltage  = OPERATING_VOLTAGE);
 
     /**
      * @brief Destroy the TIADS1x15Base object

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -340,7 +340,7 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * Adafruit_ADS1X15 channel type convention and to avoid sign-extension
      * when computing hardware MUX configuration values internally.
      */
-    static bool isValidDifferentialPair(uint8_t channel1, uint8_t channel2);
+    static bool isValidDifferentialPair(int8_t channel1, int8_t channel2);
 
  protected:
     /**

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -390,6 +390,24 @@ class TIADS1x15Base : public AnalogVoltageBase {
 };
 
 // Inline utility function implementation
+/**
+ * @brief Create a TIADS1x15Base analog voltage reader with ownership tracking
+ *
+ * This utility function safely creates a new TIADS1x15Base object with default
+ * settings and verifies it was created successfully. It handles the pattern of
+ * creating default analog voltage readers when none is provided to sensor
+ * constructors.
+ *
+ * @param[out] ownsAnalogVoltageReader Reference to bool that tracks ownership.
+ *   Set to true if the reader was created successfully, false if creation
+ * failed.
+ * @return Pointer to created TIADS1x15Base object, or nullptr if creation
+ * failed
+ *
+ * @note This function is designed for use in sensor constructors that need a
+ * default analog voltage reader. The ownership flag should be used to determine
+ * whether the returned pointer needs to be deleted in the sensor's destructor.
+ */
 inline TIADS1x15Base* createTIADS1x15Base(bool& ownsAnalogVoltageReader) {
     TIADS1x15Base* reader = new TIADS1x15Base();
     // verify that the voltage reader was created successfully

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -427,7 +427,7 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
      * volts; defaults to the processor operating voltage from KnownProcessors.h
      */
-    TIADS1x15(int8_t powerPin, int8_t adsChannel1, uint8_t adsChannel2,
+    TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
               float voltageMultiplier = 1, adsGain_t adsGain = GAIN_ONE,
               uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
               uint8_t measurementsToAverage = 1,
@@ -457,7 +457,7 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * For single-ended measurements: -1 (not used)
      * For differential measurements: the second ADS channel (0-3)
      */
-    int8_t _adsDifferentialChannel;
+    int8_t _adsDifferentialChannel = -1;
 
     /**
      * @brief Helper function to check if this sensor is configured for

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -394,11 +394,7 @@ inline TIADS1x15Base* createTIADS1x15Base(bool& ownsAnalogVoltageReader) {
     TIADS1x15Base* reader = new TIADS1x15Base();
     // verify that the voltage reader was created successfully
     // this could fail silently on no-exceptions Arduino targets
-    if (reader != nullptr) {
-        ownsAnalogVoltageReader = true;
-    } else {
-        ownsAnalogVoltageReader = false;
-    }
+    ownsAnalogVoltageReader = (reader != nullptr);
     return reader;
 }
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -374,6 +374,26 @@ class TIADS1x15Base : public AnalogVoltageBase {
      */
     void setSupplyVoltage(float supplyVoltage) override;
 
+    /**
+     * @brief Calculate the analog resolution in volts for the ADS1x15
+     *
+     * For ADS1x15, this calculates the voltage resolution based on the current
+     * gain setting, supply voltage, and ADC bit resolution. The resolution
+     * depends on:
+     * - ADC model: 12-bit (ADS1015) or 16-bit (ADS1115)
+     * - Gain setting: determines PGA full-scale range
+     * - Supply voltage: limits actual usable range for single-ended
+     * measurements
+     *
+     * The effective full scale range is the minimum of:
+     * - PGA full-scale range (gain-dependent)
+     * - Supply voltage + 0.3V (for single-ended measurements)
+     * - Absolute maximum 5.5V per datasheet
+     *
+     * @return The analog resolution in volts per LSB
+     */
+    float calculateAnalogResolutionVolts(void) override;
+
  protected:
     /**
      * @brief Internal reference to the I2C address of the TI-ADS1x15

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -190,6 +190,16 @@
 /**@}*/
 
 /**
+ * @brief Enum for the pins used for differential voltages.
+ */
+typedef enum : uint16_t {
+    TIADS1X15_DIFF_MUX_0_1,  ///< differential across pins 0 and 1
+    TIADS1X15_DIFF_MUX_0_3,  ///< differential across pins 0 and 3
+    TIADS1X15_DIFF_MUX_1_3,  ///< differential across pins 1 and 3
+    TIADS1X15_DIFF_MUX_2_3   ///< differential across pins 2 and 3
+} tiads1x15_adsDiffMux_t;
+
+/**
  * @anchor sensor_ads1x15_timing
  * @name Sensor Timing
  * The sensor timing for a TI ADS1x15 analog-to-digital converter (ADC)
@@ -299,6 +309,30 @@ class TIADS1x15 : public Sensor {
               uint8_t   measurementsToAverage = 1,
               float     adsSupplyVoltage      = OPERATING_VOLTAGE);
     /**
+     * @brief Construct a new TIADS1x15 object for differential measurements
+     *
+     * @param powerPin The pin on the mcu controlling power to the sensor
+     * Use -1 if it is continuously powered.
+     * @param adsDiffMux The differential pin configuration for voltage
+     * measurement
+     * @param voltageMultiplier The voltage multiplier, if a voltage divider is
+     * used.
+     * @param adsGain The internal gain setting of the ADS1x15; defaults to
+     * GAIN_ONE for +/- 4.096V range
+     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
+     * = GND)
+     * @param measurementsToAverage The number of measurements to take and
+     * average before giving a "final" result from the sensor; optional with a
+     * default value of 1.
+     * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
+     * volts; defaults to the processor operating voltage from KnownProcessors.h
+     */
+    TIADS1x15(int8_t powerPin, tiads1x15_adsDiffMux_t adsDiffMux,
+              float voltageMultiplier = 1, adsGain_t adsGain = GAIN_ONE,
+              uint8_t i2cAddress            = ADS1115_ADDRESS,
+              uint8_t measurementsToAverage = 1,
+              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
+    /**
      * @brief Destroy the External Voltage object
      */
     ~TIADS1x15();
@@ -346,12 +380,28 @@ class TIADS1x15 : public Sensor {
      */
     virtual bool readVoltageSingleEnded(float& resultValue);
 
+    /**
+     * @brief Read a differential voltage measurement from the ADS1x15
+     *
+     * @param resultValue Reference to store the resulting voltage measurement
+     * @return True if the voltage reading was successful and within valid range
+     */
+    virtual bool readVoltageDifferential(float& resultValue);
+
  private:
     /**
      * @brief Internal reference to the ADS channel number of the device
-     * attached to the TI-ADS1x15
+     * attached to the TI-ADS1x15 (used for single-ended measurements)
      */
     uint8_t _adsChannel;
+    /**
+     * @brief Internal reference to whether we are using differential mode
+     */
+    bool _isDifferential;
+    /**
+     * @brief Internal reference to the differential mux configuration
+     */
+    tiads1x15_adsDiffMux_t _adsDiffMux;
     /**
      * @brief Internal reference to the voltage multiplier for the TI-ADS1x15
      */

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -394,8 +394,8 @@ class TIADS1x15Base : public AnalogVoltageBase {
 class TIADS1x15 : public Sensor, public TIADS1x15Base {
  public:
     /**
-     * @brief Construct a new External Voltage object - need the power pin and
-     * the data channel on the ADS1x15.
+     * @brief Construct a new TIADS1x15 object for single-ended or differential
+     * voltage measurements
      *
      * The voltage multiplier value, I2C address, and number of measurements to
      * average are optional.  If nothing is given a 1x voltage multiplier is
@@ -408,7 +408,8 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * @param powerPin The pin on the mcu controlling power to the sensor
      * Use -1 if it is continuously powered.
      * @param adsChannel The ADS channel of interest (0-3, physical channel
-     * only).
+     * only). For differential measurements, this is the first (positive)
+     * channel.
      * @param voltageMultiplier The voltage multiplier, if a voltage divider is
      * used.
      * @param adsGain The internal gain setting of the ADS1x15; defaults to
@@ -420,39 +421,17 @@ class TIADS1x15 : public Sensor, public TIADS1x15Base {
      * default value of 1.
      * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
      * volts; defaults to the processor operating voltage from KnownProcessors.h
+     * @param differentialChannel The second (reference/negative) ADS channel
+     * for differential measurement (0-3, physical channel only). Valid pairs
+     * are: 0-1, 0-3, 1-3, or 2-3. Use -1 (default) for single-ended
+     * measurements.
      */
     TIADS1x15(int8_t powerPin, int8_t adsChannel,
               float voltageMultiplier = 1.0f, adsGain_t adsGain = GAIN_ONE,
               uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
               uint8_t measurementsToAverage = 1,
-              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
-    /**
-     * @brief Construct a new TIADS1x15 object for differential measurements
-     *
-     * @param powerPin The pin on the mcu controlling power to the sensor
-     * Use -1 if it is continuously powered.
-     * @param adsChannel1 The first (measurement) ADS channel for differential
-     * measurement (0-3, physical channel only)
-     * @param adsChannel2 The second (reference) ADS channel for differential
-     * measurement (0-3, physical channel only) Valid combinations are: 0-1,
-     * 0-3, 1-3, or 2-3
-     * @param voltageMultiplier The voltage multiplier, if a voltage divider is
-     * used.
-     * @param adsGain The internal gain setting of the ADS1x15; defaults to
-     * GAIN_ONE for +/- 4.096V range
-     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
-     * = GND)
-     * @param measurementsToAverage The number of measurements to take and
-     * average before giving a "final" result from the sensor; optional with a
-     * default value of 1.
-     * @param adsSupplyVoltage The power supply voltage for the ADS1x15 in
-     * volts; defaults to the processor operating voltage from KnownProcessors.h
-     */
-    TIADS1x15(int8_t powerPin, int8_t adsChannel1, int8_t adsChannel2,
-              float voltageMultiplier = 1, adsGain_t adsGain = GAIN_ONE,
-              uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
-              uint8_t measurementsToAverage = 1,
-              float   adsSupplyVoltage      = OPERATING_VOLTAGE);
+              float   adsSupplyVoltage      = OPERATING_VOLTAGE,
+              int8_t  differentialChannel   = -1);
     /**
      * @brief Destroy the External Voltage object
      */

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -290,6 +290,17 @@ class TIADS1x15Base : public AnalogVoltageBase {
     virtual ~TIADS1x15Base() = default;
 
     /**
+     * @brief Initialize the ADS1x15 analog voltage reading system
+     *
+     * This function performs hardware initialization that cannot be safely
+     * done in the constructor, including I2C communication with the ADS1x15
+     * device to configure gain and data rate settings.
+     *
+     * @return True if the initialization was successful, false otherwise
+     */
+    bool begin(void) override;
+
+    /**
      * @brief Read a single-ended voltage measurement from the ADS1x15
      *
      * @param analogChannel The ADS channel of interest (0-3, physical channel
@@ -400,6 +411,14 @@ class TIADS1x15Base : public AnalogVoltageBase {
      */
     uint8_t _i2cAddress;
     /**
+     * @brief The internal gain setting for the ADS1x15
+     */
+    adsGain_t _adsGain;
+    /**
+     * @brief The data rate setting for the ADS1x15
+     */
+    uint16_t _adsDataRate;
+    /**
      * @brief Per-instance ADS1x15 driver to maintain separate I2C state
      */
 #ifndef MS_USE_ADS1015
@@ -489,6 +508,8 @@ class TIADS1x15 : public Sensor {
     TIADS1x15& operator=(TIADS1x15&&) = delete;
 
     String getSensorLocation(void) override;
+
+    bool setup(void) override;
 
     bool addSingleMeasurementResult(void) override;
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -372,9 +372,9 @@ class TIADS1x15Base : public AnalogVoltageBase {
      * @param channel2 Second channel (0-3, physical ADS channel indices only)
      * @return True if the combination is valid (0-1, 0-3, 1-3, or 2-3)
      *
-     * @note This function expects uint8_t to match
-     * Adafruit_ADS1X15::readADC_SingleEnded(uint8_t) and avoid sign-extension
-     * issues. Negative sentinel values are handled internally.
+     * @note Channel parameters use uint8_t to be consistent with the
+     * Adafruit_ADS1X15 channel type convention and to avoid sign-extension
+     * when computing hardware MUX configuration values internally.
      */
     static bool isValidDifferentialPair(uint8_t channel1, uint8_t channel2);
 

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -428,33 +428,6 @@ class TIADS1x15Base : public AnalogVoltageBase {
 #endif
 };
 
-// Inline utility function implementation
-/**
- * @brief Create a TIADS1x15Base analog voltage reader with ownership tracking
- *
- * This utility function safely creates a new TIADS1x15Base object with default
- * settings and verifies it was created successfully. It handles the pattern of
- * creating default analog voltage readers when none is provided to sensor
- * constructors.
- *
- * @param[out] ownsAnalogVoltageReader Reference to bool that tracks ownership.
- *   Set to true if the reader was created successfully, false if creation
- * failed.
- * @return Pointer to created TIADS1x15Base object, or nullptr if creation
- * failed
- *
- * @note This function is designed for use in sensor constructors that need a
- * default analog voltage reader. The ownership flag should be used to determine
- * whether the returned pointer needs to be deleted in the sensor's destructor.
- */
-inline TIADS1x15Base* createTIADS1x15Base(bool& ownsAnalogVoltageReader) {
-    TIADS1x15Base* reader = new TIADS1x15Base();
-    // verify that the voltage reader was created successfully
-    // this could fail silently on no-exceptions Arduino targets
-    ownsAnalogVoltageReader = (reader != nullptr);
-    return reader;
-}
-
 /* clang-format off */
 /**
  * @brief The Sensor sub-class for the

--- a/src/sensors/TIADS1x15.h
+++ b/src/sensors/TIADS1x15.h
@@ -313,7 +313,7 @@ class TIADS1x15Base : public AnalogVoltageBase {
                                  float& resultValue) override;
 
     String getAnalogLocation(int8_t analogChannel,
-                             int8_t analogReferenceChannel = -1) override;
+                             int8_t analogReferenceChannel) override;
 
     /**
      * @brief Set the internal gain setting for the ADS1x15

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -25,13 +25,11 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t analogChannel,
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 TurnerCyclops::~TurnerCyclops() {
@@ -52,9 +50,9 @@ String TurnerCyclops::getSensorLocation(void) {
 
 
 bool TurnerCyclops::setup(void) {
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -65,7 +63,7 @@ bool TurnerCyclops::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -51,6 +51,25 @@ String TurnerCyclops::getSensorLocation(void) {
 }
 
 
+bool TurnerCyclops::setup(void) {
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
+}
+
+
 bool TurnerCyclops::addSingleMeasurementResult(void) {
     // Immediately quit if the measurement was not successfully started
     if (!getStatusBit(MEASUREMENT_SUCCESSFUL)) {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -14,7 +14,7 @@
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
-TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t analogChannel,
+TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t analogChannel,
                              float conc_std, float volt_std, float volt_blank,
                              uint8_t            measurementsToAverage,
                              AnalogVoltageBase* analogVoltageReader)

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -35,7 +35,6 @@ TurnerCyclops::~TurnerCyclops() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -71,8 +71,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
     }
 
     bool  success     = false;
-    float adcVoltage  = -9999;
-    float calibResult = -9999;
+    float adcVoltage  = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
@@ -90,7 +89,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
                                                            adcVoltage);
     if (success) {
         // Apply the unique calibration curve for the given sensor
-        calibResult = (_conc_std / (_volt_std - _volt_blank)) *
+        float calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VAR_NUM, calibResult);

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -65,10 +65,6 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    float adcVoltage = -9999.0f;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
@@ -76,6 +72,10 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         MS_DBG(F("Invalid calibration: point voltage equals blank voltage"));
         return bumpMeasurementAttemptCount(false);
     }
+
+    float adcVoltage = -9999.0f;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Read the single-ended analog voltage using the AnalogVoltageBase
     // interface.

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -72,8 +72,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
-    const float epsilon = 1e-4f;  // tune to expected sensor precision
-    if (fabs(_volt_std - _volt_blank) < epsilon) {
+    if (fabs(_volt_std - _volt_blank) < CYCLOPS_CALIBRATION_EPSILON) {
         MS_DBG(F("Invalid calibration: point voltage equals blank voltage"));
         return bumpMeasurementAttemptCount(false);
     }

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -24,13 +24,12 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t analogChannel,
              CYCLOPS_INC_CALC_VARIABLES),
       _conc_std(conc_std),
       _volt_std(volt_std),
-      _volt_blank(volt_blank) {
+      _volt_blank(volt_blank),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -41,7 +41,7 @@ TurnerCyclops::~TurnerCyclops() {
 
 String TurnerCyclops::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getAnalogLocation(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
         return String("Unknown_AnalogVoltageReader");
     }

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -46,7 +46,7 @@ String TurnerCyclops::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
         return _analogVoltageReader->getAnalogLocation(_dataPin, -1);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 
@@ -67,7 +67,7 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
-    if (fabs(_volt_std - _volt_blank) < CYCLOPS_CALIBRATION_EPSILON) {
+    if (fabsf(_volt_std - _volt_blank) < CYCLOPS_CALIBRATION_EPSILON) {
         MS_DBG(F("Invalid calibration: point voltage equals blank voltage"));
         return bumpMeasurementAttemptCount(false);
     }

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -24,11 +24,15 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t analogChannel,
              CYCLOPS_INC_CALC_VARIABLES),
       _conc_std(conc_std),
       _volt_std(volt_std),
-      _volt_blank(volt_blank),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new TIADS1x15Base()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _volt_blank(volt_blank) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 TurnerCyclops::~TurnerCyclops() {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -10,35 +10,80 @@
 
 
 #include "TurnerCyclops.h"
+#include "TIADS1x15.h"
+#include "ProcessorAnalog.h"
 #include <Adafruit_ADS1X15.h>
 
 
-// The constructor - need the power pin, the data pin, and the calibration info
-TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t adsChannel,
+// Primary constructor using AnalogVoltageBase abstraction
+TurnerCyclops::TurnerCyclops(int8_t             powerPin,
+                             AnalogVoltageBase* analogVoltageReader,
                              float conc_std, float volt_std, float volt_blank,
-                             uint8_t i2cAddress, uint8_t measurementsToAverage)
+                             uint8_t measurementsToAverage)
     : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
              CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
              powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
-      _adsChannel(adsChannel),
+      _analogVoltageReader(analogVoltageReader),
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _i2cAddress(i2cAddress) {}
+      _ownsVoltageReader(false) {}
+
+// Constructor that creates a TIADS1x15 object internally
+TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t adsChannel, float conc_std,
+                             float volt_std, float volt_blank,
+                             float voltageMultiplier, adsGain_t adsGain,
+                             uint8_t i2cAddress, uint8_t measurementsToAverage,
+                             float adsSupplyVoltage)
+    : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
+             CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
+             powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
+      _analogVoltageReader(nullptr),
+      _conc_std(conc_std),
+      _volt_std(volt_std),
+      _volt_blank(volt_blank),
+      _ownsVoltageReader(true) {
+    // Create a TIADS1x15 object for analog voltage reading
+    _analogVoltageReader =
+        new TIADS1x15(powerPin, adsChannel, voltageMultiplier, adsGain,
+                      i2cAddress, measurementsToAverage, adsSupplyVoltage);
+}
+
+// Constructor that creates a ProcessorAnalog object internally
+TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t dataPin, float conc_std,
+                             float volt_std, float volt_blank,
+                             float voltageMultiplier, float operatingVoltage,
+                             uint8_t measurementsToAverage)
+    : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
+             CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
+             powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
+      _analogVoltageReader(nullptr),
+      _conc_std(conc_std),
+      _volt_std(volt_std),
+      _volt_blank(volt_blank),
+      _ownsVoltageReader(true) {
+    // Create a ProcessorAnalog object for analog voltage reading
+    _analogVoltageReader =
+        new ProcessorAnalog(powerPin, dataPin, voltageMultiplier,
+                            operatingVoltage, measurementsToAverage);
+}
 // Destructor
-TurnerCyclops::~TurnerCyclops() {}
+TurnerCyclops::~TurnerCyclops() {
+    // Clean up owned voltage reader if created by legacy constructor
+    if (_ownsVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
 
 
 String TurnerCyclops::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_adsChannel);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation();
+    } else {
+        // Fallback for cases where voltage reader is not set
+        return F("TurnerCyclops_UnknownLocation");
+    }
 }
 
 
@@ -48,43 +93,13 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   calibResult = -9999;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-// Create an auxiliary ADC object
-// We create and set up the ADC object here so that each sensor using
-// the ADC may set the gain appropriately without effecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-
-    // Bump the gain up to 1x = +/- 4.096V range
-    // Sensor return range is 0-2.5V, but the next gain option is 2x which
-    // only allows up to 2.048V
-    ads.setGain(GAIN_ONE);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
+    // Ensure we have a valid voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(F("  No analog voltage reader configured!"));
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Print out the calibration curve
+    // Print out the calibration curve and check that it is valid
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
     const float epsilon = 1e-4f;  // tune to expected sensor precision
@@ -93,25 +108,22 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the ADC raw count
-    adcCounts = ads.readADC_SingleEnded(_adsChannel);
-    // Convert ADC raw counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"), adcCounts,
-           '=', adcVoltage);
+    bool  success     = false;
+    float adcVoltage  = -9999;
+    float calibResult = -9999;
 
-    // @todo Verify the voltage range for the Cyclops sensor
-    // Here we are using the range of the ADS when it is powered at 3.3V
-    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+    // Use the abstracted voltage reading method
+    success = _analogVoltageReader->readVoltageSingleEnded(adcVoltage);
+
+    if (success) {
         // Apply the unique calibration curve for the given sensor
         calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VOLTAGE_VAR_NUM, adcVoltage);
-        success = true;
     }
 
     // Return success value when finished

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -46,14 +46,11 @@ TurnerCyclops::~TurnerCyclops() {
 
 
 String TurnerCyclops::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
-            String(_dataPin);
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_Channel");
+    sensorLocation += String(_dataPin);
+    return sensorLocation;
 }
 
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -81,7 +81,11 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Read voltage using the AnalogVoltageBase interface
+    // Read the single-ended analog voltage using the AnalogVoltageBase
+    // interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
                                                            adcVoltage);
     if (success) {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -12,7 +12,6 @@
 #include "TurnerCyclops.h"
 #include "TIADS1x15.h"
 #include "ProcessorAnalog.h"
-#include <Adafruit_ADS1X15.h>
 
 
 // Primary constructor using AnalogVoltageBase abstraction
@@ -30,10 +29,10 @@ TurnerCyclops::TurnerCyclops(int8_t             powerPin,
       _ownsVoltageReader(false) {}
 
 // Constructor that creates a TIADS1x15 object internally
-TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t adsChannel, float conc_std,
-                             float volt_std, float volt_blank,
-                             float voltageMultiplier, adsGain_t adsGain,
+TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t adsChannel,
+                             float conc_std, float volt_std, float volt_blank,
                              uint8_t i2cAddress, uint8_t measurementsToAverage,
+                             float voltageMultiplier, adsGain_t adsGain,
                              float adsSupplyVoltage)
     : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
              CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
@@ -52,8 +51,8 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t adsChannel, float conc_std,
 // Constructor that creates a ProcessorAnalog object internally
 TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t dataPin, float conc_std,
                              float volt_std, float volt_blank,
-                             float voltageMultiplier, float operatingVoltage,
-                             uint8_t measurementsToAverage)
+                             uint8_t measurementsToAverage,
+                             float voltageMultiplier, float operatingVoltage)
     : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
              CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
              powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
@@ -124,6 +123,8 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VOLTAGE_VAR_NUM, adcVoltage);
+    } else {
+        MS_DBG(F("  Failed to read voltage from analog voltage reader"));
     }
 
     // Return success value when finished

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -28,7 +28,11 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t analogChannel,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -24,16 +24,11 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t analogChannel,
              CYCLOPS_INC_CALC_VARIABLES),
       _conc_std(conc_std),
       _volt_std(volt_std),
-      _volt_blank(volt_blank) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _volt_blank(volt_blank),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new TIADS1x15Base()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 TurnerCyclops::~TurnerCyclops() {

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -41,12 +41,9 @@ TurnerCyclops::~TurnerCyclops() {
 
 String TurnerCyclops::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
-            String(_dataPin);
+        return _analogVoltageReader->getAnalogLocation(_dataPin);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
-        sensorLocation += String(_dataPin);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -61,7 +61,6 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -79,8 +78,8 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
     // NOTE: All implementations of the AnalogVoltageBase class validate both
     // the input channel and the resulting voltage, so we can trust that a
     // successful read will give us a valid voltage value to work with.
-    success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
-                                                           adcVoltage);
+    bool success = _analogVoltageReader->readVoltageSingleEnded(_dataPin,
+                                                                adcVoltage);
     if (success) {
         // Apply the unique calibration curve for the given sensor
         float calibResult = (_conc_std / (_volt_std - _volt_blank)) *

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -28,11 +28,7 @@ TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t analogChannel,
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader     = new TIADS1x15Base();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;
@@ -74,8 +70,8 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999.0f;
+    bool  success    = false;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -41,11 +41,14 @@ TurnerCyclops::~TurnerCyclops() {
 
 
 String TurnerCyclops::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_Channel");
-    sensorLocation += String(_dataPin);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Channel") +
+            String(_dataPin);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Channel");
+        sensorLocation += String(_dataPin);
+        return sensorLocation;
+    }
 }
 
 

--- a/src/sensors/TurnerCyclops.cpp
+++ b/src/sensors/TurnerCyclops.cpp
@@ -10,79 +10,35 @@
 
 
 #include "TurnerCyclops.h"
-#include "TIADS1x15.h"
-#include "ProcessorAnalog.h"
+#include <Adafruit_ADS1X15.h>
 
 
-// Primary constructor using AnalogVoltageBase abstraction
-TurnerCyclops::TurnerCyclops(int8_t             powerPin,
-                             AnalogVoltageBase* analogVoltageReader,
-                             float conc_std, float volt_std, float volt_blank,
-                             uint8_t measurementsToAverage)
-    : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
-             CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
-             powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
-      _analogVoltageReader(analogVoltageReader),
-      _conc_std(conc_std),
-      _volt_std(volt_std),
-      _volt_blank(volt_blank),
-      _ownsVoltageReader(false) {}
-
-// Constructor that creates a TIADS1x15 object internally
+// The constructor - need the power pin, the data pin, and the calibration info
 TurnerCyclops::TurnerCyclops(int8_t powerPin, uint8_t adsChannel,
                              float conc_std, float volt_std, float volt_blank,
-                             uint8_t i2cAddress, uint8_t measurementsToAverage,
-                             float voltageMultiplier, adsGain_t adsGain,
-                             float adsSupplyVoltage)
+                             uint8_t i2cAddress, uint8_t measurementsToAverage)
     : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
              CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
              powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
-      _analogVoltageReader(nullptr),
+      _adsChannel(adsChannel),
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _ownsVoltageReader(true) {
-    // Create a TIADS1x15 object for analog voltage reading
-    _analogVoltageReader =
-        new TIADS1x15(powerPin, adsChannel, voltageMultiplier, adsGain,
-                      i2cAddress, measurementsToAverage, adsSupplyVoltage);
-}
-
-// Constructor that creates a ProcessorAnalog object internally
-TurnerCyclops::TurnerCyclops(int8_t powerPin, int8_t dataPin, float conc_std,
-                             float volt_std, float volt_blank,
-                             uint8_t measurementsToAverage,
-                             float voltageMultiplier, float operatingVoltage)
-    : Sensor("TurnerCyclops", CYCLOPS_NUM_VARIABLES, CYCLOPS_WARM_UP_TIME_MS,
-             CYCLOPS_STABILIZATION_TIME_MS, CYCLOPS_MEASUREMENT_TIME_MS,
-             powerPin, -1, measurementsToAverage, CYCLOPS_INC_CALC_VARIABLES),
-      _analogVoltageReader(nullptr),
-      _conc_std(conc_std),
-      _volt_std(volt_std),
-      _volt_blank(volt_blank),
-      _ownsVoltageReader(true) {
-    // Create a ProcessorAnalog object for analog voltage reading
-    _analogVoltageReader =
-        new ProcessorAnalog(powerPin, dataPin, voltageMultiplier,
-                            operatingVoltage, measurementsToAverage);
-}
+      _i2cAddress(i2cAddress) {}
 // Destructor
-TurnerCyclops::~TurnerCyclops() {
-    // Clean up owned voltage reader if created by legacy constructor
-    if (_ownsVoltageReader && _analogVoltageReader != nullptr) {
-        delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
-    }
-}
+TurnerCyclops::~TurnerCyclops() {}
 
 
 String TurnerCyclops::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation();
-    } else {
-        // Fallback for cases where voltage reader is not set
-        return F("TurnerCyclops_UnknownLocation");
-    }
+#ifndef MS_USE_ADS1015
+    String sensorLocation = F("ADS1115_0x");
+#else
+    String sensorLocation = F("ADS1015_0x");
+#endif
+    sensorLocation += String(_i2cAddress, HEX);
+    sensorLocation += F("_Channel");
+    sensorLocation += String(_adsChannel);
+    return sensorLocation;
 }
 
 
@@ -92,13 +48,43 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Ensure we have a valid voltage reader
-    if (_analogVoltageReader == nullptr) {
-        MS_DBG(F("  No analog voltage reader configured!"));
+    bool    success     = false;
+    int16_t adcCounts   = -9999;
+    float   adcVoltage  = -9999;
+    float   calibResult = -9999;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+// Create an auxiliary ADC object
+// We create and set up the ADC object here so that each sensor using
+// the ADC may set the gain appropriately without effecting others.
+#ifndef MS_USE_ADS1015
+    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
+#else
+    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
+#endif
+    // ADS Library default settings:
+    //  - TI ADS1115 (16 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 128 samples per second (8ms conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+    //  - TI ADS1015 (12 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 1600 samples per second (625µs conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+
+    // Bump the gain up to 1x = +/- 4.096V range
+    // Sensor return range is 0-2.5V, but the next gain option is 2x which
+    // only allows up to 2.048V
+    ads.setGain(GAIN_ONE);
+    // Begin ADC, returns true if anything was detected at the address
+    if (!ads.begin(_i2cAddress)) {
+        MS_DBG(F("  ADC initialization failed at 0x"),
+               String(_i2cAddress, HEX));
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Print out the calibration curve and check that it is valid
+    // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
     const float epsilon = 1e-4f;  // tune to expected sensor precision
@@ -107,24 +93,25 @@ bool TurnerCyclops::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999;
-    float calibResult = -9999;
+    // Read Analog to Digital Converter (ADC)
+    // Taking this reading includes the 8ms conversion delay.
+    // Measure the ADC raw count
+    adcCounts = ads.readADC_SingleEnded(_adsChannel);
+    // Convert ADC raw counts value to voltage (V)
+    adcVoltage = ads.computeVolts(adcCounts);
+    MS_DBG(F("  ads.readADC_SingleEnded("), _adsChannel, F("):"), adcCounts,
+           '=', adcVoltage);
 
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-    // Use the abstracted voltage reading method
-    success = _analogVoltageReader->readVoltageSingleEnded(adcVoltage);
-
-    if (success) {
+    // @todo Verify the voltage range for the Cyclops sensor
+    // Here we are using the range of the ADS when it is powered at 3.3V
+    if (adcVoltage < 3.6 && adcVoltage > -0.3) {
         // Apply the unique calibration curve for the given sensor
         calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
         MS_DBG(F("  calibResult:"), calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(CYCLOPS_VOLTAGE_VAR_NUM, adcVoltage);
-    } else {
-        MS_DBG(F("  Failed to read voltage from analog voltage reader"));
+        success = true;
     }
 
     // Return success value when finished

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -347,7 +347,7 @@ class TurnerCyclops : public Sensor {
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
      * internally create and own an analog voltage reader.  For backward
-     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
      */

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -165,7 +165,9 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
+
+// Forward declaration
+class AnalogVoltageBase;
 
 // Sensor Specific Defines
 /** @ingroup sensor_cyclops */

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -367,11 +367,11 @@ class TurnerCyclops : public Sensor {
      * settings.
      */
     float _volt_blank;
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -130,6 +130,8 @@
  * @section sensor_cyclops_flags Build flags
  * - ```-D MS_USE_ADS1015```
  *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
+ * - `-D CYCLOPS_CALIBRATION_EPSILON=x.xf`
+ *     - Sets the tolerance for validating the calibration values
  *
  * @section sensor_cyclops_ctor Sensor Constructor
  * {{ @ref TurnerCyclops::TurnerCyclops }}
@@ -170,6 +172,27 @@
 // Sensor Specific Defines
 /** @ingroup sensor_cyclops */
 /**@{*/
+
+/**
+ * @anchor sensor_cyclops_config
+ * @name Configuration Parameters
+ * Configuration parameters for the Turner Cyclops-7F sensor
+ */
+/**@{*/
+/**
+ * @brief Minimum voltage difference threshold for calibration validation
+ *
+ * This epsilon value is used to validate that the calibration standard voltage
+ * and blank voltage are sufficiently different to provide a meaningful
+ * calibration. If the absolute difference between these voltages is less than
+ * this threshold, the calibration is considered invalid.
+ *
+ * @note This should be tuned to match the expected precision of the sensor
+ * and ADC system. A value of 1e-4f (0.0001V or 0.1mV) is appropriate for
+ * most high-precision ADC configurations.
+ */
+#define CYCLOPS_CALIBRATION_EPSILON 1e-4f
+/**@}*/
 
 /**
  * @anchor sensor_cyclops_var_counts
@@ -305,7 +328,8 @@ class TurnerCyclops : public Sensor {
      * measurements.  The significance of the channel number depends on the
      * specific AnalogVoltageBase implementation used for voltage readings. For
      * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
-     * the sensor is connected to.
+     * the sensor is connected to.  Negative or invalid channel numbers are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration.  The concentration units should be the same as the
      * final measuring units.

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -154,9 +154,6 @@
 // Include the debugging config
 #include "ModSensorDebugConfig.h"
 
-// Include known processor settings for default operating voltage
-#include "sensors/KnownProcessors.h"
-
 // Define the print label[s] for the debugger
 #ifdef MS_TURNERCYCLOPS_DEBUG
 #define MS_DEBUGGING_STD "TurnerCyclops"
@@ -170,8 +167,6 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
-#include <Adafruit_ADS1X15.h>
 
 // Sensor Specific Defines
 /** @ingroup sensor_cyclops */
@@ -311,9 +306,8 @@ class TurnerCyclops : public Sensor {
      * assumes the ADS is powered with 3.3V.
      * - The Cyclops-7F itself requires a 3-15V power supply, which can be
      * turned off between measurements.
-     * @param analogVoltageReader Pointer to an AnalogVoltageBase object (e.g.,
-     * TIADS1x15 or ProcessorAnalog) that will be used to read the analog
-     * voltage from the sensor
+     * @param adsChannel The analog data channel _on the TI ADS1115_ that the
+     * Cyclops is connected to (0-3).
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration.  The concentration units should be the same as the
      * final measuring units.
@@ -323,53 +317,16 @@ class TurnerCyclops : public Sensor {
      * @param volt_blank The voltage (in volts) measured for a blank.  This
      * voltage should be the final voltage *after* accounting for any voltage
      * dividers or gain settings.
+     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
+     * = GND)
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      */
-    TurnerCyclops(int8_t powerPin, AnalogVoltageBase* analogVoltageReader,
-                  float conc_std, float volt_std, float volt_blank,
-                  uint8_t measurementsToAverage = 1);
-
-    /**
-     * @brief Construct a new Turner Cyclops object using TIADS1x15 - creates
-     * an internal TIADS1x15 object for reading analog voltages
-     *
-     * @param powerPin The pin on the mcu controlling power to the Cyclops-7F
-     * @param adsChannel The ADS channel (0-3) connected to the sensor
-     * @param conc_std The concentration of the standard for calibration
-     * @param volt_std The voltage measured for the conc_std
-     * @param volt_blank The voltage measured for a blank
-     * @param voltageMultiplier The voltage multiplier for voltage dividers
-     * @param adsGain The internal gain setting of the ADS1x15
-     * @param i2cAddress The I2C address of the ADS1x15
-     * @param measurementsToAverage Number of measurements to average
-     * @param adsSupplyVoltage The power supply voltage for the ADS1x15
-     */
     TurnerCyclops(int8_t powerPin, uint8_t adsChannel, float conc_std,
                   float volt_std, float volt_blank,
                   uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
-                  uint8_t measurementsToAverage = 1,
-                  float voltageMultiplier = 1.0, adsGain_t adsGain = GAIN_ONE,
-                  float adsSupplyVoltage = OPERATING_VOLTAGE);
-
-    /**
-     * @brief Construct a new Turner Cyclops object using ProcessorAnalog -
-     * creates an internal ProcessorAnalog object for reading analog voltages
-     *
-     * @param powerPin The pin on the mcu controlling power to the Cyclops-7F
-     * @param dataPin The processor ADC pin connected to the sensor
-     * @param conc_std The concentration of the standard for calibration
-     * @param volt_std The voltage measured for the conc_std
-     * @param volt_blank The voltage measured for a blank
-     * @param voltageMultiplier The voltage multiplier for voltage dividers
-     * @param operatingVoltage The processor's operating voltage
-     * @param measurementsToAverage Number of measurements to average
-     */
-    TurnerCyclops(int8_t powerPin, int8_t dataPin, float conc_std,
-                  float volt_std, float volt_blank,
-                  uint8_t measurementsToAverage = 1, float voltageMultiplier,
-                  float operatingVoltage        = OPERATING_VOLTAGE);
+                  uint8_t measurementsToAverage = 1);
     /**
      * @brief Destroy the Turner Cyclops object
      */
@@ -381,9 +338,9 @@ class TurnerCyclops : public Sensor {
 
  private:
     /**
-     * @brief Internal reference to the analog voltage reading object
+     * @brief Internal reference to the ADS channel number of the Turner Cyclops
      */
-    AnalogVoltageBase* _analogVoltageReader;
+    uint8_t _adsChannel;
     /**
      * @brief The concentration of the standard used for a 1-point sensor
      * calibration.  The concentration units should be the same as the final
@@ -403,11 +360,9 @@ class TurnerCyclops : public Sensor {
      */
     float _volt_blank;
     /**
-     * @brief Internal flag to indicate if a _analogVoltageReader was created
-     * when this object was instantiated so that it can be properly deleted in
-     * the destructor if needed.
+     * @brief Internal reference to the I2C address of the TI-ADS1x15
      */
-    bool _ownsVoltageReader;
+    uint8_t _i2cAddress;
 };
 
 

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -193,7 +193,7 @@ class AnalogVoltageBase;
  * most high-precision ADC configurations.
  */
 #define CYCLOPS_CALIBRATION_EPSILON 1e-4f
-#endif  // !defined(CYCLOPS_CALIBRATION_EPSILON) || defined(DOXYGEN)
+#endif
 /**@}*/
 
 /**

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -179,6 +179,7 @@
  * Configuration parameters for the Turner Cyclops-7F sensor
  */
 /**@{*/
+#if !defined(CYCLOPS_CALIBRATION_EPSILON) || defined(DOXYGEN)
 /**
  * @brief Minimum voltage difference threshold for calibration validation
  *
@@ -192,6 +193,7 @@
  * most high-precision ADC configurations.
  */
 #define CYCLOPS_CALIBRATION_EPSILON 1e-4f
+#endif  // !defined(CYCLOPS_CALIBRATION_EPSILON) || defined(DOXYGEN)
 /**@}*/
 
 /**

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -350,6 +350,14 @@ class TurnerCyclops : public Sensor {
      * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
+     *
+     * @warning In library versions 0.37.0 and earlier, a different constructor
+     * was used that the I2C address of the ADS1x15 was an optional input
+     * parameter which came *before* the optional input parameter for the number
+     * of measurements to average.  The input parameter for the I2C address has
+     * been *removed* and the input for the number of measurements to average
+     * has been moved up in the order!  Please update your code to prevent a
+     * compiler error or a silent reading error.
      */
     TurnerCyclops(int8_t powerPin, int8_t analogChannel, float conc_std,
                   float volt_std, float volt_blank,

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -200,16 +200,6 @@
 /**@}*/
 
 /**
- * @anchor sensor_cyclops_config
- * @name Configuration Defines
- * Defines to help configure the address of the ADD used by the Cyclops
- */
-/**@{*/
-/// @brief The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
-/**@}*/
-
-/**
  * @anchor sensor_cyclops_timing
  * @name Sensor Timing
  * The sensor timing for an Cyclops-7F
@@ -358,7 +348,7 @@ class TurnerCyclops : public Sensor {
      */
     TurnerCyclops(int8_t powerPin, uint8_t adsChannel, float conc_std,
                   float volt_std, float volt_blank,
-                  uint8_t i2cAddress            = ADS1115_ADDRESS,
+                  uint8_t i2cAddress            = MS_DEFAULT_ADS1X15_ADDRESS,
                   uint8_t measurementsToAverage = 1,
                   float voltageMultiplier = 1.0, adsGain_t adsGain = GAIN_ONE,
                   float adsSupplyVoltage = OPERATING_VOLTAGE);

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -104,19 +104,19 @@
  *
  * | ID  | Variable                     | Units                               |
  * | --- | ---------------------------- | ----------------------------------- |
+ * | U   | TurnerCyclops_CDOM           | parts per billion (ppb)             |
  * | C   | TurnerCyclops_Chlorophyll    | micrograms per Liter (µg/L)         |
- * | R   | TurnerCyclops_Rhodamine      | parts per billion (ppb)             |
+ * | D   | TurnerCyclops_RedChlorophyll | micrograms per Liter (µg/L)         |
  * | F   | TurnerCyclops_Fluorescein    | parts per billion (ppb)             |
+ * | O   | TurnerCyclops_CrudeOil       | parts per billion (ppb)             |
+ * | G   | TurnerCyclops_BTEX           | parts per million (ppm)             |
+ * | B   | TurnerCyclops_Brighteners    | parts per billion (ppb)             |
  * | P   | TurnerCyclops_Phycocyanin    | parts per billion (ppb)             |
  * | E   | TurnerCyclops_Phycoerythrin  | parts per billion (ppb)             |
- * | U   | TurnerCyclops_CDOM           | parts per billion (ppb)             |
- * | O   | TurnerCyclops_CrudeOil       | parts per billion (ppb)             |
- * | B   | TurnerCyclops_Brighteners    | parts per billion (ppb)             |
- * | T   | TurnerCyclops_Turbidity      | nephelometric turbidity units (NTU) |
  * | A   | TurnerCyclops_PTSA           | parts per billion (ppb)             |
- * | G   | TurnerCyclops_BTEX           | parts per million (ppm)             |
+ * | R   | TurnerCyclops_Rhodamine      | parts per billion (ppb)             |
  * | L   | TurnerCyclops_Tryptophan     | parts per billion (ppb)             |
- * | D   | TurnerCyclops_RedChlorophyll | micrograms per Liter (µg/L)         |
+ * | T   | TurnerCyclops_Turbidity      | nephelometric turbidity units (NTU) |
  *
  * Before applying any calibration, the analog output from the Cyclops-7F
  * must be converted into a high resolution digital signal.  See the
@@ -293,9 +293,9 @@ class TurnerCyclops : public Sensor {
      * @brief Construct a new Turner Cyclops object - need the power pin, the
      * analog data channel, and the calibration info.
      *
-     * By default, this constructor will use a new TIADS1x15Base object with all
-     * default values for voltage readings, but a pointer to a custom
-     * AnalogVoltageBase object can be passed in if desired.
+     * By default, this constructor will internally create a default
+     * AnalogVoltageBase implementation for voltage readings, but a pointer to
+     * a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @param powerPin The pin on the mcu controlling power to the Cyclops-7F
      * Use -1 if it is continuously powered.

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -9,8 +9,6 @@
  * TurnerCyclops_Turbidity and TurnerCyclops_Voltage.
  *
  * These are used for the Turner Scientific Cyclops-7F.
- *
- * This depends on the Adafruit ADS1X15 v2.x library
  */
 /* clang-format off */
 /**
@@ -291,8 +289,6 @@
 /* clang-format on */
 class TurnerCyclops : public Sensor {
  public:
-    // The constructor - need the power pin, the ADS1X15 data channel, and the
-    // calibration info
     /**
      * @brief Construct a new Turner Cyclops object - need the power pin, the
      * analog data channel, and the calibration info.
@@ -324,7 +320,9 @@ class TurnerCyclops : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.
+     * internally create and own a TIADS1x15Base instance.  If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      */
     TurnerCyclops(int8_t powerPin, uint8_t analogChannel, float conc_std,
                   float volt_std, float volt_blank,

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -368,10 +368,10 @@ class TurnerCyclops : public Sensor {
      */
     float _volt_blank;
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -324,7 +324,7 @@ class TurnerCyclops : public Sensor {
      * pointer is supplied, the caller retains ownership and must ensure its
      * lifetime exceeds that of this object.
      */
-    TurnerCyclops(int8_t powerPin, uint8_t analogChannel, float conc_std,
+    TurnerCyclops(int8_t powerPin, int8_t analogChannel, float conc_std,
                   float volt_std, float volt_blank,
                   uint8_t            measurementsToAverage = 1,
                   AnalogVoltageBase* analogVoltageReader   = nullptr);

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -301,21 +301,15 @@ class TurnerCyclops : public Sensor {
      * default values for voltage readings, but a pointer to a custom
      * AnalogVoltageBase object can be passed in if desired.
      *
-     * @note ModularSensors only supports connecting the ADS1x15 to the primary
-     * hardware I2C instance defined in the Arduino core.  Connecting the ADS to
-     * a secondary hardware or software I2C instance is *not* supported!
-     *
      * @param powerPin The pin on the mcu controlling power to the Cyclops-7F
      * Use -1 if it is continuously powered.
-     * - The ADS1x15 requires an input voltage of 2.0-5.5V, but this library
-     * assumes the ADS is powered with 3.3V.
      * - The Cyclops-7F itself requires a 3-15V power supply, which can be
      * turned off between measurements.
-     * @param analogChannel The analog data channel or processor pin that the
-     * OBS3 is connected to.  The significance of the channel number depends on
-     * the specific AnalogVoltageBase implementation used for voltage readings.
-     * For example, with the TI ADS1x15, this would be the ADC channel (0-3)
-     * that the sensor is connected to.
+     * @param analogChannel The analog data channel or processor pin for voltage
+     * measurements.  The significance of the channel number depends on the
+     * specific AnalogVoltageBase implementation used for voltage readings. For
+     * example, with the TI ADS1x15, this would be the ADC channel (0-3) that
+     * the sensor is connected to.
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration.  The concentration units should be the same as the
      * final measuring units.
@@ -329,8 +323,8 @@ class TurnerCyclops : public Sensor {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new TIADS1x15Base
-     * object.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a TIADS1x15Base instance.
      */
     TurnerCyclops(int8_t powerPin, uint8_t analogChannel, float conc_std,
                   float volt_std, float volt_blank,
@@ -340,6 +334,15 @@ class TurnerCyclops : public Sensor {
      * @brief Destroy the Turner Cyclops object
      */
     ~TurnerCyclops();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    TurnerCyclops(const TurnerCyclops&)            = delete;
+    TurnerCyclops& operator=(const TurnerCyclops&) = delete;
+
+    // Delete move constructor and move assignment operator
+    TurnerCyclops(TurnerCyclops&&)            = delete;
+    TurnerCyclops& operator=(TurnerCyclops&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -295,10 +295,11 @@ class TurnerCyclops : public Sensor {
     // calibration info
     /**
      * @brief Construct a new Turner Cyclops object - need the power pin, the
-     * analog data channel, and the calibration info.  By default, this
-     * constructor will use a new TIADS1x15Base object with all default values
-     * for voltage readings, but a pointer to a custom AnalogVoltageBase object
-     * can be passed in if desired.
+     * analog data channel, and the calibration info.
+     *
+     * By default, this constructor will use a new TIADS1x15Base object with all
+     * default values for voltage readings, but a pointer to a custom
+     * AnalogVoltageBase object can be passed in if desired.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core.  Connecting the ADS to

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -379,6 +379,8 @@ class TurnerCyclops : public Sensor {
 
     String getSensorLocation(void) override;
 
+    bool setup(void) override;
+
     bool addSingleMeasurementResult(void) override;
 
  private:

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -346,9 +346,10 @@ class TurnerCyclops : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.  If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      */
     TurnerCyclops(int8_t powerPin, int8_t analogChannel, float conc_std,
                   float volt_std, float volt_blank,

--- a/src/sensors/TurnerCyclops.h
+++ b/src/sensors/TurnerCyclops.h
@@ -120,7 +120,7 @@
  *
  * Before applying any calibration, the analog output from the Cyclops-7F
  * must be converted into a high resolution digital signal.  See the
- * [ADS1115 page](@ref analog_group) for details on the conversion.
+ * [analog group](@ref analog_group) for details on supported ADC backends.
  *
  * @section sensor_cyclops_datasheet Sensor Datasheet
  * - [Main Information Page](https://www.turnerdesigns.com/cyclops-7f-submersible-fluorometer)
@@ -128,8 +128,6 @@
  * - [Manual](http://docs.turnerdesigns.com/t2/doc/manuals/998-2100.pdf)
  *
  * @section sensor_cyclops_flags Build flags
- * - ```-D MS_USE_ADS1015```
- *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
  * - `-D CYCLOPS_CALIBRATION_EPSILON=x.xf`
  *     - Sets the tolerance for validating the calibration values
  *

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -50,12 +50,17 @@ TurnerTurbidityPlus::~TurnerTurbidityPlus() {
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        return _analogVoltageReader->getSensorLocation() + F("_Diff_") +
-            String(_dataPin) + F("_") + String(_analogReferenceChannel);
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
     } else {
         String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin) + F("_") +
-            String(_analogReferenceChannel);
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
         return sensorLocation;
     }
 }

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -27,11 +27,15 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _analogReferenceChannel(analogReferenceChannel),
-      // If no analog voltage reader was provided, create a default one
-      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
-                                               : new TIADS1x15Base()),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
+      _analogReferenceChannel(analogReferenceChannel) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
 
 // Destructor
 TurnerTurbidityPlus::~TurnerTurbidityPlus() {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -30,12 +30,8 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _analogReferenceChannel(analogReferenceChannel) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = new TIADS1x15Base();
-        if (_analogVoltageReader != nullptr) {
-            _ownsAnalogVoltageReader = true;
-        } else {
-            _ownsAnalogVoltageReader = false;
-        }
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -50,7 +50,7 @@ String TurnerTurbidityPlus::getSensorLocation(void) {
         return _analogVoltageReader->getAnalogLocation(_dataPin,
                                                        _analogReferenceChannel);
     } else {
-        return String("Unknown_AnalogVoltageReader");
+        return String(F("Unknown_AnalogVoltageReader"));
     }
 }
 
@@ -113,8 +113,7 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
-    const float epsilon = 1e-4f;  // tune to expected sensor precision
-    if (fabs(_volt_std - _volt_blank) < epsilon) {
+    if (fabsf(_volt_std - _volt_blank) < TURBIDITY_PLUS_CALIBRATION_EPSILON) {
         MS_DBG(F("Invalid calibration: point voltage equals blank voltage"));
         return bumpMeasurementAttemptCount(false);
     }

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -30,8 +30,12 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _analogReferenceChannel(analogReferenceChannel) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
+        _analogVoltageReader = new TIADS1x15Base();
+        if (_analogVoltageReader != nullptr) {
+            _ownsAnalogVoltageReader = true;
+        } else {
+            _ownsAnalogVoltageReader = false;
+        }
     } else {
         _analogVoltageReader     = analogVoltageReader;
         _ownsAnalogVoltageReader = false;

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -111,10 +111,6 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    float adcVoltage = -9999.0f;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
            F(".  "), _volt_blank, F("V blank."));
@@ -123,6 +119,10 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         MS_DBG(F("Invalid calibration: point voltage equals blank voltage"));
         return bumpMeasurementAttemptCount(false);
     }
+
+    float adcVoltage = -9999.0f;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Read the differential voltage using the AnalogVoltageBase interface.
     // NOTE: All implementations of the AnalogVoltageBase class validate both

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -9,41 +9,55 @@
 
 
 #include "TurnerTurbidityPlus.h"
+#include "TIADS1x15.h"
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
 TurnerTurbidityPlus::TurnerTurbidityPlus(
-    int8_t powerPin, int8_t wiperTriggerPin, ttp_adsDiffMux_t adsDiffMux,
-    float conc_std, float volt_std, float volt_blank, uint8_t i2cAddress,
-    adsGain_t PGA_gain, uint8_t measurementsToAverage,
-    float voltageDividerFactor)
+    int8_t powerPin, int8_t wiperTriggerPin, int8_t analogChannel,
+    int8_t analogReferenceChannel, float conc_std, float volt_std,
+    float volt_blank, uint8_t measurementsToAverage,
+    AnalogVoltageBase* analogVoltageReader)
     : Sensor("TurnerTurbidityPlus", TURBIDITY_PLUS_NUM_VARIABLES,
              TURBIDITY_PLUS_WARM_UP_TIME_MS,
              TURBIDITY_PLUS_STABILIZATION_TIME_MS,
-             TURBIDITY_PLUS_MEASUREMENT_TIME_MS, powerPin, -1,
+             TURBIDITY_PLUS_MEASUREMENT_TIME_MS, powerPin, analogChannel,
              measurementsToAverage),
       _wiperTriggerPin(wiperTriggerPin),
-      _adsDiffMux(adsDiffMux),
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _i2cAddress(i2cAddress),
-      _PGA_gain(PGA_gain),
-      _voltageDividerFactor(voltageDividerFactor) {}
+      _analogReferenceChannel(analogReferenceChannel) {
+    // If no analog voltage reader was provided, create a default one
+    if (analogVoltageReader == nullptr) {
+        _analogVoltageReader     = new TIADS1x15Base();
+        _ownsAnalogVoltageReader = true;
+    } else {
+        _analogVoltageReader     = analogVoltageReader;
+        _ownsAnalogVoltageReader = false;
+    }
+}
+
 // Destructor
-TurnerTurbidityPlus::~TurnerTurbidityPlus() {}
+TurnerTurbidityPlus::~TurnerTurbidityPlus() {
+    // Clean up the analog voltage reader if we created it
+    if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
+        delete _analogVoltageReader;
+        _analogVoltageReader = nullptr;
+    }
+}
 
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
-#ifndef MS_USE_ADS1015
-    String sensorLocation = F("ADS1115_0x");
-#else
-    String sensorLocation = F("ADS1015_0x");
-#endif
-    sensorLocation += String(_i2cAddress, HEX);
-    sensorLocation += F("_adsDiffMux");
-    sensorLocation += String(_adsDiffMux);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        return _analogVoltageReader->getSensorLocation() + F("_Diff_") +
+            String(_dataPin) + F("_") + String(_analogReferenceChannel);
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
+        sensorLocation += String(_dataPin) + F("_") +
+            String(_analogReferenceChannel);
+        return sensorLocation;
+    }
 }
 
 void TurnerTurbidityPlus::runWiper() {
@@ -80,13 +94,13 @@ bool TurnerTurbidityPlus::wake(void) {
 void TurnerTurbidityPlus::powerDown(void) {
     // Set the wiper trigger pin LOW to avoid power drain.
     digitalWrite(_wiperTriggerPin, LOW);
-    return Sensor::powerDown();
+    Sensor::powerDown();
 }
 
 void TurnerTurbidityPlus::powerUp(void) {
     // Set the wiper trigger pin HIGH to prepare for wiping.
     digitalWrite(_wiperTriggerPin, HIGH);
-    return Sensor::powerUp();
+    Sensor::powerUp();
 }
 
 bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
@@ -95,38 +109,18 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool    success     = false;
-    int16_t adcCounts   = -9999;
-    float   adcVoltage  = -9999;
-    float   calibResult = -9999;
-
-    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
-
-// Create an auxiliary ADC object
-// We create and set up the ADC object here so that each sensor using the ADC
-// may set the gain appropriately without affecting others.
-#ifndef MS_USE_ADS1015
-    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
-#else
-    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
-#endif
-    // ADS Library default settings:
-    //  - TI ADS1115 (16 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 128 samples per second (8ms conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-    //  - TI ADS1015 (12 bit)
-    //    - single-shot mode (powers down between conversions)
-    //    - 1600 samples per second (625µs conversion time)
-    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
-
-    ads.setGain(_PGA_gain);
-    // Begin ADC, returns true if anything was detected at the address
-    if (!ads.begin(_i2cAddress)) {
-        MS_DBG(F("  ADC initialization failed at 0x"),
-               String(_i2cAddress, HEX));
+    // Check if we have a valid analog voltage reader
+    if (_analogVoltageReader == nullptr) {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader available"));
         return bumpMeasurementAttemptCount(false);
     }
+
+    bool  success     = false;
+    float adcVoltage  = -9999;
+    float calibResult = -9999;
+
+    MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
@@ -137,53 +131,11 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Read Analog to Digital Converter (ADC)
-    // Taking this reading includes the 8ms conversion delay.
-    // Measure the voltage differential across the two voltage pins
-    switch (_adsDiffMux) {
-        case DIFF_MUX_0_1: {
-            adcCounts = ads.readADC_Differential_0_1();
-            break;
-        }
-        case DIFF_MUX_0_3: {
-            adcCounts = ads.readADC_Differential_0_3();
-            break;
-        }
-        case DIFF_MUX_1_3: {
-            adcCounts = ads.readADC_Differential_1_3();
-            break;
-        }
-        case DIFF_MUX_2_3: {
-            adcCounts = ads.readADC_Differential_2_3();
-            break;
-        }
-        default: {
-            MS_DBG(F("  Invalid differential mux configuration"));
-            return bumpMeasurementAttemptCount(false);
-        }
-    }
-    // Convert ADC counts value to voltage (V)
-    adcVoltage = ads.computeVolts(adcCounts);
-    MS_DBG(F("  ads.readADC_Differential("), _adsDiffMux, F("):"), adcCounts,
-           '=', String(adcVoltage, 3));
+    // Read differential voltage using the AnalogVoltageBase interface
+    success = _analogVoltageReader->readVoltageDifferential(
+        _dataPin, _analogReferenceChannel, adcVoltage);
 
-    // The ADS1X15 outputs a max value corresponding to Vcc + 0.3V
-    if (adcVoltage < 5.3 && adcVoltage > -0.3) {
-        if (_voltageDividerFactor > 0) {
-            // Apply voltage divider factor if using a voltage divider to step
-            // down the voltage
-            adcVoltage *= _voltageDividerFactor;
-        } else {
-            // If the voltage divider factor is not set to a positive value,
-            // print a debugging message and continue without applying a voltage
-            // divider factor.  We continue because the voltage divider factor
-            // can be easily fixed in post-processing if the raw voltage value
-            // is available, and we don't want to lose the voltage reading if
-            // the voltage divider factor is just set incorrectly.
-            MS_DBG(F("  Invalid voltage divider factor:"),
-                   _voltageDividerFactor,
-                   F("Voltage divider will be ignored."));
-        }
+    if (success) {
         // Apply the unique calibration curve for the given sensor
         calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
@@ -191,7 +143,8 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         verifyAndAddMeasurementResult(TURBIDITY_PLUS_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(TURBIDITY_PLUS_VOLTAGE_VAR_NUM,
                                       adcVoltage);
-        success = true;
+    } else {
+        MS_DBG(F("  Failed to read differential voltage from analog reader"));
     }
 
     // Return success value when finished

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -52,12 +52,12 @@ void TurnerTurbidityPlus::runWiper() {
     // without pausing for ~540ms between them.
     MS_DBG(F("Turn TurbidityPlus wiper on"), getSensorLocation());
     digitalWrite(_wiperTriggerPin, LOW);
-    delay(50);
+    delay(TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS);
     digitalWrite(_wiperTriggerPin, HIGH);
     // It takes ~7.5 sec for a rotation to complete. Wait for that to finish
     // before continuing, otherwise the sensor will get powered off before wipe
     // completes, and any reading taken during wiper cycle is invalid.
-    delay(8000);
+    delay(TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS);
     MS_DBG(F("TurbidityPlus wiper cycle should be finished"));
 }
 
@@ -80,13 +80,13 @@ bool TurnerTurbidityPlus::wake(void) {
 void TurnerTurbidityPlus::powerDown(void) {
     // Set the wiper trigger pin LOW to avoid power drain.
     digitalWrite(_wiperTriggerPin, LOW);
-    return TIADS1x15::powerDown();
+    TIADS1x15::powerDown();
 }
 
 void TurnerTurbidityPlus::powerUp(void) {
     // Set the wiper trigger pin HIGH to prepare for wiping.
     digitalWrite(_wiperTriggerPin, HIGH);
-    return TIADS1x15::powerUp();
+    TIADS1x15::powerUp();
 }
 
 bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -121,9 +121,8 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999;
-    float calibResult = -9999;
+    bool  success    = false;
+    float adcVoltage = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 
@@ -142,12 +141,12 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
 
     if (success) {
         // Apply the unique calibration curve for the given sensor
-        calibResult = (_conc_std / (_volt_std - _volt_blank)) *
+        float calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
         MS_DBG(F("  calibResult:"), String(calibResult, 3));
-        verifyAndAddMeasurementResult(TURBIDITY_PLUS_VAR_NUM, calibResult);
         verifyAndAddMeasurementResult(TURBIDITY_PLUS_VOLTAGE_VAR_NUM,
                                       adcVoltage);
+        verifyAndAddMeasurementResult(TURBIDITY_PLUS_VAR_NUM, calibResult);
     } else {
         MS_DBG(F("  Failed to read differential voltage from analog reader"));
     }

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -29,7 +29,11 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
     _warmUpTime_ms        = TURBIDITY_PLUS_WARM_UP_TIME_MS;
     _stabilizationTime_ms = TURBIDITY_PLUS_STABILIZATION_TIME_MS;
     _measurementTime_ms   = TURBIDITY_PLUS_MEASUREMENT_TIME_MS;
-    // Note: _numReturnedValues and _sensorName are set in the parent class
+    // Override variable counts from parent class defaults
+    _numReturnedValues = TURBIDITY_PLUS_NUM_VARIABLES;
+    _incCalcValues     = TURBIDITY_PLUS_INC_CALC_VARIABLES;
+    // Set the sensor name
+    _sensorName = "TurnerTurbidityPlus";
 }
 // Destructor
 TurnerTurbidityPlus::~TurnerTurbidityPlus() {}
@@ -107,8 +111,7 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
     }
 
     // Use the TIADS1x15 differential voltage reading function
-    // Note: Voltage multiplier/divider is automatically applied by the parent
-    // class
+    // The voltage multiplier and gain settings are handled by the parent class
     if (readVoltageDifferential(adcVoltage)) {
         MS_DBG(F("  Differential voltage (after voltage multiplier):"),
                String(adcVoltage, 3), F("V"));

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -44,13 +44,20 @@ TurnerTurbidityPlus::~TurnerTurbidityPlus() {
 
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
-    // NOTE: The constructor guarantees that _analogVoltageReader is not null
-    String sensorLocation = _analogVoltageReader->getSensorLocation();
-    sensorLocation += F("_Diff_");
-    sensorLocation += String(_dataPin);
-    sensorLocation += F("_");
-    sensorLocation += String(_analogReferenceChannel);
-    return sensorLocation;
+    if (_analogVoltageReader != nullptr) {
+        String sensorLocation = _analogVoltageReader->getSensorLocation();
+        sensorLocation += F("_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
+    } else {
+        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
+        sensorLocation += String(_dataPin);
+        sensorLocation += F("_");
+        sensorLocation += String(_analogReferenceChannel);
+        return sensorLocation;
+    }
 }
 
 void TurnerTurbidityPlus::runWiper() {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -44,18 +44,10 @@ TurnerTurbidityPlus::~TurnerTurbidityPlus() {
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
     if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
+        return _analogVoltageReader->getAnalogLocation(_dataPin,
+                                                       _analogReferenceChannel);
     } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
+        return String("Unknown_AnalogVoltageReader");
     }
 }
 

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -128,7 +128,10 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Read differential voltage using the AnalogVoltageBase interface
+    // Read the differential voltage using the AnalogVoltageBase interface.
+    // NOTE: All implementations of the AnalogVoltageBase class validate both
+    // the input channel and the resulting voltage, so we can trust that a
+    // successful read will give us a valid voltage value to work with.
     success = _analogVoltageReader->readVoltageDifferential(
         _dataPin, _analogReferenceChannel, adcVoltage);
 

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -28,13 +28,11 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _volt_std(volt_std),
       _volt_blank(volt_blank),
       _analogReferenceChannel(analogReferenceChannel),
-      _analogVoltageReader(analogVoltageReader),
-      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    }
-}
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader == nullptr
+                               ? new TIADS1x15Base()
+                               : analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 TurnerTurbidityPlus::~TurnerTurbidityPlus() {
@@ -72,9 +70,9 @@ void TurnerTurbidityPlus::runWiper() {
 bool TurnerTurbidityPlus::setup(void) {
     // Set up the wiper trigger pin, which is active-LOW.
     pinMode(_wiperTriggerPin, OUTPUT);
-    bool sensorSetupSuccess = Sensor::setup();
+    bool sensorSetupSuccess         = Sensor::setup();
     bool analogVoltageReaderSuccess = false;
-    
+
     if (_analogVoltageReader != nullptr) {
         analogVoltageReaderSuccess = _analogVoltageReader->begin();
         if (!analogVoltageReaderSuccess) {
@@ -85,7 +83,7 @@ bool TurnerTurbidityPlus::setup(void) {
         MS_DBG(getSensorNameAndLocation(),
                F("No analog voltage reader to initialize"));
     }
-    
+
     return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -38,7 +38,6 @@ TurnerTurbidityPlus::~TurnerTurbidityPlus() {
     // Clean up the analog voltage reader if we created it
     if (_ownsAnalogVoltageReader && _analogVoltageReader != nullptr) {
         delete _analogVoltageReader;
-        _analogVoltageReader = nullptr;
     }
 }
 
@@ -117,7 +116,7 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
     }
 
     bool  success    = false;
-    float adcVoltage = -9999;
+    float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
 

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -9,40 +9,40 @@
 
 
 #include "TurnerTurbidityPlus.h"
-#include "TIADS1x15.h"
 
 
 // The constructor - need the power pin, the data pin, and the calibration info
 TurnerTurbidityPlus::TurnerTurbidityPlus(
-    int8_t powerPin, int8_t wiperTriggerPin, tiads1x15_adsDiffMux_t adsDiffMux,
+    int8_t powerPin, int8_t wiperTriggerPin, ttp_adsDiffMux_t adsDiffMux,
     float conc_std, float volt_std, float volt_blank, uint8_t i2cAddress,
     adsGain_t PGA_gain, uint8_t measurementsToAverage,
     float voltageDividerFactor)
-    : TIADS1x15(powerPin, adsDiffMux, voltageDividerFactor, PGA_gain,
-                i2cAddress, measurementsToAverage),
+    : Sensor("TurnerTurbidityPlus", TURBIDITY_PLUS_NUM_VARIABLES,
+             TURBIDITY_PLUS_WARM_UP_TIME_MS,
+             TURBIDITY_PLUS_STABILIZATION_TIME_MS,
+             TURBIDITY_PLUS_MEASUREMENT_TIME_MS, powerPin, -1,
+             measurementsToAverage),
       _wiperTriggerPin(wiperTriggerPin),
+      _adsDiffMux(adsDiffMux),
       _conc_std(conc_std),
       _volt_std(volt_std),
-      _volt_blank(volt_blank) {
-    // Override timing settings for Turner-specific requirements
-    // These are protected members from the Sensor base class
-    _warmUpTime_ms        = TURBIDITY_PLUS_WARM_UP_TIME_MS;
-    _stabilizationTime_ms = TURBIDITY_PLUS_STABILIZATION_TIME_MS;
-    _measurementTime_ms   = TURBIDITY_PLUS_MEASUREMENT_TIME_MS;
-    // Override variable counts from parent class defaults
-    _numReturnedValues = TURBIDITY_PLUS_NUM_VARIABLES;
-    _incCalcValues     = TURBIDITY_PLUS_INC_CALC_VARIABLES;
-    // Set the sensor name
-    _sensorName = "TurnerTurbidityPlus";
-}
+      _volt_blank(volt_blank),
+      _i2cAddress(i2cAddress),
+      _PGA_gain(PGA_gain),
+      _voltageDividerFactor(voltageDividerFactor) {}
 // Destructor
 TurnerTurbidityPlus::~TurnerTurbidityPlus() {}
 
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
-    // Use TIADS1x15's location with Turner-specific identifier
-    String sensorLocation = TIADS1x15::getSensorLocation();
-    sensorLocation += F("_TurnerTurb");
+#ifndef MS_USE_ADS1015
+    String sensorLocation = F("ADS1115_0x");
+#else
+    String sensorLocation = F("ADS1015_0x");
+#endif
+    sensorLocation += String(_i2cAddress, HEX);
+    sensorLocation += F("_adsDiffMux");
+    sensorLocation += String(_adsDiffMux);
     return sensorLocation;
 }
 
@@ -64,7 +64,7 @@ void TurnerTurbidityPlus::runWiper() {
 bool TurnerTurbidityPlus::setup(void) {
     // Set up the wiper trigger pin, which is active-LOW.
     pinMode(_wiperTriggerPin, OUTPUT);
-    return TIADS1x15::setup();
+    return Sensor::setup();
 }
 
 bool TurnerTurbidityPlus::wake(void) {
@@ -74,19 +74,19 @@ bool TurnerTurbidityPlus::wake(void) {
     // Run the wiper before taking a reading
     runWiper();
 
-    return TIADS1x15::wake();
+    return Sensor::wake();
 }
 
 void TurnerTurbidityPlus::powerDown(void) {
     // Set the wiper trigger pin LOW to avoid power drain.
     digitalWrite(_wiperTriggerPin, LOW);
-    TIADS1x15::powerDown();
+    return Sensor::powerDown();
 }
 
 void TurnerTurbidityPlus::powerUp(void) {
     // Set the wiper trigger pin HIGH to prepare for wiping.
     digitalWrite(_wiperTriggerPin, HIGH);
-    TIADS1x15::powerUp();
+    return Sensor::powerUp();
 }
 
 bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
@@ -95,11 +95,38 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success     = false;
-    float adcVoltage  = -9999;
-    float calibResult = -9999;
+    bool    success     = false;
+    int16_t adcCounts   = -9999;
+    float   adcVoltage  = -9999;
+    float   calibResult = -9999;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
+
+// Create an auxiliary ADC object
+// We create and set up the ADC object here so that each sensor using the ADC
+// may set the gain appropriately without affecting others.
+#ifndef MS_USE_ADS1015
+    Adafruit_ADS1115 ads;  // Use this for the 16-bit version
+#else
+    Adafruit_ADS1015 ads;  // Use this for the 12-bit version
+#endif
+    // ADS Library default settings:
+    //  - TI ADS1115 (16 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 128 samples per second (8ms conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+    //  - TI ADS1015 (12 bit)
+    //    - single-shot mode (powers down between conversions)
+    //    - 1600 samples per second (625µs conversion time)
+    //    - 2/3 gain +/- 6.144V range (limited to VDD +0.3V max)
+
+    ads.setGain(_PGA_gain);
+    // Begin ADC, returns true if anything was detected at the address
+    if (!ads.begin(_i2cAddress)) {
+        MS_DBG(F("  ADC initialization failed at 0x"),
+               String(_i2cAddress, HEX));
+        return bumpMeasurementAttemptCount(false);
+    }
 
     // Print out the calibration curve
     MS_DBG(F("  Input calibration Curve:"), _volt_std, F("V at"), _conc_std,
@@ -110,11 +137,53 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    // Use the TIADS1x15 differential voltage reading function
-    // The voltage multiplier and gain settings are handled by the parent class
-    if (readVoltageDifferential(adcVoltage)) {
-        MS_DBG(F("  Differential voltage (after voltage multiplier):"),
-               String(adcVoltage, 3), F("V"));
+    // Read Analog to Digital Converter (ADC)
+    // Taking this reading includes the 8ms conversion delay.
+    // Measure the voltage differential across the two voltage pins
+    switch (_adsDiffMux) {
+        case DIFF_MUX_0_1: {
+            adcCounts = ads.readADC_Differential_0_1();
+            break;
+        }
+        case DIFF_MUX_0_3: {
+            adcCounts = ads.readADC_Differential_0_3();
+            break;
+        }
+        case DIFF_MUX_1_3: {
+            adcCounts = ads.readADC_Differential_1_3();
+            break;
+        }
+        case DIFF_MUX_2_3: {
+            adcCounts = ads.readADC_Differential_2_3();
+            break;
+        }
+        default: {
+            MS_DBG(F("  Invalid differential mux configuration"));
+            return bumpMeasurementAttemptCount(false);
+        }
+    }
+    // Convert ADC counts value to voltage (V)
+    adcVoltage = ads.computeVolts(adcCounts);
+    MS_DBG(F("  ads.readADC_Differential("), _adsDiffMux, F("):"), adcCounts,
+           '=', String(adcVoltage, 3));
+
+    // The ADS1X15 outputs a max value corresponding to Vcc + 0.3V
+    if (adcVoltage < 5.3 && adcVoltage > -0.3) {
+        if (_voltageDividerFactor > 0) {
+            // Apply voltage divider factor if using a voltage divider to step
+            // down the voltage
+            adcVoltage *= _voltageDividerFactor;
+        } else {
+            // If the voltage divider factor is not set to a positive value,
+            // print a debugging message and continue without applying a voltage
+            // divider factor.  We continue because the voltage divider factor
+            // can be easily fixed in post-processing if the raw voltage value
+            // is available, and we don't want to lose the voltage reading if
+            // the voltage divider factor is just set incorrectly.
+            MS_DBG(F("  Invalid voltage divider factor:"),
+                   _voltageDividerFactor,
+                   F("Voltage divider will be ignored."));
+        }
         // Apply the unique calibration curve for the given sensor
         calibResult = (_conc_std / (_volt_std - _volt_blank)) *
             (adcVoltage - _volt_blank);
@@ -123,8 +192,6 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         verifyAndAddMeasurementResult(TURBIDITY_PLUS_VOLTAGE_VAR_NUM,
                                       adcVoltage);
         success = true;
-    } else {
-        MS_DBG(F("  Failed to read differential voltage"));
     }
 
     // Return success value when finished

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -27,16 +27,11 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _analogReferenceChannel(analogReferenceChannel) {
-    // If no analog voltage reader was provided, create a default one
-    if (analogVoltageReader == nullptr) {
-        _analogVoltageReader     = new TIADS1x15Base();
-        _ownsAnalogVoltageReader = true;
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
-    }
-}
+      _analogReferenceChannel(analogReferenceChannel),
+      // If no analog voltage reader was provided, create a default one
+      _analogVoltageReader(analogVoltageReader ? analogVoltageReader
+                                               : new TIADS1x15Base()),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {}
 
 // Destructor
 TurnerTurbidityPlus::~TurnerTurbidityPlus() {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -27,13 +27,12 @@ TurnerTurbidityPlus::TurnerTurbidityPlus(
       _conc_std(conc_std),
       _volt_std(volt_std),
       _volt_blank(volt_blank),
-      _analogReferenceChannel(analogReferenceChannel) {
+      _analogReferenceChannel(analogReferenceChannel),
+      _analogVoltageReader(analogVoltageReader),
+      _ownsAnalogVoltageReader(analogVoltageReader == nullptr) {
     // If no analog voltage reader was provided, create a default one
     if (analogVoltageReader == nullptr) {
         _analogVoltageReader = createTIADS1x15Base(_ownsAnalogVoltageReader);
-    } else {
-        _analogVoltageReader     = analogVoltageReader;
-        _ownsAnalogVoltageReader = false;
     }
 }
 

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -107,7 +107,6 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
         return bumpMeasurementAttemptCount(false);
     }
 
-    bool  success    = false;
     float adcVoltage = -9999.0f;
 
     MS_DBG(getSensorNameAndLocation(), F("is reporting:"));
@@ -125,7 +124,7 @@ bool TurnerTurbidityPlus::addSingleMeasurementResult(void) {
     // NOTE: All implementations of the AnalogVoltageBase class validate both
     // the input channel and the resulting voltage, so we can trust that a
     // successful read will give us a valid voltage value to work with.
-    success = _analogVoltageReader->readVoltageDifferential(
+    bool success = _analogVoltageReader->readVoltageDifferential(
         _dataPin, _analogReferenceChannel, adcVoltage);
 
     if (success) {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -49,20 +49,13 @@ TurnerTurbidityPlus::~TurnerTurbidityPlus() {
 
 
 String TurnerTurbidityPlus::getSensorLocation(void) {
-    if (_analogVoltageReader != nullptr) {
-        String sensorLocation = _analogVoltageReader->getSensorLocation();
-        sensorLocation += F("_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
-    } else {
-        String sensorLocation = F("Unknown_AnalogVoltageReader_Diff_");
-        sensorLocation += String(_dataPin);
-        sensorLocation += F("_");
-        sensorLocation += String(_analogReferenceChannel);
-        return sensorLocation;
-    }
+    // NOTE: The constructor guarantees that _analogVoltageReader is not null
+    String sensorLocation = _analogVoltageReader->getSensorLocation();
+    sensorLocation += F("_Diff_");
+    sensorLocation += String(_dataPin);
+    sensorLocation += F("_");
+    sensorLocation += String(_analogReferenceChannel);
+    return sensorLocation;
 }
 
 void TurnerTurbidityPlus::runWiper() {

--- a/src/sensors/TurnerTurbidityPlus.cpp
+++ b/src/sensors/TurnerTurbidityPlus.cpp
@@ -72,7 +72,21 @@ void TurnerTurbidityPlus::runWiper() {
 bool TurnerTurbidityPlus::setup(void) {
     // Set up the wiper trigger pin, which is active-LOW.
     pinMode(_wiperTriggerPin, OUTPUT);
-    return Sensor::setup();
+    bool sensorSetupSuccess = Sensor::setup();
+    bool analogVoltageReaderSuccess = false;
+    
+    if (_analogVoltageReader != nullptr) {
+        analogVoltageReaderSuccess = _analogVoltageReader->begin();
+        if (!analogVoltageReaderSuccess) {
+            MS_DBG(getSensorNameAndLocation(),
+                   F("Analog voltage reader initialization failed"));
+        }
+    } else {
+        MS_DBG(getSensorNameAndLocation(),
+               F("No analog voltage reader to initialize"));
+    }
+    
+    return sensorSetupSuccess && analogVoltageReaderSuccess;
 }
 
 bool TurnerTurbidityPlus::wake(void) {

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -236,9 +236,10 @@ class TurnerTurbidityPlus : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.  If a non-null
-     * pointer is supplied, the caller retains ownership and must ensure its
-     * lifetime exceeds that of this object.
+     * internally create and own an analog voltage reader.  For backward
+     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * non-null pointer is supplied, the caller retains ownership and must
+     * ensure its lifetime exceeds that of this object.
      *
      * @attention For 3.3V processors like the Mayfly, The Turner's 0-5V output
      * signal must be shifted down to a maximum of 3.3V. This can be done either

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -29,6 +29,8 @@
  *      - Changes the wiper trigger pulse duration from 50 ms to x ms
  * - ```-D TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS=x```
  *      - Changes the wiper rotation wait time from 8000 ms to x ms
+ * - ```-D TURBIDITY_PLUS_CALIBRATION_EPSILON=x```
+ *      - Changes the calibration validation epsilon from 1e-4 to x
  *
  * @section sensor_turbidity_plus_ctor Sensor Constructor
  * {{ @ref TurnerTurbidityPlus::TurnerTurbidityPlus }}
@@ -103,6 +105,12 @@ class AnalogVoltageBase;
  * @brief Wait time for wiper rotation to complete in milliseconds
  */
 #define TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS 8000
+#endif
+#if !defined(TURBIDITY_PLUS_CALIBRATION_EPSILON) || defined(DOXYGEN)
+/**
+ * @brief Epsilon value for calibration validation to detect invalid calibration curves
+ */
+#define TURBIDITY_PLUS_CALIBRATION_EPSILON 1e-4f
 #endif
 /**@}*/
 
@@ -332,7 +340,7 @@ class TurnerTurbidityPlus : public Sensor {
     /**
      * @brief The second (reference) pin for differential voltage measurements.
      */
-    int8_t _analogReferenceChannel;
+    int8_t _analogReferenceChannel = -1;
     /// @brief Pointer to analog voltage reader
     AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -329,10 +329,10 @@ class TurnerTurbidityPlus : public Sensor {
      */
     int8_t _analogReferenceChannel;
     /// @brief Pointer to analog voltage reader
-    AnalogVoltageBase* _analogVoltageReader;
+    AnalogVoltageBase* _analogVoltageReader = nullptr;
     /// @brief Flag to track if this object owns the analog voltage reader and
     /// should delete it in the destructor
-    bool _ownsAnalogVoltageReader;
+    bool _ownsAnalogVoltageReader = false;
 };
 
 

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -64,7 +64,9 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
-#include "AnalogVoltageBase.h"
+
+// Forward declaration
+class AnalogVoltageBase;
 
 /** @ingroup sensor_turbidity_plus */
 /**@{*/

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -210,10 +210,6 @@ class TurnerTurbidityPlus : public Sensor {
      * default values for voltage readings, but a pointer to a custom
      * AnalogVoltageBase object can be passed in if desired.
      *
-     * @note ModularSensors only supports connecting the ADS1x15 to the primary
-     * hardware I2C instance defined in the Arduino core. Connecting the ADS to
-     * a secondary hardware or software I2C instance is *not* supported!
-     *
      * @param powerPin The pin on the mcu controlling power to the Turbidity
      * Plus Use -1 if it is continuously powered.
      * - The Turbidity Plus requires a 3-15V power supply, which can be turned
@@ -237,13 +233,13 @@ class TurnerTurbidityPlus : public Sensor {
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
-     * voltage measurements; optional with a default of a new TIADS1x15Base
-     * object.
+     * voltage measurements.  Pass nullptr (the default) to have the constructor
+     * internally create and own a TIADS1x15Base instance.
      *
      * @attention For 3.3V processors like the Mayfly, The Turner's 0-5V output
      * signal must be shifted down to a maximum of 3.3V. This can be done either
-     * either with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting
-     * the Turner's output signal via a voltage divider. By default, the
+     * with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting the
+     * Turner's output signal via a voltage divider. By default, the
      * TurnerTurbidityPlus object does **NOT** include any level-shifting or
      * voltage dividers. To have a voltage divider applied correctly, you must
      * supply a pointer to a custom AnalogVoltageBase object that applies the
@@ -269,6 +265,15 @@ class TurnerTurbidityPlus : public Sensor {
      * @brief Destroy the Turner Turbidity Plus object
      */
     ~TurnerTurbidityPlus();
+
+    // Delete copy constructor and copy assignment operator to prevent shallow
+    // copies
+    TurnerTurbidityPlus(const TurnerTurbidityPlus&)            = delete;
+    TurnerTurbidityPlus& operator=(const TurnerTurbidityPlus&) = delete;
+
+    // Delete move constructor and move assignment operator
+    TurnerTurbidityPlus(TurnerTurbidityPlus&&)            = delete;
+    TurnerTurbidityPlus& operator=(TurnerTurbidityPlus&&) = delete;
 
     String getSensorLocation(void) override;
 

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -63,7 +63,7 @@
 
 // Include other in-library and external dependencies
 #include "VariableBase.h"
-#include "SensorBase.h"
+#include "TIADS1x15.h"
 #include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_turbidity_plus */
@@ -82,25 +82,6 @@
 /// @brief Sensor::_incCalcValues; turbidity is calculated from raw voltage
 /// using the input calibration equation.
 #define TURBIDITY_PLUS_INC_CALC_VARIABLES 1
-/**@}*/
-
-/**
- * @anchor sensor__turbidity_plus_config
- * @name Configuration Defines
- * Defines to set the address of the ADD.
- */
-/**@{*/
-/**
- * @brief Enum for the pins used for differential voltages.
- */
-typedef enum : uint16_t {
-    DIFF_MUX_0_1,  ///< differential across pins 0 and 1
-    DIFF_MUX_0_3,  ///< differential across pins 0 and 3
-    DIFF_MUX_1_3,  ///< differential across pins 1 and 3
-    DIFF_MUX_2_3   ///< differential across pins 2 and 3
-} ttp_adsDiffMux_t;
-/// @brief The assumed address of the ADS1115, 1001 000 (ADDR = GND)
-#define ADS1115_ADDRESS 0x48
 /**@}*/
 
 /**
@@ -195,7 +176,7 @@ typedef enum : uint16_t {
  *
  * @ingroup sensor_turbidity_plus
  */
-class TurnerTurbidityPlus : public Sensor {
+class TurnerTurbidityPlus : public TIADS1x15 {
  public:
     // The constructor - need the power pin, the ADS1X15 data channel, and the
     // calibration info
@@ -215,7 +196,7 @@ class TurnerTurbidityPlus : public Sensor {
      * @param wiperTriggerPin The pin on the mcu that triggers the sensor's
      * wiper.
      * @param adsDiffMux Which two pins _on the TI ADS1115_ that will measure
-     * differential voltage. See #ttp_adsDiffMux_t
+     * differential voltage. See #tiads1x15_adsDiffMux_t
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration. The concentration units should be the same as the
      * final measuring units.
@@ -240,7 +221,7 @@ class TurnerTurbidityPlus : public Sensor {
      * requires a voltageDividerFactor of 2. The default value is 1.
      */
     TurnerTurbidityPlus(int8_t powerPin, int8_t wiperTriggerPin,
-                        ttp_adsDiffMux_t adsDiffMux, float conc_std,
+                        tiads1x15_adsDiffMux_t adsDiffMux, float conc_std,
                         float volt_std, float volt_blank,
                         uint8_t   i2cAddress            = ADS1115_ADDRESS,
                         adsGain_t PGA_gain              = GAIN_ONE,
@@ -283,11 +264,6 @@ class TurnerTurbidityPlus : public Sensor {
      */
     int8_t _wiperTriggerPin;
     /**
-     * @brief Which two pins _on the TI ADS1115_ that will measure differential
-     * voltage from the Turbidity Plus. See #ttp_adsDiffMux_t
-     */
-    ttp_adsDiffMux_t _adsDiffMux;
-    /**
      * @brief The concentration of the standard used for a 1-point sensor
      * calibration. The concentration units should be the same as the final
      * measuring units.
@@ -305,25 +281,6 @@ class TurnerTurbidityPlus : public Sensor {
      */
     float _volt_blank;
     /**
-     * @brief Internal reference to the I2C address of the TI-ADS1x15
-     */
-    uint8_t _i2cAddress;
-    /**
-     * @brief The programmable gain amplification to set on the ADS 1x15,
-     * default is GAIN_ONE (+/-4.096V range = Gain 1).
-     *
-     * Other gain options are:
-     *   GAIN_TWOTHIRDS = +/-6.144V range = Gain 2/3,
-     *   GAIN_ONE = +/-4.096V range = Gain 1,
-     *   GAIN_TWO = +/-2.048V range = Gain 2,
-     *   GAIN_FOUR = +/-1.024V range = Gain 4,
-     *   GAIN_EIGHT = +/-0.512V range = Gain 8,
-     *   GAIN_SIXTEEN = +/-0.256V range = Gain 16
-     *
-     * @todo Determine gain automatically based on the board voltage?
-     */
-    adsGain_t _PGA_gain;
-    /**
      * @brief For 3.3V processors like the Mayfly, The Turner's 0-5V output
      * signal must be shifted down to a maximum of 3.3V. This can be done either
      * either with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting
@@ -331,8 +288,8 @@ class TurnerTurbidityPlus : public Sensor {
      * voltageDividerFactor is used for the latter case: e.g., a divider that
      * uses 2 matched resistors will halve the voltage reading and requires a
      * voltageDividerFactor of 2. The default value is 1.
+     * Note: This functionality is now handled by the parent class's _voltageMultiplier.
      */
-    float _voltageDividerFactor;
 };
 
 

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -37,8 +37,8 @@
  *
  * ___
  * @section sensor_turbidity_plus_examples Example Code
- * The Alphasense CO2 sensor is used in the @menulink{turner_turbidity_plus}
- * example.
+ * The Turner Turbidity Plus sensor is used in the
+ * @menulink{turner_turbidity_plus} example.
  *
  * @menusnip{turner_turbidity_plus}
  */
@@ -215,9 +215,13 @@ class TurnerTurbidityPlus : public Sensor {
      * @param wiperTriggerPin The pin on the mcu that triggers the sensor's
      * wiper.
      * @param analogChannel The primary analog channel for differential
-     * measurement
+     * measurement. Negative or invalid channel numbers or parings between the
+     * analogChannel and analogReferenceChannel are not clamped and will cause
+     * the reading to fail and emit a warning.
      * @param analogReferenceChannel The secondary (reference) analog channel
-     * for differential measurement
+     * for differential measurement. Negative or invalid channel numbers or
+     * parings between the analogChannel and analogReferenceChannel are not
+     * clamped and will cause the reading to fail and emit a warning.
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration. The concentration units should be the same as the
      * final measuring units.

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -245,8 +245,8 @@ class TurnerTurbidityPlus : public TIADS1x15 {
     TurnerTurbidityPlus(int8_t powerPin, int8_t wiperTriggerPin,
                         tiads1x15_adsDiffMux_t adsDiffMux, float conc_std,
                         float volt_std, float volt_blank,
-                        uint8_t   i2cAddress            = ADS1115_ADDRESS,
-                        adsGain_t PGA_gain              = GAIN_ONE,
+                        uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
+                        adsGain_t PGA_gain   = GAIN_ONE,
                         uint8_t   measurementsToAverage = 1,
                         float     voltageDividerFactor  = 1);
     /**

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -215,12 +215,12 @@ class TurnerTurbidityPlus : public Sensor {
      * @param wiperTriggerPin The pin on the mcu that triggers the sensor's
      * wiper.
      * @param analogChannel The primary analog channel for differential
-     * measurement. Negative or invalid channel numbers or parings between the
+     * measurement. Negative or invalid channel numbers or pairings between the
      * analogChannel and analogReferenceChannel are not clamped and will cause
      * the reading to fail and emit a warning.
      * @param analogReferenceChannel The secondary (reference) analog channel
      * for differential measurement. Negative or invalid channel numbers or
-     * parings between the analogChannel and analogReferenceChannel are not
+     * pairings between the analogChannel and analogReferenceChannel are not
      * clamped and will cause the reading to fail and emit a warning.
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration. The concentration units should be the same as the

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -204,9 +204,9 @@ class TurnerTurbidityPlus : public Sensor {
      * @brief Construct a new Turner Turbidity Plus object - need the power pin,
      * the analog data and reference channels, and the calibration info.
      *
-     * By default, this constructor will use a new TIADS1x15Base object with all
-     * default values for voltage readings, but a pointer to a custom
-     * AnalogVoltageBase object can be passed in if desired.
+     * By default, this constructor will internally create a default
+     * AnalogVoltageBase implementation for voltage readings, but a pointer to
+     * a custom AnalogVoltageBase object can be passed in if desired.
      *
      * @param powerPin The pin on the mcu controlling power to the Turbidity
      * Plus Use -1 if it is continuously powered.

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -237,7 +237,7 @@ class TurnerTurbidityPlus : public Sensor {
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
      * internally create and own an analog voltage reader.  For backward
-     * compatibility, the default reader uses a TI ADS1115 or ADS10115.  If a
+     * compatibility, the default reader uses a TI ADS1115 or ADS1015.  If a
      * non-null pointer is supplied, the caller retains ownership and must
      * ensure its lifetime exceeds that of this object.
      *

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -302,16 +302,6 @@ class TurnerTurbidityPlus : public TIADS1x15 {
      * be the final voltage *after* accounting for any voltage.
      */
     float _volt_blank;
-    /**
-     * @brief For 3.3V processors like the Mayfly, The Turner's 0-5V output
-     * signal must be shifted down to a maximum of 3.3V. This can be done either
-     * either with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting
-     * the Turner's output signal via a voltage divider. This
-     * voltageDividerFactor is used for the latter case: e.g., a divider that
-     * uses 2 matched resistors will halve the voltage reading and requires a
-     * voltageDividerFactor of 2. The default value is 1.
-     * Note: This functionality is now handled by the parent class's _voltageMultiplier.
-     */
 };
 
 

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -69,7 +69,6 @@
 #include "VariableBase.h"
 #include "SensorBase.h"
 #include "AnalogVoltageBase.h"
-#include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_turbidity_plus */
 /**@{*/
@@ -193,7 +192,8 @@
 ///  - Resolution:
 ///     - 16-bit ADC (ADS1115): 0.125 mV
 #define TURBIDITY_PLUS_VOLTAGE_RESOLUTION 4
-#endif /**@}*/
+#endif
+/**@}*/
 /**
  * @brief The Sensor sub-class for the [Turner Turbidity Plus turbidity
  * sensor](@ref sensor_turbidity_plus).

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -339,6 +339,8 @@ class TurnerTurbidityPlus : public Sensor {
 
     /**
      * @brief The second (reference) pin for differential voltage measurements.
+     *
+     * @note The primary pin is stored as Sensor::_dataPin.
      */
     int8_t _analogReferenceChannel = -1;
     /// @brief Pointer to analog voltage reader

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -29,6 +29,10 @@
  * @section sensor_turbidity_plus_flags Build flags
  * - ```-D MS_USE_ADS1015```
  *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
+ * - ```-D TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS=x```
+ *      - Changes the wiper trigger pulse duration from 50 ms to x ms
+ * - ```-D TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS=x```
+ *      - Changes the wiper rotation wait time from 8000 ms to x ms
  *
  * @section sensor_turbidity_plus_ctor Sensor Constructor
  * {{ @ref TurnerTurbidityPlus::TurnerTurbidityPlus }}
@@ -82,6 +86,26 @@
 /// @brief Sensor::_incCalcValues; turbidity is calculated from raw voltage
 /// using the input calibration equation.
 #define TURBIDITY_PLUS_INC_CALC_VARIABLES 1
+/**@}*/
+
+/**
+ * @anchor sensor_turbidity_plus_config
+ * @name Configuration Defines
+ * Defines to set the timing configuration of the Turner Turbidity Plus sensor.
+ */
+/**@{*/
+#if !defined(TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS) || defined(DOXYGEN)
+/**
+ * @brief Wiper trigger pulse duration in milliseconds
+ */
+#define TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS 50
+#endif
+#if !defined(TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS) || defined(DOXYGEN)
+/**
+ * @brief Wait time for wiper rotation to complete in milliseconds
+ */
+#define TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS 8000
+#endif
 /**@}*/
 
 /**
@@ -161,15 +185,14 @@
 #ifdef MS_USE_ADS1015
 /// @brief Decimals places in string representation; voltage should have 1.
 ///  - Resolution:
-///     - 16-bit ADC (ADS1115): 0.125 mV
+///     - 12-bit ADC (ADS1015): 2 mV
 #define TURBIDITY_PLUS_VOLTAGE_RESOLUTION 1
 #else
 /// @brief Decimals places in string representation; voltage should have 4.
 ///  - Resolution:
-///     - 12-bit ADC (ADS1015, using build flag ```MS_USE_ADS1015```): 2 mV
+///     - 16-bit ADC (ADS1115): 0.125 mV
 #define TURBIDITY_PLUS_VOLTAGE_RESOLUTION 4
-#endif
-/**@}*/
+#endif /**@}*/
 /**
  * @brief The Sensor sub-class for the [Turner Turbidity Plus turbidity
  * sensor](@ref sensor_turbidity_plus).
@@ -205,8 +228,7 @@ class TurnerTurbidityPlus : public TIADS1x15 {
      * dividers or gain settings.
      * @param volt_blank The voltage (in volts) measured for a blank. This
      * voltage should be the final voltage *after* accounting for any voltage
-     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
-     * = GND)
+     * dividers or gain settings.     * = GND)
      * @param PGA_gain The programmable gain amplification to set on the
      * ADS 1x15, default is GAIN_ONE (0-4.096V).
      * @param measurementsToAverage The number of measurements to take and

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -25,8 +25,6 @@
  * [Datasheet](http://docs.turnerdesigns.com/t2/doc/brochures/S-0210.pdf)
  *
  * @section sensor_turbidity_plus_flags Build flags
- * - ```-D MS_USE_ADS1015```
- *      - switches from the 16-bit ADS1115 to the 12 bit ADS1015
  * - ```-D TURBIDITY_PLUS_WIPER_TRIGGER_PULSE_MS=x```
  *      - Changes the wiper trigger pulse duration from 50 ms to x ms
  * - ```-D TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS=x```
@@ -435,7 +433,5 @@ class TurnerTurbidityPlus_Turbidity : public Variable {
     ~TurnerTurbidityPlus_Turbidity() {}
 };
 /**@}*/
-
-// cspell:words GAIN_TWOTHIRDS
 
 #endif  // SRC_SENSORS_TURNERTURBIDITYPLUS_H_

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -238,7 +238,7 @@ class TurnerTurbidityPlus : public Sensor {
      *
      * @attention For 3.3V processors like the Mayfly, The Turner's 0-5V output
      * signal must be shifted down to a maximum of 3.3V. This can be done either
-     * with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting the
+     * with a level-shifting chip (e.g. Adafruit BSS138), OR by connecting the
      * Turner's output signal via a voltage divider. By default, the
      * TurnerTurbidityPlus object does **NOT** include any level-shifting or
      * voltage dividers. To have a voltage divider applied correctly, you must

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -328,11 +328,11 @@ class TurnerTurbidityPlus : public Sensor {
      * @brief The second (reference) pin for differential voltage measurements.
      */
     int8_t _analogReferenceChannel;
-    AnalogVoltageBase*
-         _analogVoltageReader;      ///< Pointer to analog voltage reader
-    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
-                                    ///< analog voltage reader and should delete
-                                    ///< it in the destructor
+    /// @brief Pointer to analog voltage reader
+    AnalogVoltageBase* _analogVoltageReader;
+    /// @brief Flag to track if this object owns the analog voltage reader and
+    /// should delete it in the destructor
+    bool _ownsAnalogVoltageReader;
 };
 
 

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -10,8 +10,6 @@
  * subclasses TurnerTurbidityPlus_Turbidity and TurnerTurbidityPlus_Voltage.
  *
  * These are used for the Turner Turbidity Plus.
- *
- * This depends on the Adafruit ADS1X15 v2.x library.
  */
 /**
  * @defgroup sensor_turbidity_plus Turner Turbidity Plus
@@ -234,7 +232,9 @@ class TurnerTurbidityPlus : public Sensor {
      * default value of 1.
      * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
      * voltage measurements.  Pass nullptr (the default) to have the constructor
-     * internally create and own a TIADS1x15Base instance.
+     * internally create and own a TIADS1x15Base instance.  If a non-null
+     * pointer is supplied, the caller retains ownership and must ensure its
+     * lifetime exceeds that of this object.
      *
      * @attention For 3.3V processors like the Mayfly, The Turner's 0-5V output
      * signal must be shifted down to a maximum of 3.3V. This can be done either

--- a/src/sensors/TurnerTurbidityPlus.h
+++ b/src/sensors/TurnerTurbidityPlus.h
@@ -68,6 +68,7 @@
 // Include other in-library and external dependencies
 #include "VariableBase.h"
 #include "SensorBase.h"
+#include "AnalogVoltageBase.h"
 #include <Adafruit_ADS1X15.h>
 
 /** @ingroup sensor_turbidity_plus */
@@ -107,16 +108,6 @@
 #define TURBIDITY_PLUS_WIPER_ROTATION_WAIT_MS 8000
 #endif
 /**@}*/
-
-/**
- * @brief Enum for the pins used for differential voltages.
- */
-typedef enum : uint16_t {
-    DIFF_MUX_0_1,  ///< differential across pins 0 and 1
-    DIFF_MUX_0_3,  ///< differential across pins 0 and 3
-    DIFF_MUX_1_3,  ///< differential across pins 1 and 3
-    DIFF_MUX_2_3   ///< differential across pins 2 and 3
-} ttp_adsDiffMux_t;
 
 /**
  * @anchor sensor_turbidity_plus_timing
@@ -211,11 +202,13 @@ typedef enum : uint16_t {
  */
 class TurnerTurbidityPlus : public Sensor {
  public:
-    // The constructor - need the power pin, the ADS1X15 data channel, and the
-    // calibration info
     /**
      * @brief Construct a new Turner Turbidity Plus object - need the power pin,
-     * the ADS1X15 data channel, and the calibration info.
+     * the analog data and reference channels, and the calibration info.
+     *
+     * By default, this constructor will use a new TIADS1x15Base object with all
+     * default values for voltage readings, but a pointer to a custom
+     * AnalogVoltageBase object can be passed in if desired.
      *
      * @note ModularSensors only supports connecting the ADS1x15 to the primary
      * hardware I2C instance defined in the Arduino core. Connecting the ADS to
@@ -223,13 +216,14 @@ class TurnerTurbidityPlus : public Sensor {
      *
      * @param powerPin The pin on the mcu controlling power to the Turbidity
      * Plus Use -1 if it is continuously powered.
-     * - The ADS1x15 requires an input voltage of 2.0-5.5V
-     * - The Turbidity Plus itself requires a 3-15V power supply, which can be
-     * turned off between measurements.
+     * - The Turbidity Plus requires a 3-15V power supply, which can be turned
+     * off between measurements.
      * @param wiperTriggerPin The pin on the mcu that triggers the sensor's
      * wiper.
-     * @param adsDiffMux Which two pins _on the TI ADS1115_ that will measure
-     * differential voltage. See #ttp_adsDiffMux_t
+     * @param analogChannel The primary analog channel for differential
+     * measurement
+     * @param analogReferenceChannel The secondary (reference) analog channel
+     * for differential measurement
      * @param conc_std The concentration of the standard used for a 1-point
      * sensor calibration. The concentration units should be the same as the
      * final measuring units.
@@ -238,28 +232,39 @@ class TurnerTurbidityPlus : public Sensor {
      * dividers or gain settings.
      * @param volt_blank The voltage (in volts) measured for a blank. This
      * voltage should be the final voltage *after* accounting for any voltage
-     * @param i2cAddress The I2C address of the ADS 1x15, default is 0x48 (ADDR
-     * = GND)
-     * @param PGA_gain The programmable gain amplification to set on the
-     * ADS 1x15, default is GAIN_ONE (0-4.096V).
+     * dividers or gain settings.
      * @param measurementsToAverage The number of measurements to take and
      * average before giving a "final" result from the sensor; optional with a
      * default value of 1.
-     * @param voltageDividerFactor For 3.3V processors like the Mayfly, The
-     * Turner's 0-5V output signal must be shifted down to a maximum of 3.3V.
-     * This can be done either either with a level-shifting chip (e.g. Adafruit
-     * BSS38), OR by connecting the Turner's output signal via a voltage
-     * divider. This voltageDividerFactor is used for the latter case: e.g., a
-     * divider that uses 2 matched resistors will halve the voltage reading and
-     * requires a voltageDividerFactor of 2. The default value is 1.
+     * @param analogVoltageReader Pointer to an AnalogVoltageBase object for
+     * voltage measurements; optional with a default of a new TIADS1x15Base
+     * object.
+     *
+     * @attention For 3.3V processors like the Mayfly, The Turner's 0-5V output
+     * signal must be shifted down to a maximum of 3.3V. This can be done either
+     * either with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting
+     * the Turner's output signal via a voltage divider. By default, the
+     * TurnerTurbidityPlus object does **NOT** include any level-shifting or
+     * voltage dividers. To have a voltage divider applied correctly, you must
+     * supply a pointer to a custom AnalogVoltageBase object that applies the
+     * voltage divider to the raw voltage readings. For example, if you are
+     * using a simple voltage divider with two equal resistors, you would need
+     * to use an AnalogVoltageBase object that multiplies the raw voltage
+     * readings by 2 to account for the halving of the signal by the voltage
+     * divider.
+     *
+     * @warning In library versions 0.37.0 and earlier, a different constructor
+     * was used that required an enum object instead of two different analog
+     * channel inputs for the differential voltage measurement. If you are using
+     * code from a previous version of the library, make sure to update your
+     * code to use the new constructor and provide the correct analog channel
+     * inputs for the differential voltage measurement.
      */
     TurnerTurbidityPlus(int8_t powerPin, int8_t wiperTriggerPin,
-                        ttp_adsDiffMux_t adsDiffMux, float conc_std,
-                        float volt_std, float volt_blank,
-                        uint8_t   i2cAddress = MS_DEFAULT_ADS1X15_ADDRESS,
-                        adsGain_t PGA_gain   = GAIN_ONE,
-                        uint8_t   measurementsToAverage = 1,
-                        float     voltageDividerFactor  = 1);
+                        int8_t analogChannel, int8_t analogReferenceChannel,
+                        float conc_std, float volt_std, float volt_blank,
+                        uint8_t            measurementsToAverage = 1,
+                        AnalogVoltageBase* analogVoltageReader   = nullptr);
     /**
      * @brief Destroy the Turner Turbidity Plus object
      */
@@ -297,11 +302,6 @@ class TurnerTurbidityPlus : public Sensor {
      */
     int8_t _wiperTriggerPin;
     /**
-     * @brief Which two pins _on the TI ADS1115_ that will measure differential
-     * voltage from the Turbidity Plus. See #ttp_adsDiffMux_t
-     */
-    ttp_adsDiffMux_t _adsDiffMux;
-    /**
      * @brief The concentration of the standard used for a 1-point sensor
      * calibration. The concentration units should be the same as the final
      * measuring units.
@@ -318,35 +318,16 @@ class TurnerTurbidityPlus : public Sensor {
      * be the final voltage *after* accounting for any voltage.
      */
     float _volt_blank;
+
     /**
-     * @brief Internal reference to the I2C address of the TI-ADS1x15
+     * @brief The second (reference) pin for differential voltage measurements.
      */
-    uint8_t _i2cAddress;
-    /**
-     * @brief The programmable gain amplification to set on the ADS 1x15,
-     * default is GAIN_ONE (+/-4.096V range = Gain 1).
-     *
-     * Other gain options are:
-     *   GAIN_TWOTHIRDS = +/-6.144V range = Gain 2/3,
-     *   GAIN_ONE = +/-4.096V range = Gain 1,
-     *   GAIN_TWO = +/-2.048V range = Gain 2,
-     *   GAIN_FOUR = +/-1.024V range = Gain 4,
-     *   GAIN_EIGHT = +/-0.512V range = Gain 8,
-     *   GAIN_SIXTEEN = +/-0.256V range = Gain 16
-     *
-     * @todo Determine gain automatically based on the board voltage?
-     */
-    adsGain_t _PGA_gain;
-    /**
-     * @brief For 3.3V processors like the Mayfly, The Turner's 0-5V output
-     * signal must be shifted down to a maximum of 3.3V. This can be done either
-     * either with a level-shifting chip (e.g. Adafruit BSS38), OR by connecting
-     * the Turner's output signal via a voltage divider. This
-     * voltageDividerFactor is used for the latter case: e.g., a divider that
-     * uses 2 matched resistors will halve the voltage reading and requires a
-     * voltageDividerFactor of 2. The default value is 1.
-     */
-    float _voltageDividerFactor;
+    int8_t _analogReferenceChannel;
+    AnalogVoltageBase*
+         _analogVoltageReader;      ///< Pointer to analog voltage reader
+    bool _ownsAnalogVoltageReader;  ///< Flag to track if this object owns the
+                                    ///< analog voltage reader and should delete
+                                    ///< it in the destructor
 };
 
 


### PR DESCRIPTION
Implements an analog abstraction layer and applies it to all analog sensors.

Signed-off-by: Sara Damiano <sdamiano@stroudcenter.org>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced AnalogVoltageBase abstraction layer for unified analog voltage reading across all sensors
  * Added ProcessorAnalogBase and TIADS1x15Base implementations for flexible voltage measurement
  * Added optional setup() methods to multiple sensor classes for initialization
  * New utility method for resolution-to-decimal-places conversion

* **Bug Fixes**
  * Fixed 18-bit ADC sign extension logic

* **Refactoring**
  * Replaced hardcoded ADS1115/ADS1015 integration with pluggable voltage reader pattern across all sensors
  * Removed copy/move constructors from non-copyable sensor classes
  * Simplified sensor measurement paths via abstracted interfaces

* **Chores**
  * Updated CI configuration
  * Minor formatting adjustments in examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->